### PR TITLE
refactor: introduce Price/Quantity/TimestampMs value newtypes across public API

### DIFF
--- a/benches/concurrent/contention.rs
+++ b/benches/concurrent/contention.rs
@@ -1,6 +1,7 @@
 use criterion::{BenchmarkId, Criterion};
 use pricelevel::{
-    Hash32, Id, OrderType, OrderUpdate, PriceLevel, Side, TimeInForce, UuidGenerator,
+    Hash32, Id, OrderType, OrderUpdate, Price, PriceLevel, Quantity, Side, TimeInForce,
+    TimestampMs, UuidGenerator,
 };
 use std::sync::{Arc, Barrier};
 use std::thread;
@@ -210,7 +211,7 @@ fn measure_hot_spot_contention(
                         // Update quantity
                         let _ = thread_price_level.update_order(OrderUpdate::UpdateQuantity {
                             order_id: Id::from_u64(order_idx),
-                            new_quantity: 15,
+                            new_quantity: Quantity::new(15),
                         });
                     }
                     _ => {
@@ -247,11 +248,11 @@ fn measure_hot_spot_contention(
 fn create_standard_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
     OrderType::Standard {
         id: Id::from_u64(id),
-        price,
-        quantity,
+        price: Price::new(price),
+        quantity: Quantity::new(quantity),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: 1616823000000,
+        timestamp: TimestampMs::new(1616823000000),
         time_in_force: TimeInForce::Gtc,
         extra_fields: (),
     }

--- a/benches/concurrent/register.rs
+++ b/benches/concurrent/register.rs
@@ -1,7 +1,7 @@
 use criterion::{BenchmarkId, Criterion, criterion_group};
 use pricelevel::{
-    Hash32, Id, OrderType, OrderUpdate, PegReferenceType, PriceLevel, Side, TimeInForce,
-    UuidGenerator,
+    Hash32, Id, OrderType, OrderUpdate, PegReferenceType, Price, PriceLevel, Quantity, Side,
+    TimeInForce, TimestampMs, UuidGenerator,
 };
 use std::sync::{Arc, Barrier};
 use std::thread;
@@ -318,7 +318,7 @@ fn measure_concurrent_mixed_operations(thread_count: usize, iterations: u64) -> 
                         let base_id = thread_id as u64 * 1_000_000 + (i - 1);
                         let _ = thread_price_level.update_order(OrderUpdate::UpdateQuantity {
                             order_id: Id::from_u64(base_id),
-                            new_quantity: 20,
+                            new_quantity: Quantity::new(20),
                         });
                     }
                 }
@@ -351,11 +351,11 @@ fn measure_concurrent_mixed_operations(thread_count: usize, iterations: u64) -> 
 fn create_standard_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
     OrderType::Standard {
         id: Id::from_u64(id),
-        price,
-        quantity,
+        price: Price::new(price),
+        quantity: Quantity::new(quantity),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: 1616823000000,
+        timestamp: TimestampMs::new(1616823000000),
         time_in_force: TimeInForce::Gtc,
         extra_fields: (),
     }
@@ -365,12 +365,12 @@ fn create_standard_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
 fn create_iceberg_order(id: u64, price: u128, visible: u64, hidden: u64) -> OrderType<()> {
     OrderType::IcebergOrder {
         id: Id::from_u64(id),
-        price,
-        visible_quantity: visible,
-        hidden_quantity: hidden,
+        price: Price::new(price),
+        visible_quantity: Quantity::new(visible),
+        hidden_quantity: Quantity::new(hidden),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: 1616823000000,
+        timestamp: TimestampMs::new(1616823000000),
         time_in_force: TimeInForce::Gtc,
         extra_fields: (),
     }
@@ -380,11 +380,11 @@ fn create_iceberg_order(id: u64, price: u128, visible: u64, hidden: u64) -> Orde
 fn create_post_only_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
     OrderType::PostOnly {
         id: Id::from_u64(id),
-        price,
-        quantity,
+        price: Price::new(price),
+        quantity: Quantity::new(quantity),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: 1616823000000,
+        timestamp: TimestampMs::new(1616823000000),
         time_in_force: TimeInForce::Gtc,
         extra_fields: (),
     }
@@ -402,15 +402,15 @@ fn create_reserve_order(
 ) -> OrderType<()> {
     OrderType::ReserveOrder {
         id: Id::from_u64(id),
-        price,
-        visible_quantity: visible,
-        hidden_quantity: hidden,
+        price: Price::new(price),
+        visible_quantity: Quantity::new(visible),
+        hidden_quantity: Quantity::new(hidden),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: 1616823000000,
+        timestamp: TimestampMs::new(1616823000000),
         time_in_force: TimeInForce::Gtc,
-        replenish_threshold: threshold,
-        replenish_amount,
+        replenish_threshold: Quantity::new(threshold),
+        replenish_amount: replenish_amount.map(Quantity::new),
         auto_replenish,
         extra_fields: (),
     }
@@ -420,11 +420,11 @@ fn create_reserve_order(
 fn create_pegged_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
     OrderType::PeggedOrder {
         id: Id::from_u64(id),
-        price,
-        quantity,
+        price: Price::new(price),
+        quantity: Quantity::new(quantity),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: 1616823000000,
+        timestamp: TimestampMs::new(1616823000000),
         time_in_force: TimeInForce::Gtc,
         reference_price_offset: -50,
         reference_price_type: PegReferenceType::BestAsk,
@@ -439,11 +439,11 @@ fn setup_standard_orders(order_count: u64) -> PriceLevel {
     for i in 0..order_count {
         let order = OrderType::Standard {
             id: Id::from_u64(i),
-            price: 10000u128,
-            quantity: 10,
+            price: Price::new(10000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000 + i,
+            timestamp: TimestampMs::new(1616823000000 + i),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };

--- a/benches/price_level/add_orders.rs
+++ b/benches/price_level/add_orders.rs
@@ -1,5 +1,7 @@
 use criterion::{BenchmarkId, Criterion};
-use pricelevel::{Hash32, Id, OrderType, PriceLevel, Side, TimeInForce};
+use pricelevel::{
+    Hash32, Id, OrderType, Price, PriceLevel, Quantity, Side, TimeInForce, TimestampMs,
+};
 use std::hint::black_box;
 
 /// Register all benchmarks for adding orders to a price level
@@ -82,11 +84,11 @@ pub fn register_benchmarks(c: &mut Criterion) {
 fn create_standard_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
     OrderType::Standard {
         id: Id::from_u64(id),
-        price,
-        quantity,
+        price: Price::new(price),
+        quantity: Quantity::new(quantity),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: 1616823000000,
+        timestamp: TimestampMs::new(1616823000000),
         time_in_force: TimeInForce::Gtc,
         extra_fields: (),
     }
@@ -96,12 +98,12 @@ fn create_standard_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
 fn create_iceberg_order(id: u64, price: u128, visible: u64, hidden: u64) -> OrderType<()> {
     OrderType::IcebergOrder {
         id: Id::from_u64(id),
-        price,
-        visible_quantity: visible,
-        hidden_quantity: hidden,
+        price: Price::new(price),
+        visible_quantity: Quantity::new(visible),
+        hidden_quantity: Quantity::new(hidden),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: 1616823000000,
+        timestamp: TimestampMs::new(1616823000000),
         time_in_force: TimeInForce::Gtc,
         extra_fields: (),
     }
@@ -111,11 +113,11 @@ fn create_iceberg_order(id: u64, price: u128, visible: u64, hidden: u64) -> Orde
 fn create_post_only_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
     OrderType::PostOnly {
         id: Id::from_u64(id),
-        price,
-        quantity,
+        price: Price::new(price),
+        quantity: Quantity::new(quantity),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: 1616823000000,
+        timestamp: TimestampMs::new(1616823000000),
         time_in_force: TimeInForce::Gtc,
         extra_fields: (),
     }
@@ -133,15 +135,15 @@ fn create_reserve_order(
 ) -> OrderType<()> {
     OrderType::ReserveOrder {
         id: Id::from_u64(id),
-        price,
-        visible_quantity: visible,
-        hidden_quantity: hidden,
+        price: Price::new(price),
+        visible_quantity: Quantity::new(visible),
+        hidden_quantity: Quantity::new(hidden),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: 1616823000000,
+        timestamp: TimestampMs::new(1616823000000),
         time_in_force: TimeInForce::Gtc,
-        replenish_threshold: threshold,
-        replenish_amount,
+        replenish_threshold: Quantity::new(threshold),
+        replenish_amount: replenish_amount.map(Quantity::new),
         auto_replenish,
         extra_fields: (),
     }
@@ -153,11 +155,11 @@ fn create_pegged_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
 
     OrderType::PeggedOrder {
         id: Id::from_u64(id),
-        price,
-        quantity,
+        price: Price::new(price),
+        quantity: Quantity::new(quantity),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: 1616823000000,
+        timestamp: TimestampMs::new(1616823000000),
         time_in_force: TimeInForce::Gtc,
         reference_price_offset: -50,
         reference_price_type: PegReferenceType::BestAsk,

--- a/benches/price_level/match_orders.rs
+++ b/benches/price_level/match_orders.rs
@@ -1,5 +1,8 @@
 use criterion::{BenchmarkId, Criterion};
-use pricelevel::{Hash32, Id, OrderType, PriceLevel, Side, TimeInForce, UuidGenerator};
+use pricelevel::{
+    Hash32, Id, OrderType, Price, PriceLevel, Quantity, Side, TimeInForce, TimestampMs,
+    UuidGenerator,
+};
 use std::hint::black_box;
 use uuid::Uuid;
 
@@ -102,11 +105,11 @@ fn setup_standard_orders(order_count: u64) -> PriceLevel {
     for i in 0..order_count {
         let order = OrderType::Standard {
             id: Id::from_u64(i),
-            price: 10000u128,
-            quantity: 10,
+            price: Price::new(10000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000 + i,
+            timestamp: TimestampMs::new(1616823000000 + i),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -123,12 +126,12 @@ fn setup_iceberg_orders(order_count: u64) -> PriceLevel {
     for i in 0..order_count {
         let order = OrderType::IcebergOrder {
             id: Id::from_u64(i),
-            price: 10000u128,
-            visible_quantity: 5,
-            hidden_quantity: 15,
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(5),
+            hidden_quantity: Quantity::new(15),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000 + i,
+            timestamp: TimestampMs::new(1616823000000 + i),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -145,15 +148,15 @@ fn setup_reserve_orders(order_count: u64) -> PriceLevel {
     for i in 0..order_count {
         let order = OrderType::ReserveOrder {
             id: Id::from_u64(i),
-            price: 10000u128,
-            visible_quantity: 5,
-            hidden_quantity: 15,
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(5),
+            hidden_quantity: Quantity::new(15),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000 + i,
+            timestamp: TimestampMs::new(1616823000000 + i),
             time_in_force: TimeInForce::Gtc,
-            replenish_threshold: 2,
-            replenish_amount: Some(5),
+            replenish_threshold: Quantity::new(2),
+            replenish_amount: Some(Quantity::new(5)),
             auto_replenish: true,
             extra_fields: (),
         };
@@ -171,36 +174,36 @@ fn setup_mixed_orders(order_count: u64) -> PriceLevel {
         let order = match i % 3 {
             0 => OrderType::Standard {
                 id: Id::from_u64(i),
-                price: 10000u128,
-                quantity: 10,
+                price: Price::new(10000),
+                quantity: Quantity::new(10),
                 side: Side::Buy,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000000 + i,
+                timestamp: TimestampMs::new(1616823000000 + i),
                 time_in_force: TimeInForce::Gtc,
                 extra_fields: (),
             },
             1 => OrderType::IcebergOrder {
                 id: Id::from_u64(i),
-                price: 10000u128,
-                visible_quantity: 5,
-                hidden_quantity: 15,
+                price: Price::new(10000),
+                visible_quantity: Quantity::new(5),
+                hidden_quantity: Quantity::new(15),
                 side: Side::Buy,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000000 + i,
+                timestamp: TimestampMs::new(1616823000000 + i),
                 time_in_force: TimeInForce::Gtc,
                 extra_fields: (),
             },
             _ => OrderType::ReserveOrder {
                 id: Id::from_u64(i),
-                price: 10000u128,
-                visible_quantity: 5,
-                hidden_quantity: 15,
+                price: Price::new(10000),
+                visible_quantity: Quantity::new(5),
+                hidden_quantity: Quantity::new(15),
                 side: Side::Buy,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000000 + i,
+                timestamp: TimestampMs::new(1616823000000 + i),
                 time_in_force: TimeInForce::Gtc,
-                replenish_threshold: 2,
-                replenish_amount: Some(5),
+                replenish_threshold: Quantity::new(2),
+                replenish_amount: Some(Quantity::new(5)),
                 auto_replenish: true,
                 extra_fields: (),
             },

--- a/benches/price_level/mixed_operations.rs
+++ b/benches/price_level/mixed_operations.rs
@@ -1,6 +1,7 @@
 use criterion::Criterion;
 use pricelevel::{
-    Hash32, Id, OrderType, OrderUpdate, PriceLevel, Side, TimeInForce, UuidGenerator,
+    Hash32, Id, OrderType, OrderUpdate, Price, PriceLevel, Quantity, Side, TimeInForce,
+    TimestampMs, UuidGenerator,
 };
 use std::hint::black_box;
 use uuid::Uuid;
@@ -40,7 +41,7 @@ pub fn register_benchmarks(c: &mut Criterion) {
                 if i % 2 == 0 {
                     let _ = black_box(price_level.update_order(OrderUpdate::UpdateQuantity {
                         order_id: Id::from_u64(i),
-                        new_quantity: 20,
+                        new_quantity: Quantity::new(20),
                     }));
                 } else {
                     let _ = black_box(price_level.update_order(OrderUpdate::Cancel {
@@ -147,11 +148,11 @@ pub fn register_benchmarks(c: &mut Criterion) {
 fn create_standard_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
     OrderType::Standard {
         id: Id::from_u64(id),
-        price,
-        quantity,
+        price: Price::new(price),
+        quantity: Quantity::new(quantity),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: 1616823000000 + id,
+        timestamp: TimestampMs::new(1616823000000 + id),
         time_in_force: TimeInForce::Gtc,
         extra_fields: (),
     }
@@ -161,12 +162,12 @@ fn create_standard_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
 fn create_iceberg_order(id: u64, price: u128, visible: u64, hidden: u64) -> OrderType<()> {
     OrderType::IcebergOrder {
         id: Id::from_u64(id),
-        price,
-        visible_quantity: visible,
-        hidden_quantity: hidden,
+        price: Price::new(price),
+        visible_quantity: Quantity::new(visible),
+        hidden_quantity: Quantity::new(hidden),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: 1616823000000 + id,
+        timestamp: TimestampMs::new(1616823000000 + id),
         time_in_force: TimeInForce::Gtc,
         extra_fields: (),
     }
@@ -184,15 +185,15 @@ fn create_reserve_order(
 ) -> OrderType<()> {
     OrderType::ReserveOrder {
         id: Id::from_u64(id),
-        price,
-        visible_quantity: visible,
-        hidden_quantity: hidden,
+        price: Price::new(price),
+        visible_quantity: Quantity::new(visible),
+        hidden_quantity: Quantity::new(hidden),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: 1616823000000 + id,
+        timestamp: TimestampMs::new(1616823000000 + id),
         time_in_force: TimeInForce::Gtc,
-        replenish_threshold: threshold,
-        replenish_amount,
+        replenish_threshold: Quantity::new(threshold),
+        replenish_amount: replenish_amount.map(Quantity::new),
         auto_replenish,
         extra_fields: (),
     }

--- a/benches/price_level/update_orders.rs
+++ b/benches/price_level/update_orders.rs
@@ -1,5 +1,7 @@
 use criterion::{BenchmarkId, Criterion};
-use pricelevel::{Hash32, Id, OrderType, OrderUpdate, PriceLevel, Side, TimeInForce};
+use pricelevel::{
+    Hash32, Id, OrderType, OrderUpdate, Price, PriceLevel, Quantity, Side, TimeInForce, TimestampMs,
+};
 use std::hint::black_box;
 
 /// Register all benchmarks for updating orders at a price level
@@ -26,7 +28,7 @@ pub fn register_benchmarks(c: &mut Criterion) {
             for i in 25..75 {
                 let _ = black_box(price_level.update_order(OrderUpdate::UpdateQuantity {
                     order_id: Id::from_u64(i),
-                    new_quantity: 200,
+                    new_quantity: Quantity::new(200),
                 }));
             }
         })
@@ -39,8 +41,8 @@ pub fn register_benchmarks(c: &mut Criterion) {
             for i in 25..75 {
                 let _ = black_box(price_level.update_order(OrderUpdate::Replace {
                     order_id: Id::from_u64(i),
-                    price: 10000, // Same price
-                    quantity: 150,
+                    price: Price::new(10000), // Same price
+                    quantity: Quantity::new(150),
                     side: Side::Buy,
                 }));
             }
@@ -54,8 +56,8 @@ pub fn register_benchmarks(c: &mut Criterion) {
             for i in 25..75 {
                 let _ = black_box(price_level.update_order(OrderUpdate::Replace {
                     order_id: Id::from_u64(i),
-                    price: 10100, // Different price
-                    quantity: 150,
+                    price: Price::new(10100), // Different price
+                    quantity: Quantity::new(150),
                     side: Side::Buy,
                 }));
             }
@@ -71,7 +73,7 @@ pub fn register_benchmarks(c: &mut Criterion) {
                 // but for benchmark we're just using the UpdateQuantity which works on visible
                 let _ = black_box(price_level.update_order(OrderUpdate::UpdateQuantity {
                     order_id: Id::from_u64(i),
-                    new_quantity: 15,
+                    new_quantity: Quantity::new(15),
                 }));
             }
         })
@@ -109,11 +111,11 @@ fn setup_standard_orders(order_count: u64) -> PriceLevel {
     for i in 0..order_count {
         let order = OrderType::Standard {
             id: Id::from_u64(i),
-            price: 10000u128,
-            quantity: 10,
+            price: Price::new(10000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000 + i,
+            timestamp: TimestampMs::new(1616823000000 + i),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -130,12 +132,12 @@ fn setup_iceberg_orders(order_count: u64) -> PriceLevel {
     for i in 0..order_count {
         let order = OrderType::IcebergOrder {
             id: Id::from_u64(i),
-            price: 10000u128,
-            visible_quantity: 5,
-            hidden_quantity: 15,
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(5),
+            hidden_quantity: Quantity::new(15),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000 + i,
+            timestamp: TimestampMs::new(1616823000000 + i),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };

--- a/examples/src/bin/contention_test.rs
+++ b/examples/src/bin/contention_test.rs
@@ -1,7 +1,8 @@
 // examples/src/bin/contention_test.rs
 
 use pricelevel::{
-    Hash32, Id, OrderType, OrderUpdate, PriceLevel, Side, TimeInForce, UuidGenerator, setup_logger,
+    Hash32, Id, OrderType, OrderUpdate, Price, PriceLevel, Quantity, Side, TimeInForce,
+    TimestampMs, UuidGenerator, setup_logger,
 };
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -194,14 +195,16 @@ fn setup_orders_for_read_write_test(price_level: &PriceLevel) {
 fn create_standard_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
     OrderType::Standard {
         id: Id::from_u64(id),
-        price,
-        quantity,
+        price: Price::new(price),
+        quantity: Quantity::new(quantity),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64,
+        timestamp: TimestampMs::new(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64,
+        ),
         time_in_force: TimeInForce::Gtc,
         extra_fields: (),
     }
@@ -299,7 +302,7 @@ fn test_hot_spot_contention() {
                             let _result =
                                 thread_price_level.update_order(OrderUpdate::UpdateQuantity {
                                     order_id: Id::from_u64(order_idx),
-                                    new_quantity: 15,
+                                    new_quantity: Quantity::new(15),
                                 });
                         }
                     }

--- a/examples/src/bin/hft_simulation.rs
+++ b/examples/src/bin/hft_simulation.rs
@@ -1,8 +1,8 @@
 // examples/src/bin/hft_simulation.rs
 
 use pricelevel::{
-    Hash32, Id, OrderType, OrderUpdate, PegReferenceType, PriceLevel, Side, TimeInForce,
-    UuidGenerator, setup_logger,
+    Hash32, Id, OrderType, OrderUpdate, PegReferenceType, Price, PriceLevel, Quantity, Side,
+    TimeInForce, TimestampMs, UuidGenerator, setup_logger,
 };
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Barrier};
@@ -316,11 +316,11 @@ fn setup_initial_orders(price_level: &PriceLevel, count: u64) {
 fn create_standard_order(id: u64) -> OrderType<()> {
     OrderType::Standard {
         id: Id::from_u64(id),
-        price: PRICE,
-        quantity: 10,
+        price: Price::new(PRICE),
+        quantity: Quantity::new(10),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: get_current_timestamp(),
+        timestamp: TimestampMs::new(get_current_timestamp()),
         time_in_force: TimeInForce::Gtc,
         extra_fields: (),
     }
@@ -330,12 +330,12 @@ fn create_standard_order(id: u64) -> OrderType<()> {
 fn create_iceberg_order(id: u64) -> OrderType<()> {
     OrderType::IcebergOrder {
         id: Id::from_u64(id),
-        price: PRICE,
-        visible_quantity: 5,
-        hidden_quantity: 15,
+        price: Price::new(PRICE),
+        visible_quantity: Quantity::new(5),
+        hidden_quantity: Quantity::new(15),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: get_current_timestamp(),
+        timestamp: TimestampMs::new(get_current_timestamp()),
         time_in_force: TimeInForce::Gtc,
         extra_fields: (),
     }
@@ -345,11 +345,11 @@ fn create_iceberg_order(id: u64) -> OrderType<()> {
 fn create_post_only_order(id: u64) -> OrderType<()> {
     OrderType::PostOnly {
         id: Id::from_u64(id),
-        price: PRICE,
-        quantity: 8,
+        price: Price::new(PRICE),
+        quantity: Quantity::new(8),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: get_current_timestamp(),
+        timestamp: TimestampMs::new(get_current_timestamp()),
         time_in_force: TimeInForce::Gtc,
         extra_fields: (),
     }
@@ -359,15 +359,15 @@ fn create_post_only_order(id: u64) -> OrderType<()> {
 fn create_reserve_order(id: u64) -> OrderType<()> {
     OrderType::ReserveOrder {
         id: Id::from_u64(id),
-        price: PRICE,
-        visible_quantity: 5,
-        hidden_quantity: 15,
+        price: Price::new(PRICE),
+        visible_quantity: Quantity::new(5),
+        hidden_quantity: Quantity::new(15),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: get_current_timestamp(),
+        timestamp: TimestampMs::new(get_current_timestamp()),
         time_in_force: TimeInForce::Gtc,
-        replenish_threshold: 2,
-        replenish_amount: Some(5),
+        replenish_threshold: Quantity::new(2),
+        replenish_amount: Some(Quantity::new(5)),
         auto_replenish: true,
         extra_fields: (),
     }
@@ -377,11 +377,11 @@ fn create_reserve_order(id: u64) -> OrderType<()> {
 fn create_pegged_order(id: u64) -> OrderType<()> {
     OrderType::PeggedOrder {
         id: Id::from_u64(id),
-        price: PRICE,
-        quantity: 10,
+        price: Price::new(PRICE),
+        quantity: Quantity::new(10),
         side: Side::Buy,
         user_id: Hash32::zero(),
-        timestamp: get_current_timestamp(),
+        timestamp: TimestampMs::new(get_current_timestamp()),
         time_in_force: TimeInForce::Gtc,
         reference_price_offset: -50,
         reference_price_type: PegReferenceType::BestAsk,

--- a/examples/src/bin/simple.rs
+++ b/examples/src/bin/simple.rs
@@ -1,7 +1,8 @@
 // examples/src/bin/multi_threaded_price_level.rs
 
 use pricelevel::{
-    Hash32, Id, OrderType, OrderUpdate, PriceLevel, Side, TimeInForce, UuidGenerator, setup_logger,
+    Hash32, Id, OrderType, OrderUpdate, Price, PriceLevel, Quantity, Side, TimeInForce,
+    TimestampMs, UuidGenerator, setup_logger,
 };
 use std::sync::{Arc, Barrier};
 use std::thread;
@@ -128,7 +129,7 @@ fn main() {
                         let order_id = Id::from_u64(100 + i);
                         let result = thread_price_level.update_order(OrderUpdate::UpdateQuantity {
                             order_id,
-                            new_quantity: 20, // Update to quantity 20
+                            new_quantity: Quantity::new(20), // Update to quantity 20
                         });
 
                         if i % 10 == 0 {
@@ -201,11 +202,11 @@ fn setup_initial_orders(price_level: &PriceLevel) {
     for i in 0..200 {
         let order = OrderType::Standard {
             id: Id::from_u64(i),
-            price: 10000u128,
-            quantity: 10,
+            price: Price::new(10000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000 + i,
+            timestamp: TimestampMs::new(1616823000000 + i),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -216,12 +217,12 @@ fn setup_initial_orders(price_level: &PriceLevel) {
     for i in 200..220 {
         let order = OrderType::IcebergOrder {
             id: Id::from_u64(i),
-            price: 10000u128,
-            visible_quantity: 5,
-            hidden_quantity: 15,
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(5),
+            hidden_quantity: Quantity::new(15),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000 + i,
+            timestamp: TimestampMs::new(1616823000000 + i),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -232,15 +233,15 @@ fn setup_initial_orders(price_level: &PriceLevel) {
     for i in 220..240 {
         let order = OrderType::ReserveOrder {
             id: Id::from_u64(i),
-            price: 10000u128,
-            visible_quantity: 5,
-            hidden_quantity: 15,
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(5),
+            hidden_quantity: Quantity::new(15),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000 + i,
+            timestamp: TimestampMs::new(1616823000000 + i),
             time_in_force: TimeInForce::Gtc,
-            replenish_threshold: 2,
-            replenish_amount: Some(5),
+            replenish_threshold: Quantity::new(2),
+            replenish_amount: Some(Quantity::new(5)),
             auto_replenish: true,
             extra_fields: (),
         };
@@ -259,46 +260,46 @@ fn create_order(thread_id: usize, order_id: u64) -> OrderType<()> {
     match thread_id % 4 {
         0 => OrderType::Standard {
             id: Id::from_u64(order_id),
-            price: 10000u128,
-            quantity: 10,
+            price: Price::new(10000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: current_time,
+            timestamp: TimestampMs::new(current_time),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         },
         1 => OrderType::IcebergOrder {
             id: Id::from_u64(order_id),
-            price: 10000u128,
-            visible_quantity: 5,
-            hidden_quantity: 15,
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(5),
+            hidden_quantity: Quantity::new(15),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: current_time,
+            timestamp: TimestampMs::new(current_time),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         },
         2 => OrderType::PostOnly {
             id: Id::from_u64(order_id),
-            price: 10000u128,
-            quantity: 10,
+            price: Price::new(10000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: current_time,
+            timestamp: TimestampMs::new(current_time),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         },
         _ => OrderType::ReserveOrder {
             id: Id::from_u64(order_id),
-            price: 10000u128,
-            visible_quantity: 5,
-            hidden_quantity: 15,
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(5),
+            hidden_quantity: Quantity::new(15),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: current_time,
+            timestamp: TimestampMs::new(current_time),
             time_in_force: TimeInForce::Gtc,
-            replenish_threshold: 2,
-            replenish_amount: Some(5),
+            replenish_threshold: Quantity::new(2),
+            replenish_amount: Some(Quantity::new(5)),
             auto_replenish: true,
             extra_fields: (),
         },

--- a/src/execution/match_result.rs
+++ b/src/execution/match_result.rs
@@ -39,7 +39,9 @@ impl MatchResult {
 
     /// Add a trade to this match result
     pub fn add_trade(&mut self, trade: Trade) {
-        self.remaining_quantity = self.remaining_quantity.saturating_sub(trade.quantity);
+        self.remaining_quantity = self
+            .remaining_quantity
+            .saturating_sub(trade.quantity.as_u64());
         self.is_complete = self.remaining_quantity == 0;
         self.trades.add(trade);
     }
@@ -51,7 +53,11 @@ impl MatchResult {
 
     /// Get the total executed quantity
     pub fn executed_quantity(&self) -> u64 {
-        self.trades.as_vec().iter().map(|t| t.quantity).sum()
+        self.trades
+            .as_vec()
+            .iter()
+            .map(|t| t.quantity.as_u64())
+            .sum()
     }
 
     /// Get the total value executed
@@ -59,7 +65,7 @@ impl MatchResult {
         self.trades
             .as_vec()
             .iter()
-            .map(|t| t.price * (t.quantity as u128))
+            .map(|t| t.price.as_u128() * (t.quantity.as_u64() as u128))
             .sum()
     }
 

--- a/src/execution/tests/list_trade.rs
+++ b/src/execution/tests/list_trade.rs
@@ -3,6 +3,7 @@ mod tests {
     use crate::execution::list::TradeList;
     use crate::execution::trade::Trade;
     use crate::orders::{Id, Side};
+    use crate::utils::{Price, Quantity, TimestampMs};
     use std::str::FromStr;
     use uuid::Uuid;
 
@@ -18,10 +19,10 @@ mod tests {
             trade_id: Id::from_uuid(parse_uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
             taker_order_id: Id::from_u64(1),
             maker_order_id: Id::from_u64(2),
-            price: 10_000,
-            quantity: 5,
+            price: Price::new(10_000),
+            quantity: Quantity::new(5),
             taker_side: Side::Buy,
-            timestamp: 1_616_823_000_000,
+            timestamp: TimestampMs::new(1_616_823_000_000),
         }
     }
 

--- a/src/execution/tests/match_result_trade.rs
+++ b/src/execution/tests/match_result_trade.rs
@@ -3,6 +3,7 @@ mod tests {
     use crate::execution::match_result::MatchResult;
     use crate::execution::trade::Trade;
     use crate::orders::{Id, Side};
+    use crate::utils::{Price, Quantity, TimestampMs};
     use std::str::FromStr;
     use uuid::Uuid;
 
@@ -18,10 +19,10 @@ mod tests {
             trade_id: Id::from_uuid(parse_uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
             taker_order_id: Id::from_u64(10),
             maker_order_id: Id::from_u64(20),
-            price: 1_000,
-            quantity,
+            price: Price::new(1_000),
+            quantity: Quantity::new(quantity),
             taker_side: Side::Buy,
-            timestamp: 1_616_823_000_000,
+            timestamp: TimestampMs::new(1_616_823_000_000),
         }
     }
 

--- a/src/execution/tests/transaction.rs
+++ b/src/execution/tests/transaction.rs
@@ -3,6 +3,7 @@ mod tests {
     use crate::errors::PriceLevelError;
     use crate::execution::trade::Trade;
     use crate::orders::{Id, Side};
+    use crate::utils::{Price, Quantity, TimestampMs};
     use std::str::FromStr;
     use std::time::{SystemTime, UNIX_EPOCH};
     use uuid::Uuid;
@@ -14,10 +15,10 @@ mod tests {
             trade_id: Id::from_uuid(uuid),
             taker_order_id: Id::from_u64(1),
             maker_order_id: Id::from_u64(2),
-            price: 10000,
-            quantity: 5,
+            price: Price::new(10000),
+            quantity: Quantity::new(5),
             taker_side: Side::Buy,
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
         }
     }
 
@@ -44,10 +45,10 @@ mod tests {
         assert_eq!(transaction.trade_id, Id::from_uuid(uuid));
         assert_eq!(transaction.taker_order_id, Id::from_u64(1));
         assert_eq!(transaction.maker_order_id, Id::from_u64(2));
-        assert_eq!(transaction.price, 10000);
-        assert_eq!(transaction.quantity, 5);
+        assert_eq!(transaction.price, Price::new(10000));
+        assert_eq!(transaction.quantity, Quantity::new(5));
         assert_eq!(transaction.taker_side, Side::Buy);
-        assert_eq!(transaction.timestamp, 1616823000000);
+        assert_eq!(transaction.timestamp, TimestampMs::new(1616823000000));
     }
 
     #[test]
@@ -132,14 +133,14 @@ mod tests {
     #[test]
     fn test_total_value() {
         let mut transaction = create_test_trade();
-        transaction.price = 10000;
-        transaction.quantity = 5;
+        transaction.price = Price::new(10000);
+        transaction.quantity = Quantity::new(5);
 
         assert_eq!(transaction.total_value(), 50000);
 
         // Test with larger values
-        transaction.price = 123456;
-        transaction.quantity = 789;
+        transaction.price = Price::new(123456);
+        transaction.quantity = Quantity::new(789);
         assert_eq!(transaction.total_value(), 97406784);
     }
 
@@ -155,20 +156,20 @@ mod tests {
             Id::from_uuid(uuid),
             Id::from_u64(1),
             Id::from_u64(2),
-            10000,
-            5,
+            Price::new(10000),
+            Quantity::new(5),
             Side::Buy,
         );
 
         assert_eq!(transaction.trade_id, Id::from_uuid(uuid));
         assert_eq!(transaction.taker_order_id, Id::from_u64(1));
         assert_eq!(transaction.maker_order_id, Id::from_u64(2));
-        assert_eq!(transaction.price, 10000);
-        assert_eq!(transaction.quantity, 5);
+        assert_eq!(transaction.price, Price::new(10000));
+        assert_eq!(transaction.quantity, Quantity::new(5));
         assert_eq!(transaction.taker_side, Side::Buy);
 
         // The timestamp should be approximately now
-        let timestamp_diff = transaction.timestamp.abs_diff(now);
+        let timestamp_diff = transaction.timestamp.as_u64().abs_diff(now);
 
         // Timestamp should be within 100ms of current time
         assert!(
@@ -189,10 +190,10 @@ mod tests {
         assert_eq!(transaction.trade_id, Id::from_uuid(uuid));
         assert_eq!(transaction.taker_order_id, Id::from_u64(1));
         assert_eq!(transaction.maker_order_id, Id::from_u64(2));
-        assert_eq!(transaction.price, 10000);
-        assert_eq!(transaction.quantity, 5);
+        assert_eq!(transaction.price, Price::new(10000));
+        assert_eq!(transaction.quantity, Quantity::new(5));
         assert_eq!(transaction.taker_side, Side::Buy);
-        assert_eq!(transaction.timestamp, 1616823000000);
+        assert_eq!(transaction.timestamp, TimestampMs::new(1616823000000));
     }
 
     #[test]
@@ -257,6 +258,7 @@ mod tests {
 mod transaction_serialization_tests {
     use crate::execution::trade::Trade;
     use crate::orders::{Id, Side};
+    use crate::utils::{Price, Quantity, TimestampMs};
     use std::str::FromStr;
     use uuid::Uuid;
 
@@ -266,10 +268,10 @@ mod transaction_serialization_tests {
             trade_id: Id::from_uuid(uuid),
             taker_order_id: Id::from_u64(1),
             maker_order_id: Id::from_u64(2),
-            price: 10000,
-            quantity: 5,
+            price: Price::new(10000),
+            quantity: Quantity::new(5),
             taker_side: Side::Buy,
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
         }
     }
 
@@ -303,10 +305,10 @@ mod transaction_serialization_tests {
         assert_eq!(transaction.trade_id, Id::from_uuid(uuid));
         assert_eq!(transaction.taker_order_id, Id::from_u64(1));
         assert_eq!(transaction.maker_order_id, Id::from_u64(2));
-        assert_eq!(transaction.price, 10000);
-        assert_eq!(transaction.quantity, 5);
+        assert_eq!(transaction.price, Price::new(10000));
+        assert_eq!(transaction.quantity, Quantity::new(5));
         assert_eq!(transaction.taker_side, Side::Buy);
-        assert_eq!(transaction.timestamp, 1616823000000);
+        assert_eq!(transaction.timestamp, TimestampMs::new(1616823000000));
     }
 
     #[test]
@@ -349,10 +351,10 @@ mod transaction_serialization_tests {
         assert_eq!(transaction.trade_id, Id::from_uuid(uuid));
         assert_eq!(transaction.taker_order_id, Id::from_u64(1));
         assert_eq!(transaction.maker_order_id, Id::from_u64(2));
-        assert_eq!(transaction.price, 10000);
-        assert_eq!(transaction.quantity, 5);
+        assert_eq!(transaction.price, Price::new(10000));
+        assert_eq!(transaction.quantity, Quantity::new(5));
         assert_eq!(transaction.taker_side, Side::Buy);
-        assert_eq!(transaction.timestamp, 1616823000000);
+        assert_eq!(transaction.timestamp, TimestampMs::new(1616823000000));
     }
 
     #[test]
@@ -426,13 +428,13 @@ mod transaction_serialization_tests {
     #[test]
     fn test_total_value_calculation() {
         let mut transaction = create_test_trade();
-        transaction.price = 10000;
-        transaction.quantity = 5;
+        transaction.price = Price::new(10000);
+        transaction.quantity = Quantity::new(5);
 
         assert_eq!(transaction.total_value(), 50000);
 
-        transaction.price = 12345;
-        transaction.quantity = 67;
+        transaction.price = Price::new(12345);
+        transaction.quantity = Quantity::new(67);
 
         assert_eq!(transaction.total_value(), 827115);
     }

--- a/src/execution/trade.rs
+++ b/src/execution/trade.rs
@@ -1,5 +1,6 @@
 use crate::errors::PriceLevelError;
 use crate::orders::{Id, Side};
+use crate::utils::{Price, Quantity, TimestampMs};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
@@ -18,16 +19,16 @@ pub struct Trade {
     pub maker_order_id: Id,
 
     /// Price at which the trade occurred
-    pub price: u128,
+    pub price: Price,
 
     /// Quantity traded
-    pub quantity: u64,
+    pub quantity: Quantity,
 
     /// Side of the taker order
     pub taker_side: Side,
 
     /// Timestamp when the trade occurred
-    pub timestamp: u64,
+    pub timestamp: TimestampMs,
 }
 
 impl Trade {
@@ -36,13 +37,14 @@ impl Trade {
         trade_id: Id,
         taker_order_id: Id,
         maker_order_id: Id,
-        price: u128,
-        quantity: u64,
+        price: Price,
+        quantity: Quantity,
         taker_side: Side,
     ) -> Self {
-        let timestamp = SystemTime::now()
+        let timestamp_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_or(0_u64, |duration| duration.as_millis() as u64);
+        let timestamp = TimestampMs::new(timestamp_ms);
 
         Self {
             trade_id,
@@ -65,7 +67,7 @@ impl Trade {
 
     /// Returns the total value of this trade
     pub fn total_value(&self) -> u128 {
-        self.price * (self.quantity as u128)
+        self.price.as_u128() * (self.quantity.as_u64() as u128)
     }
 }
 
@@ -111,24 +113,6 @@ impl FromStr for Trade {
             }
         };
 
-        let parse_u64 = |field: &str, value: &str| -> Result<u64, PriceLevelError> {
-            value
-                .parse::<u64>()
-                .map_err(|_| PriceLevelError::InvalidFieldValue {
-                    field: field.to_string(),
-                    value: value.to_string(),
-                })
-        };
-
-        let parse_u128 = |field: &str, value: &str| -> Result<u128, PriceLevelError> {
-            value
-                .parse::<u128>()
-                .map_err(|_| PriceLevelError::InvalidFieldValue {
-                    field: field.to_string(),
-                    value: value.to_string(),
-                })
-        };
-
         // Parse trade_id
         let trade_id_str = get_field("trade_id")?;
         let trade_id =
@@ -155,11 +139,18 @@ impl FromStr for Trade {
 
         // Parse price
         let price_str = get_field("price")?;
-        let price = parse_u128("price", price_str)?;
+        let price = Price::from_str(price_str).map_err(|_| PriceLevelError::InvalidFieldValue {
+            field: "price".to_string(),
+            value: price_str.to_string(),
+        })?;
 
         // Parse quantity
         let quantity_str = get_field("quantity")?;
-        let quantity = parse_u64("quantity", quantity_str)?;
+        let quantity =
+            Quantity::from_str(quantity_str).map_err(|_| PriceLevelError::InvalidFieldValue {
+                field: "quantity".to_string(),
+                value: quantity_str.to_string(),
+            })?;
 
         // Parse taker_side
         let taker_side_str = get_field("taker_side")?;
@@ -171,7 +162,12 @@ impl FromStr for Trade {
 
         // Parse timestamp
         let timestamp_str = get_field("timestamp")?;
-        let timestamp = parse_u64("timestamp", timestamp_str)?;
+        let timestamp = TimestampMs::from_str(timestamp_str).map_err(|_| {
+            PriceLevelError::InvalidFieldValue {
+                field: "timestamp".to_string(),
+                value: timestamp_str.to_string(),
+            }
+        })?;
 
         Ok(Trade {
             trade_id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,4 +150,4 @@ pub use orders::DEFAULT_RESERVE_REPLENISH_AMOUNT;
 pub use orders::PegReferenceType;
 pub use orders::{Hash32, Id, OrderType, OrderUpdate, Side, TimeInForce};
 pub use price_level::{OrderQueue, PriceLevel, PriceLevelData, PriceLevelSnapshot};
-pub use utils::{UuidGenerator, setup_logger};
+pub use utils::{Price, Quantity, TimestampMs, UuidGenerator, setup_logger};

--- a/src/orders/order_type.rs
+++ b/src/orders/order_type.rs
@@ -3,6 +3,7 @@
 use crate::OrderQueue;
 use crate::errors::PriceLevelError;
 use crate::orders::{Hash32, Id, PegReferenceType, Side, TimeInForce};
+use crate::utils::{Price, Quantity, TimestampMs};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
@@ -27,15 +28,15 @@ pub enum OrderType<T> {
         /// The order ID
         id: Id,
         /// The price of the order
-        price: u128,
+        price: Price,
         /// The quantity of the order
-        quantity: u64,
+        quantity: Quantity,
         /// The side of the order (buy or sell)
         side: Side,
         /// Owner identifier for fast lookup (32 bytes)
         user_id: Hash32,
         /// When the order was created
-        timestamp: u64,
+        timestamp: TimestampMs,
         /// Time-in-force policy
         time_in_force: TimeInForce,
         /// Additional custom fields
@@ -47,17 +48,17 @@ pub enum OrderType<T> {
         /// The order ID
         id: Id,
         /// The price of the order
-        price: u128,
+        price: Price,
         /// The visible quantity of the order
-        visible_quantity: u64,
+        visible_quantity: Quantity,
         /// The hidden quantity of the order
-        hidden_quantity: u64,
+        hidden_quantity: Quantity,
         /// The side of the order (buy or sell)
         side: Side,
         /// Owner identifier for fast lookup (32 bytes)
         user_id: Hash32,
         /// When the order was created
-        timestamp: u64,
+        timestamp: TimestampMs,
         /// Time-in-force policy
         time_in_force: TimeInForce,
         /// Additional custom fields
@@ -69,15 +70,15 @@ pub enum OrderType<T> {
         /// The order ID
         id: Id,
         /// The price of the order
-        price: u128,
+        price: Price,
         /// The quantity of the order
-        quantity: u64,
+        quantity: Quantity,
         /// The side of the order (buy or sell)
         side: Side,
         /// Owner identifier for fast lookup (32 bytes)
         user_id: Hash32,
         /// When the order was created
-        timestamp: u64,
+        timestamp: TimestampMs,
         /// Time-in-force policy
         time_in_force: TimeInForce,
         /// Additional custom fields
@@ -89,21 +90,21 @@ pub enum OrderType<T> {
         /// The order ID
         id: Id,
         /// The price of the order
-        price: u128,
+        price: Price,
         /// The quantity of the order
-        quantity: u64,
+        quantity: Quantity,
         /// The side of the order (buy or sell)
         side: Side,
         /// Owner identifier for fast lookup (32 bytes)
         user_id: Hash32,
         /// When the order was created
-        timestamp: u64,
+        timestamp: TimestampMs,
         /// Time-in-force policy
         time_in_force: TimeInForce,
         /// Amount to trail the market price
-        trail_amount: u64,
+        trail_amount: Quantity,
         /// Last reference price
-        last_reference_price: u128,
+        last_reference_price: Price,
         /// Additional custom fields
         extra_fields: T,
     },
@@ -113,15 +114,15 @@ pub enum OrderType<T> {
         /// The order ID
         id: Id,
         /// The price of the order
-        price: u128,
+        price: Price,
         /// The quantity of the order
-        quantity: u64,
+        quantity: Quantity,
         /// The side of the order (buy or sell)
         side: Side,
         /// Owner identifier for fast lookup (32 bytes)
         user_id: Hash32,
         /// When the order was created
-        timestamp: u64,
+        timestamp: TimestampMs,
         /// Time-in-force policy
         time_in_force: TimeInForce,
         /// Offset from the reference price
@@ -137,15 +138,15 @@ pub enum OrderType<T> {
         /// The order ID
         id: Id,
         /// The price of the order
-        price: u128,
+        price: Price,
         /// The quantity of the order
-        quantity: u64,
+        quantity: Quantity,
         /// The side of the order (buy or sell)
         side: Side,
         /// Owner identifier for fast lookup (32 bytes)
         user_id: Hash32,
         /// When the order was created
-        timestamp: u64,
+        timestamp: TimestampMs,
         /// Time-in-force policy
         time_in_force: TimeInForce,
         /// Additional custom fields
@@ -161,23 +162,23 @@ pub enum OrderType<T> {
         /// The order ID
         id: Id,
         /// The price of the order
-        price: u128,
+        price: Price,
         /// The visible quantity of the order
-        visible_quantity: u64,
+        visible_quantity: Quantity,
         /// The hidden quantity of the order
-        hidden_quantity: u64,
+        hidden_quantity: Quantity,
         /// The side of the order (buy or sell)
         side: Side,
         /// Owner identifier for fast lookup (32 bytes)
         user_id: Hash32,
         /// When the order was created
-        timestamp: u64,
+        timestamp: TimestampMs,
         /// Time-in-force policy
         time_in_force: TimeInForce,
         /// Threshold at which to replenish
-        replenish_threshold: u64,
+        replenish_threshold: Quantity,
         /// Optional amount to replenish by. If None, uses DEFAULT_RESERVE_REPLENISH_AMOUNT
-        replenish_amount: Option<u64>,
+        replenish_amount: Option<Quantity>,
         /// Whether to replenish automatically when below threshold. If false, only replenish on next match
         auto_replenish: bool,
         /// Additional custom fields
@@ -213,7 +214,7 @@ impl<T: Clone> OrderType<T> {
     }
 
     /// Get the price
-    pub fn price(&self) -> u128 {
+    pub fn price(&self) -> Price {
         match self {
             Self::Standard { price, .. } => *price,
             Self::IcebergOrder { price, .. } => *price,
@@ -228,17 +229,17 @@ impl<T: Clone> OrderType<T> {
     /// Get the visible quantity
     pub fn visible_quantity(&self) -> u64 {
         match self {
-            Self::Standard { quantity, .. } => *quantity,
+            Self::Standard { quantity, .. } => quantity.as_u64(),
             Self::IcebergOrder {
                 visible_quantity, ..
-            } => *visible_quantity,
-            Self::PostOnly { quantity, .. } => *quantity,
-            Self::TrailingStop { quantity, .. } => *quantity,
-            Self::PeggedOrder { quantity, .. } => *quantity,
-            Self::MarketToLimit { quantity, .. } => *quantity,
+            } => visible_quantity.as_u64(),
+            Self::PostOnly { quantity, .. } => quantity.as_u64(),
+            Self::TrailingStop { quantity, .. } => quantity.as_u64(),
+            Self::PeggedOrder { quantity, .. } => quantity.as_u64(),
+            Self::MarketToLimit { quantity, .. } => quantity.as_u64(),
             Self::ReserveOrder {
                 visible_quantity, ..
-            } => *visible_quantity,
+            } => visible_quantity.as_u64(),
         }
     }
 
@@ -247,10 +248,10 @@ impl<T: Clone> OrderType<T> {
         match self {
             Self::IcebergOrder {
                 hidden_quantity, ..
-            } => *hidden_quantity,
+            } => hidden_quantity.as_u64(),
             Self::ReserveOrder {
                 hidden_quantity, ..
-            } => *hidden_quantity,
+            } => hidden_quantity.as_u64(),
             _ => 0,
         }
     }
@@ -284,13 +285,13 @@ impl<T: Clone> OrderType<T> {
     /// Get the timestamp
     pub fn timestamp(&self) -> u64 {
         match self {
-            Self::Standard { timestamp, .. } => *timestamp,
-            Self::IcebergOrder { timestamp, .. } => *timestamp,
-            Self::PostOnly { timestamp, .. } => *timestamp,
-            Self::TrailingStop { timestamp, .. } => *timestamp,
-            Self::PeggedOrder { timestamp, .. } => *timestamp,
-            Self::MarketToLimit { timestamp, .. } => *timestamp,
-            Self::ReserveOrder { timestamp, .. } => *timestamp,
+            Self::Standard { timestamp, .. } => timestamp.as_u64(),
+            Self::IcebergOrder { timestamp, .. } => timestamp.as_u64(),
+            Self::PostOnly { timestamp, .. } => timestamp.as_u64(),
+            Self::TrailingStop { timestamp, .. } => timestamp.as_u64(),
+            Self::PeggedOrder { timestamp, .. } => timestamp.as_u64(),
+            Self::MarketToLimit { timestamp, .. } => timestamp.as_u64(),
+            Self::ReserveOrder { timestamp, .. } => timestamp.as_u64(),
         }
     }
 
@@ -311,6 +312,7 @@ impl<T: Clone> OrderType<T> {
 
     /// Create a new standard order with reduced quantity
     pub fn with_reduced_quantity(&self, new_quantity: u64) -> Self {
+        let new_quantity = Quantity::new(new_quantity);
         match self {
             Self::Standard {
                 id,
@@ -393,15 +395,15 @@ impl<T: Clone> OrderType<T> {
                 time_in_force,
                 extra_fields,
             } => {
-                let used_hidden = refresh_amount.min(*hidden_quantity);
-                let new_hidden = *hidden_quantity - used_hidden;
+                let used_hidden = refresh_amount.min(hidden_quantity.as_u64());
+                let new_hidden = hidden_quantity.as_u64() - used_hidden;
 
                 (
                     Self::IcebergOrder {
                         id: *id,
                         price: *price,
-                        visible_quantity: used_hidden,
-                        hidden_quantity: new_hidden,
+                        visible_quantity: Quantity::new(used_hidden),
+                        hidden_quantity: Quantity::new(new_hidden),
                         side: *side,
                         user_id: *user_id,
                         timestamp: *timestamp,
@@ -425,15 +427,15 @@ impl<T: Clone> OrderType<T> {
                 auto_replenish,
                 extra_fields,
             } => {
-                let used_hidden = refresh_amount.min(*hidden_quantity);
-                let new_hidden = *hidden_quantity - used_hidden;
+                let used_hidden = refresh_amount.min(hidden_quantity.as_u64());
+                let new_hidden = hidden_quantity.as_u64() - used_hidden;
 
                 (
                     Self::ReserveOrder {
                         id: *id,
                         price: *price,
-                        visible_quantity: used_hidden,
-                        hidden_quantity: new_hidden,
+                        visible_quantity: Quantity::new(used_hidden),
+                        hidden_quantity: Quantity::new(new_hidden),
                         side: *side,
                         user_id: *user_id,
                         timestamp: *timestamp,
@@ -471,13 +473,13 @@ impl<T: Clone> OrderType<T> {
                 time_in_force,
                 extra_fields,
             } => {
-                if *quantity <= incoming_quantity {
+                if quantity.as_u64() <= incoming_quantity {
                     // Full match
                     (
-                        *quantity,                     // consumed = full order quantity
-                        None,                          // no updated order (fully matched)
-                        0,                             // no hidden quantity reduced
-                        incoming_quantity - *quantity, // remaining = incoming - consumed
+                        quantity.as_u64(),                     // consumed = full order quantity
+                        None,                                  // no updated order (fully matched)
+                        0,                                     // no hidden quantity reduced
+                        incoming_quantity - quantity.as_u64(), // remaining = incoming - consumed
                     )
                 } else {
                     // Partial match
@@ -486,7 +488,7 @@ impl<T: Clone> OrderType<T> {
                         Some(Self::Standard {
                             id: *id,
                             price: *price,
-                            quantity: *quantity - incoming_quantity, // reduce quantity
+                            quantity: Quantity::new(quantity.as_u64() - incoming_quantity),
                             side: *side,
                             user_id: *user_id,
                             timestamp: *timestamp,
@@ -511,15 +513,16 @@ impl<T: Clone> OrderType<T> {
                 time_in_force,
                 extra_fields,
             } => {
-                if *visible_quantity <= incoming_quantity {
+                if visible_quantity.as_u64() <= incoming_quantity {
                     // Fully match the visible portion
-                    let consumed = *visible_quantity;
+                    let consumed = visible_quantity.as_u64();
                     let remaining = incoming_quantity - consumed;
 
-                    if *hidden_quantity > 0 {
+                    if hidden_quantity.as_u64() > 0 {
                         // Refresh visible portion from hidden
-                        let refresh_qty = std::cmp::min(*hidden_quantity, *visible_quantity);
-                        let new_hidden = *hidden_quantity - refresh_qty;
+                        let refresh_qty =
+                            std::cmp::min(hidden_quantity.as_u64(), visible_quantity.as_u64());
+                        let new_hidden = hidden_quantity.as_u64() - refresh_qty;
 
                         // Create updated order with refreshed quantities
                         (
@@ -527,8 +530,8 @@ impl<T: Clone> OrderType<T> {
                             Some(Self::IcebergOrder {
                                 id: *id,
                                 price: *price,
-                                visible_quantity: refresh_qty,
-                                hidden_quantity: new_hidden,
+                                visible_quantity: Quantity::new(refresh_qty),
+                                hidden_quantity: Quantity::new(new_hidden),
                                 side: *side,
                                 user_id: *user_id,
                                 timestamp: *timestamp,
@@ -551,7 +554,7 @@ impl<T: Clone> OrderType<T> {
                         Some(Self::IcebergOrder {
                             id: *id,
                             price: *price,
-                            visible_quantity: *visible_quantity - executed,
+                            visible_quantity: Quantity::new(visible_quantity.as_u64() - executed),
                             hidden_quantity: *hidden_quantity,
                             side: *side,
                             user_id: *user_id,
@@ -580,33 +583,34 @@ impl<T: Clone> OrderType<T> {
                 extra_fields,
             } => {
                 // Ensure the threshold is never 0 if auto_replenish is true
-                let safe_threshold = if *auto_replenish && *replenish_threshold == 0 {
+                let safe_threshold = if *auto_replenish && replenish_threshold.as_u64() == 0 {
                     1
                 } else {
-                    *replenish_threshold
+                    replenish_threshold.as_u64()
                 };
 
                 let replenish_qty = replenish_amount
-                    .unwrap_or(DEFAULT_RESERVE_REPLENISH_AMOUNT)
-                    .min(*hidden_quantity);
+                    .unwrap_or(Quantity::new(DEFAULT_RESERVE_REPLENISH_AMOUNT))
+                    .as_u64()
+                    .min(hidden_quantity.as_u64());
 
-                if *visible_quantity <= incoming_quantity {
+                if visible_quantity.as_u64() <= incoming_quantity {
                     // Full match of the visible part
-                    let consumed = *visible_quantity;
+                    let consumed = visible_quantity.as_u64();
                     let remaining = incoming_quantity - consumed;
 
                     // Verify if we need and can replenish
-                    if *hidden_quantity > 0 && *auto_replenish {
+                    if hidden_quantity.as_u64() > 0 && *auto_replenish {
                         // Restore from the hidden quantity
-                        let new_hidden = *hidden_quantity - replenish_qty;
+                        let new_hidden = hidden_quantity.as_u64() - replenish_qty;
 
                         (
                             consumed,
                             Some(Self::ReserveOrder {
                                 id: *id,
                                 price: *price,
-                                visible_quantity: replenish_qty,
-                                hidden_quantity: new_hidden,
+                                visible_quantity: Quantity::new(replenish_qty),
+                                hidden_quantity: Quantity::new(new_hidden),
                                 side: *side,
                                 user_id: *user_id,
                                 timestamp: *timestamp,
@@ -626,20 +630,23 @@ impl<T: Clone> OrderType<T> {
                 } else {
                     // Partial match of the visible part
                     let consumed = incoming_quantity;
-                    let new_visible = *visible_quantity - consumed;
+                    let new_visible = visible_quantity.as_u64() - consumed;
 
                     // Check if we need to replenish (we fell below the threshold)
-                    if new_visible < safe_threshold && *hidden_quantity > 0 && *auto_replenish {
+                    if new_visible < safe_threshold
+                        && hidden_quantity.as_u64() > 0
+                        && *auto_replenish
+                    {
                         // Restore from the hidden quantity
-                        let new_hidden = *hidden_quantity - replenish_qty;
+                        let new_hidden = hidden_quantity.as_u64() - replenish_qty;
 
                         (
                             consumed,
                             Some(Self::ReserveOrder {
                                 id: *id,
                                 price: *price,
-                                visible_quantity: new_visible + replenish_qty,
-                                hidden_quantity: new_hidden,
+                                visible_quantity: Quantity::new(new_visible + replenish_qty),
+                                hidden_quantity: Quantity::new(new_hidden),
                                 side: *side,
                                 user_id: *user_id,
                                 timestamp: *timestamp,
@@ -659,7 +666,7 @@ impl<T: Clone> OrderType<T> {
                             Some(Self::ReserveOrder {
                                 id: *id,
                                 price: *price,
-                                visible_quantity: new_visible,
+                                visible_quantity: Quantity::new(new_visible),
                                 hidden_quantity: *hidden_quantity,
                                 side: *side,
                                 user_id: *user_id,
@@ -924,22 +931,25 @@ impl<T: Default> FromStr for OrderType<T> {
             }
         };
 
-        let parse_u64 = |field: &str, value: &str| -> Result<u64, PriceLevelError> {
-            value
-                .parse::<u64>()
-                .map_err(|_| PriceLevelError::InvalidFieldValue {
-                    field: field.to_string(),
-                    value: value.to_string(),
-                })
+        let parse_quantity = |field: &str, value: &str| -> Result<Quantity, PriceLevelError> {
+            Quantity::from_str(value).map_err(|_| PriceLevelError::InvalidFieldValue {
+                field: field.to_string(),
+                value: value.to_string(),
+            })
         };
 
-        let parse_u128 = |field: &str, value: &str| -> Result<u128, PriceLevelError> {
-            value
-                .parse::<u128>()
-                .map_err(|_| PriceLevelError::InvalidFieldValue {
-                    field: field.to_string(),
-                    value: value.to_string(),
-                })
+        let parse_price = |field: &str, value: &str| -> Result<Price, PriceLevelError> {
+            Price::from_str(value).map_err(|_| PriceLevelError::InvalidFieldValue {
+                field: field.to_string(),
+                value: value.to_string(),
+            })
+        };
+
+        let parse_timestamp = |field: &str, value: &str| -> Result<TimestampMs, PriceLevelError> {
+            TimestampMs::from_str(value).map_err(|_| PriceLevelError::InvalidFieldValue {
+                field: field.to_string(),
+                value: value.to_string(),
+            })
         };
 
         let parse_i64 = |field: &str, value: &str| -> Result<i64, PriceLevelError> {
@@ -959,13 +969,13 @@ impl<T: Default> FromStr for OrderType<T> {
         })?;
 
         let price_str = get_field("price")?;
-        let price = parse_u128("price", price_str)?;
+        let price = parse_price("price", price_str)?;
 
         let side_str = get_field("side")?;
         let side: Side = Side::from_str(side_str)?;
 
         let timestamp_str = get_field("timestamp")?;
-        let timestamp = parse_u64("timestamp", timestamp_str)?;
+        let timestamp = parse_timestamp("timestamp", timestamp_str)?;
 
         let tif_str = get_field("time_in_force")?;
         let time_in_force = TimeInForce::from_str(tif_str)?;
@@ -979,7 +989,7 @@ impl<T: Default> FromStr for OrderType<T> {
         match order_type {
             "Standard" => {
                 let quantity_str = get_field("quantity")?;
-                let quantity = parse_u64("quantity", quantity_str)?;
+                let quantity = parse_quantity("quantity", quantity_str)?;
 
                 Ok(OrderType::Standard {
                     id,
@@ -994,10 +1004,10 @@ impl<T: Default> FromStr for OrderType<T> {
             }
             "IcebergOrder" => {
                 let visible_quantity_str = get_field("visible_quantity")?;
-                let visible_quantity = parse_u64("visible_quantity", visible_quantity_str)?;
+                let visible_quantity = parse_quantity("visible_quantity", visible_quantity_str)?;
 
                 let hidden_quantity_str = get_field("hidden_quantity")?;
-                let hidden_quantity = parse_u64("hidden_quantity", hidden_quantity_str)?;
+                let hidden_quantity = parse_quantity("hidden_quantity", hidden_quantity_str)?;
 
                 Ok(OrderType::IcebergOrder {
                     id,
@@ -1013,7 +1023,7 @@ impl<T: Default> FromStr for OrderType<T> {
             }
             "PostOnly" => {
                 let quantity_str = get_field("quantity")?;
-                let quantity = parse_u64("quantity", quantity_str)?;
+                let quantity = parse_quantity("quantity", quantity_str)?;
 
                 Ok(OrderType::PostOnly {
                     id,
@@ -1028,14 +1038,14 @@ impl<T: Default> FromStr for OrderType<T> {
             }
             "TrailingStop" => {
                 let quantity_str = get_field("quantity")?;
-                let quantity = parse_u64("quantity", quantity_str)?;
+                let quantity = parse_quantity("quantity", quantity_str)?;
 
                 let trail_amount_str = get_field("trail_amount")?;
-                let trail_amount = parse_u64("trail_amount", trail_amount_str)?;
+                let trail_amount = parse_quantity("trail_amount", trail_amount_str)?;
 
                 let last_reference_price_str = get_field("last_reference_price")?;
                 let last_reference_price =
-                    parse_u128("last_reference_price", last_reference_price_str)?;
+                    parse_price("last_reference_price", last_reference_price_str)?;
 
                 Ok(OrderType::TrailingStop {
                     id,
@@ -1052,7 +1062,7 @@ impl<T: Default> FromStr for OrderType<T> {
             }
             "PeggedOrder" => {
                 let quantity_str = get_field("quantity")?;
-                let quantity = parse_u64("quantity", quantity_str)?;
+                let quantity = parse_quantity("quantity", quantity_str)?;
 
                 let reference_price_offset_str = get_field("reference_price_offset")?;
                 let reference_price_offset =
@@ -1087,7 +1097,7 @@ impl<T: Default> FromStr for OrderType<T> {
             }
             "MarketToLimit" => {
                 let quantity_str = get_field("quantity")?;
-                let quantity = parse_u64("quantity", quantity_str)?;
+                let quantity = parse_quantity("quantity", quantity_str)?;
 
                 Ok(OrderType::MarketToLimit {
                     id,
@@ -1102,19 +1112,19 @@ impl<T: Default> FromStr for OrderType<T> {
             }
             "ReserveOrder" => {
                 let visible_quantity_str = get_field("visible_quantity")?;
-                let visible_quantity = parse_u64("visible_quantity", visible_quantity_str)?;
+                let visible_quantity = parse_quantity("visible_quantity", visible_quantity_str)?;
 
                 let hidden_quantity_str = get_field("hidden_quantity")?;
-                let hidden_quantity = parse_u64("hidden_quantity", hidden_quantity_str)?;
+                let hidden_quantity = parse_quantity("hidden_quantity", hidden_quantity_str)?;
 
                 let replenish_threshold_str = get_field("replenish_threshold")?;
                 let replenish_threshold =
-                    parse_u64("replenish_threshold", replenish_threshold_str)?;
+                    parse_quantity("replenish_threshold", replenish_threshold_str)?;
                 let replenish_amount_str = get_field("replenish_amount")?;
                 let replenish_amount = if replenish_amount_str == "None" {
                     None
                 } else {
-                    Some(parse_u64("replenish_amount", replenish_amount_str)?)
+                    Some(parse_quantity("replenish_amount", replenish_amount_str)?)
                 };
                 let auto_replenish_str = get_field("auto_replenish")?;
                 let auto_replenish = match auto_replenish_str {

--- a/src/orders/tests/order_type.rs
+++ b/src/orders/tests/order_type.rs
@@ -2,17 +2,18 @@
 mod tests {
     use crate::orders::time_in_force::TimeInForce;
     use crate::orders::{Hash32, Id, OrderType, PegReferenceType, Side};
+    use crate::utils::{Price, Quantity, TimestampMs};
     use std::str::FromStr;
     use tracing::info;
 
     fn create_standard_order() -> OrderType<()> {
         OrderType::<()>::Standard {
             id: Id::from_u64(123),
-            price: 10000u128,
-            quantity: 5,
+            price: Price::new(10000),
+            quantity: Quantity::new(5),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         }
@@ -22,12 +23,12 @@ mod tests {
     fn create_iceberg_order() -> OrderType<()> {
         OrderType::<()>::IcebergOrder {
             id: Id::from_u64(124),
-            price: 10000u128,
-            visible_quantity: 1,
-            hidden_quantity: 4,
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(1),
+            hidden_quantity: Quantity::new(4),
             side: Side::Sell,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         }
@@ -37,11 +38,11 @@ mod tests {
     fn create_post_only_order() -> OrderType<()> {
         OrderType::<()>::PostOnly {
             id: Id::from_u64(125),
-            price: 10000u128,
-            quantity: 5,
+            price: Price::new(10000),
+            quantity: Quantity::new(5),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         }
@@ -51,14 +52,14 @@ mod tests {
     fn create_trailing_stop_order() -> OrderType<()> {
         OrderType::<()>::TrailingStop {
             id: Id::from_u64(126),
-            price: 10000u128,
-            quantity: 5,
+            price: Price::new(10000),
+            quantity: Quantity::new(5),
             side: Side::Sell,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
-            trail_amount: 100,
-            last_reference_price: 10100u128,
+            trail_amount: Quantity::new(100),
+            last_reference_price: Price::new(10100),
             extra_fields: (),
         }
     }
@@ -67,11 +68,11 @@ mod tests {
     fn create_pegged_order() -> OrderType<()> {
         OrderType::<()>::PeggedOrder {
             id: Id::from_u64(127),
-            price: 10000u128,
-            quantity: 5,
+            price: Price::new(10000),
+            quantity: Quantity::new(5),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             reference_price_offset: -50,
             reference_price_type: PegReferenceType::BestAsk,
@@ -83,11 +84,11 @@ mod tests {
     fn create_market_to_limit_order() -> OrderType<()> {
         OrderType::<()>::MarketToLimit {
             id: Id::from_u64(128),
-            price: 10000u128,
-            quantity: 5,
+            price: Price::new(10000),
+            quantity: Quantity::new(5),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         }
@@ -97,15 +98,15 @@ mod tests {
     fn create_reserve_order() -> OrderType<()> {
         OrderType::<()>::ReserveOrder {
             id: Id::from_u64(129),
-            price: 10000u128,
-            visible_quantity: 1,
-            hidden_quantity: 4,
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(1),
+            hidden_quantity: Quantity::new(4),
             side: Side::Sell,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
-            replenish_threshold: 0,
-            replenish_amount: Some(1),
+            replenish_threshold: Quantity::new(0),
+            replenish_amount: Some(Quantity::new(1)),
             auto_replenish: false,
             extra_fields: (),
         }
@@ -124,13 +125,13 @@ mod tests {
 
     #[test]
     fn test_order_price() {
-        assert_eq!(create_standard_order().price(), 10000u128);
-        assert_eq!(create_iceberg_order().price(), 10000u128);
-        assert_eq!(create_post_only_order().price(), 10000u128);
-        assert_eq!(create_trailing_stop_order().price(), 10000u128);
-        assert_eq!(create_pegged_order().price(), 10000u128);
-        assert_eq!(create_market_to_limit_order().price(), 10000u128);
-        assert_eq!(create_reserve_order().price(), 10000u128);
+        assert_eq!(create_standard_order().price(), Price::new(10000));
+        assert_eq!(create_iceberg_order().price(), Price::new(10000));
+        assert_eq!(create_post_only_order().price(), Price::new(10000));
+        assert_eq!(create_trailing_stop_order().price(), Price::new(10000));
+        assert_eq!(create_pegged_order().price(), Price::new(10000));
+        assert_eq!(create_market_to_limit_order().price(), Price::new(10000));
+        assert_eq!(create_reserve_order().price(), Price::new(10000));
     }
 
     #[test]
@@ -246,7 +247,7 @@ mod tests {
         let reduced = order.with_reduced_quantity(3);
 
         if let OrderType::<()>::Standard { quantity, .. } = reduced {
-            assert_eq!(quantity, 3);
+            assert_eq!(quantity, Quantity::new(3));
         } else {
             panic!("Expected StandardOrder");
         }
@@ -261,8 +262,8 @@ mod tests {
             ..
         } = reduced
         {
-            assert_eq!(visible_quantity, 0);
-            assert_eq!(hidden_quantity, 4); // Hidden quantity should remain unchanged
+            assert_eq!(visible_quantity, Quantity::new(0));
+            assert_eq!(hidden_quantity, Quantity::new(4)); // Hidden quantity should remain unchanged
         } else {
             panic!("Expected IcebergOrder");
         }
@@ -272,7 +273,7 @@ mod tests {
         let reduced = order.with_reduced_quantity(2);
 
         if let OrderType::<()>::PostOnly { quantity, .. } = reduced {
-            assert_eq!(quantity, 2);
+            assert_eq!(quantity, Quantity::new(2));
         } else {
             panic!("Expected PostOnly order");
         }
@@ -283,7 +284,7 @@ mod tests {
 
         match reduced {
             OrderType::<()>::TrailingStop { quantity, .. } => {
-                assert_eq!(quantity, 5);
+                assert_eq!(quantity, Quantity::new(5));
             }
             _ => panic!("Expected TrailingStop order"),
         }
@@ -294,7 +295,7 @@ mod tests {
 
         match reduced {
             OrderType::<()>::PeggedOrder { quantity, .. } => {
-                assert_eq!(quantity, 5);
+                assert_eq!(quantity, Quantity::new(5));
             }
             _ => panic!("Expected PeggedOrder"),
         }
@@ -305,7 +306,7 @@ mod tests {
 
         match reduced {
             OrderType::<()>::MarketToLimit { quantity, .. } => {
-                assert_eq!(quantity, 5);
+                assert_eq!(quantity, Quantity::new(5));
             }
             _ => panic!("Expected MarketToLimit order"),
         }
@@ -320,8 +321,8 @@ mod tests {
                 hidden_quantity,
                 ..
             } => {
-                assert_eq!(visible_quantity, 1);
-                assert_eq!(hidden_quantity, 4); // Hidden should remain unchanged
+                assert_eq!(visible_quantity, Quantity::new(1));
+                assert_eq!(hidden_quantity, Quantity::new(4)); // Hidden should remain unchanged
             }
             _ => panic!("Expected ReserveOrder"),
         }
@@ -339,8 +340,8 @@ mod tests {
             ..
         } = refreshed
         {
-            assert_eq!(visible_quantity, 2);
-            assert_eq!(hidden_quantity, 2); // 4 - 2 = 2
+            assert_eq!(visible_quantity, Quantity::new(2));
+            assert_eq!(hidden_quantity, Quantity::new(2)); // 4 - 2 = 2
             assert_eq!(used, 2);
         } else {
             panic!("Expected IcebergOrder");
@@ -356,8 +357,8 @@ mod tests {
             ..
         } = refreshed
         {
-            assert_eq!(visible_quantity, 3);
-            assert_eq!(hidden_quantity, 1); // 4 - 3 = 1
+            assert_eq!(visible_quantity, Quantity::new(3));
+            assert_eq!(hidden_quantity, Quantity::new(1)); // 4 - 3 = 1
             assert_eq!(used, 3);
         } else {
             panic!("Expected ReserveOrder");
@@ -368,7 +369,7 @@ mod tests {
         let (refreshed, used) = order.refresh_iceberg(2);
 
         if let OrderType::<()>::Standard { quantity, .. } = refreshed {
-            assert_eq!(quantity, 5); // Should remain unchanged
+            assert_eq!(quantity, Quantity::new(5)); // Should remain unchanged
             assert_eq!(used, 0);
         } else {
             panic!("Expected StandardOrder");
@@ -391,10 +392,10 @@ mod tests {
         } = order
         {
             assert_eq!(id, Id::from_u64(123));
-            assert_eq!(price, 10000u128);
-            assert_eq!(quantity, 5);
+            assert_eq!(price, Price::new(10000));
+            assert_eq!(quantity, Quantity::new(5));
             assert_eq!(side, Side::Buy);
-            assert_eq!(timestamp, 1616823000000);
+            assert_eq!(timestamp, TimestampMs::new(1616823000000));
             assert_eq!(time_in_force, TimeInForce::Gtc);
         } else {
             panic!("Expected StandardOrder");
@@ -418,11 +419,11 @@ mod tests {
         } = order
         {
             assert_eq!(id, Id::from_u64(124));
-            assert_eq!(price, 10000u128);
-            assert_eq!(visible_quantity, 1);
-            assert_eq!(hidden_quantity, 4);
+            assert_eq!(price, Price::new(10000));
+            assert_eq!(visible_quantity, Quantity::new(1));
+            assert_eq!(hidden_quantity, Quantity::new(4));
             assert_eq!(side, Side::Buy);
-            assert_eq!(timestamp, 1616823000000);
+            assert_eq!(timestamp, TimestampMs::new(1616823000000));
             assert_eq!(time_in_force, TimeInForce::Gtc);
         } else {
             panic!("Expected IcebergOrder");
@@ -447,13 +448,13 @@ mod tests {
         } = order
         {
             assert_eq!(id, Id::from_u64(126));
-            assert_eq!(price, 10000u128);
-            assert_eq!(quantity, 5);
+            assert_eq!(price, Price::new(10000));
+            assert_eq!(quantity, Quantity::new(5));
             assert_eq!(side, Side::Sell);
-            assert_eq!(timestamp, 1616823000000);
+            assert_eq!(timestamp, TimestampMs::new(1616823000000));
             assert_eq!(time_in_force, TimeInForce::Gtc);
-            assert_eq!(trail_amount, 100);
-            assert_eq!(last_reference_price, 10100u128);
+            assert_eq!(trail_amount, Quantity::new(100));
+            assert_eq!(last_reference_price, Price::new(10100));
         } else {
             panic!("Expected TrailingStop");
         }
@@ -477,10 +478,10 @@ mod tests {
         } = order
         {
             assert_eq!(id, Id::from_u64(127));
-            assert_eq!(price, 10000u128);
-            assert_eq!(quantity, 5);
+            assert_eq!(price, Price::new(10000));
+            assert_eq!(quantity, Quantity::new(5));
             assert_eq!(side, Side::Buy);
-            assert_eq!(timestamp, 1616823000000);
+            assert_eq!(timestamp, TimestampMs::new(1616823000000));
             assert_eq!(time_in_force, TimeInForce::Gtc);
             assert_eq!(reference_price_offset, -50);
             assert_eq!(reference_price_type, PegReferenceType::BestAsk);
@@ -650,11 +651,11 @@ mod tests {
         // Lines 663-664
         let order = OrderType::<()>::MarketToLimit {
             id: Id::from_u64(1),
-            price: 1000u128,
-            quantity: 10,
+            price: Price::new(1000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -664,7 +665,7 @@ mod tests {
         // Verify the quantity is not changed (market to limit orders don't support
         // reduced quantity in the current implementation)
         if let OrderType::MarketToLimit { quantity, .. } = reduced {
-            assert_eq!(quantity, 10); // Original quantity, not reduced
+            assert_eq!(quantity, Quantity::new(10)); // Original quantity, not reduced
         } else {
             panic!("Expected MarketToLimit order");
         }
@@ -675,11 +676,11 @@ mod tests {
         // Lines 720-721
         let order = OrderType::PeggedOrder {
             id: Id::from_u64(1),
-            price: 1000u128,
-            quantity: 10,
+            price: Price::new(1000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             reference_price_offset: -50,
             reference_price_type: PegReferenceType::BestAsk,
@@ -691,7 +692,7 @@ mod tests {
         // Verify the quantity is not changed (pegged orders don't support
         // reduced quantity in the current implementation)
         if let OrderType::PeggedOrder { quantity, .. } = reduced {
-            assert_eq!(quantity, 10); // Original quantity, not reduced
+            assert_eq!(quantity, Quantity::new(10)); // Original quantity, not reduced
         } else {
             panic!("Expected PeggedOrder order");
         }
@@ -702,14 +703,14 @@ mod tests {
         // Line 741
         let order = OrderType::TrailingStop {
             id: Id::from_u64(1),
-            price: 1000u128,
-            quantity: 10,
+            price: Price::new(1000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
-            trail_amount: 100,
-            last_reference_price: 1100u128,
+            trail_amount: Quantity::new(100),
+            last_reference_price: Price::new(1100),
             extra_fields: (),
         };
 
@@ -718,7 +719,7 @@ mod tests {
         // Verify the quantity is not changed (trailing stop orders don't support
         // reduced quantity in the current implementation)
         if let OrderType::TrailingStop { quantity, .. } = reduced {
-            assert_eq!(quantity, 10); // Original quantity, not reduced
+            assert_eq!(quantity, Quantity::new(10)); // Original quantity, not reduced
         } else {
             panic!("Expected TrailingStop order");
         }
@@ -729,11 +730,11 @@ mod tests {
         // Line 760
         let standard_order = OrderType::Standard {
             id: Id::from_u64(1),
-            price: 1000u128,
-            quantity: 10,
+            price: Price::new(1000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -744,7 +745,7 @@ mod tests {
         assert_eq!(used, 0);
 
         match refreshed {
-            OrderType::Standard { quantity, .. } => assert_eq!(quantity, 10), // Unchanged
+            OrderType::Standard { quantity, .. } => assert_eq!(quantity, Quantity::new(10)), // Unchanged
             _ => panic!("Expected StandardOrder"),
         }
     }
@@ -754,14 +755,14 @@ mod tests {
         // Line 809 (or nearby)
         let order = OrderType::TrailingStop {
             id: Id::from_u64(1),
-            price: 1000u128,
-            quantity: 10,
+            price: Price::new(1000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
-            trail_amount: 100,
-            last_reference_price: 1100u128,
+            trail_amount: Quantity::new(100),
+            last_reference_price: Price::new(1100),
             extra_fields: (),
         };
 
@@ -793,17 +794,18 @@ mod tests {
 mod test_order_type_display {
     use crate::orders::time_in_force::TimeInForce;
     use crate::orders::{Hash32, Id, OrderType, PegReferenceType, Side};
+    use crate::utils::{Price, Quantity, TimestampMs};
     use std::str::FromStr;
 
     #[test]
     fn test_standard_order_display() {
         let order = OrderType::Standard {
             id: Id::from_u64(123),
-            price: 10000u128,
-            quantity: 5,
+            price: Price::new(10000),
+            quantity: Quantity::new(5),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -827,8 +829,8 @@ mod test_order_type_display {
         }) = parsed
         {
             assert_eq!(id, Id::from_u64(123));
-            assert_eq!(price, 10000u128);
-            assert_eq!(quantity, 5);
+            assert_eq!(price, Price::new(10000));
+            assert_eq!(quantity, Quantity::new(5));
             assert_eq!(side, Side::Buy);
         } else {
             panic!("Parsed result is not a Standard order");
@@ -839,12 +841,12 @@ mod test_order_type_display {
     fn test_iceberg_order_display() {
         let order = OrderType::IcebergOrder {
             id: Id::from_u64(124),
-            price: 10000u128,
-            visible_quantity: 1,
-            hidden_quantity: 4,
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(1),
+            hidden_quantity: Quantity::new(4),
             side: Side::Sell,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -869,9 +871,9 @@ mod test_order_type_display {
         }) = parsed
         {
             assert_eq!(id, Id::from_u64(124));
-            assert_eq!(price, 10000u128);
-            assert_eq!(visible_quantity, 1);
-            assert_eq!(hidden_quantity, 4);
+            assert_eq!(price, Price::new(10000));
+            assert_eq!(visible_quantity, Quantity::new(1));
+            assert_eq!(hidden_quantity, Quantity::new(4));
             assert_eq!(side, Side::Sell);
         } else {
             panic!("Parsed result is not an IcebergOrder");
@@ -882,11 +884,11 @@ mod test_order_type_display {
     fn test_post_only_order_display() {
         let order = OrderType::PostOnly {
             id: Id::from_u64(125),
-            price: 10000u128,
-            quantity: 5,
+            price: Price::new(10000),
+            quantity: Quantity::new(5),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -916,14 +918,14 @@ mod test_order_type_display {
     fn test_trailing_stop_order_display() {
         let order = OrderType::TrailingStop {
             id: Id::from_u64(126),
-            price: 10000u128,
-            quantity: 5,
+            price: Price::new(10000),
+            quantity: Quantity::new(5),
             side: Side::Sell,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
-            trail_amount: 100,
-            last_reference_price: 10100u128,
+            trail_amount: Quantity::new(100),
+            last_reference_price: Price::new(10100),
             extra_fields: (),
         };
 
@@ -949,11 +951,11 @@ mod test_order_type_display {
     fn test_pegged_order_display() {
         let order = OrderType::PeggedOrder {
             id: Id::from_u64(127),
-            price: 10000u128,
-            quantity: 5,
+            price: Price::new(10000),
+            quantity: Quantity::new(5),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             reference_price_offset: -50,
             reference_price_type: PegReferenceType::BestAsk,
@@ -982,11 +984,11 @@ mod test_order_type_display {
     fn test_market_to_limit_order_display() {
         let order = OrderType::MarketToLimit {
             id: Id::from_u64(128),
-            price: 10000u128,
-            quantity: 5,
+            price: Price::new(10000),
+            quantity: Quantity::new(5),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -1011,15 +1013,15 @@ mod test_order_type_display {
     fn test_reserve_order_display() {
         let order = OrderType::ReserveOrder {
             id: Id::from_u64(129),
-            price: 10000u128,
-            visible_quantity: 1,
-            hidden_quantity: 4,
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(1),
+            hidden_quantity: Quantity::new(4),
             side: Side::Sell,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
-            replenish_threshold: 0,
-            replenish_amount: Some(1),
+            replenish_threshold: Quantity::new(0),
+            replenish_amount: Some(Quantity::new(1)),
             auto_replenish: false,
             extra_fields: (),
         };
@@ -1046,6 +1048,7 @@ mod test_order_type_display {
 #[cfg(test)]
 mod from_str_specific_tests {
     use crate::orders::{Hash32, Id, OrderType, PegReferenceType, Side, TimeInForce};
+    use crate::utils::{Price, Quantity, TimestampMs};
     use std::str::FromStr;
 
     #[test]
@@ -1069,14 +1072,14 @@ mod from_str_specific_tests {
                 ..
             } => {
                 assert_eq!(id, Id::from_u64(129));
-                assert_eq!(price, 10000);
-                assert_eq!(visible_quantity, 1);
-                assert_eq!(hidden_quantity, 4);
+                assert_eq!(price, Price::new(10000));
+                assert_eq!(visible_quantity, Quantity::new(1));
+                assert_eq!(hidden_quantity, Quantity::new(4));
                 assert_eq!(side, Side::Sell);
-                assert_eq!(timestamp, 1616823000000);
+                assert_eq!(timestamp, TimestampMs::new(1616823000000));
                 assert_eq!(time_in_force, TimeInForce::Gtc);
-                assert_eq!(replenish_threshold, 0);
-                assert_eq!(replenish_amount, Some(1));
+                assert_eq!(replenish_threshold, Quantity::new(0));
+                assert_eq!(replenish_amount, Some(Quantity::new(1)));
                 assert!(!auto_replenish);
             }
             _ => panic!("Expected ReserveOrder"),
@@ -1094,7 +1097,7 @@ mod from_str_specific_tests {
                 ..
             } => {
                 assert_eq!(replenish_amount, None);
-                assert_eq!(replenish_threshold, 10);
+                assert_eq!(replenish_threshold, Quantity::new(10));
                 assert!(auto_replenish);
             }
             _ => panic!("Expected ReserveOrder"),
@@ -1113,8 +1116,8 @@ mod from_str_specific_tests {
                 ..
             } => {
                 assert_eq!(time_in_force, TimeInForce::Gtd(1617000000000));
-                assert_eq!(replenish_threshold, 5);
-                assert_eq!(replenish_amount, Some(2));
+                assert_eq!(replenish_threshold, Quantity::new(5));
+                assert_eq!(replenish_amount, Some(Quantity::new(2)));
                 assert!(auto_replenish);
             }
             _ => panic!("Expected ReserveOrder"),
@@ -1138,10 +1141,10 @@ mod from_str_specific_tests {
                 ..
             } => {
                 assert_eq!(id, Id::from_u64(128));
-                assert_eq!(price, 10000);
-                assert_eq!(quantity, 5);
+                assert_eq!(price, Price::new(10000));
+                assert_eq!(quantity, Quantity::new(5));
                 assert_eq!(side, Side::Buy);
-                assert_eq!(timestamp, 1616823000000);
+                assert_eq!(timestamp, TimestampMs::new(1616823000000));
                 assert_eq!(time_in_force, TimeInForce::Gtc);
             }
             _ => panic!("Expected MarketToLimit"),
@@ -1189,10 +1192,10 @@ mod from_str_specific_tests {
                 ..
             } => {
                 assert_eq!(id, Id::from_u64(127));
-                assert_eq!(price, 10000);
-                assert_eq!(quantity, 5);
+                assert_eq!(price, Price::new(10000));
+                assert_eq!(quantity, Quantity::new(5));
                 assert_eq!(side, Side::Buy);
-                assert_eq!(timestamp, 1616823000000);
+                assert_eq!(timestamp, TimestampMs::new(1616823000000));
                 assert_eq!(time_in_force, TimeInForce::Gtc);
                 assert_eq!(reference_price_offset, -50);
                 assert_eq!(reference_price_type, PegReferenceType::BestAsk);
@@ -1321,9 +1324,9 @@ mod from_str_specific_tests {
                 ..
             } => {
                 assert_eq!(id, Id::from_u64(u64::MAX));
-                assert_eq!(price, u64::MAX.into());
-                assert_eq!(quantity, u64::MAX);
-                assert_eq!(timestamp, u64::MAX);
+                assert_eq!(price, Price::new(u64::MAX as u128));
+                assert_eq!(quantity, Quantity::new(u64::MAX));
+                assert_eq!(timestamp, TimestampMs::new(u64::MAX));
                 assert_eq!(reference_price_offset, i64::MAX);
             }
             _ => panic!("Expected PeggedOrder"),
@@ -1353,35 +1356,35 @@ mod from_str_specific_tests {
         let orders = vec![
             OrderType::ReserveOrder {
                 id: Id::from_u64(129),
-                price: 10000u128,
-                visible_quantity: 1,
-                hidden_quantity: 4,
+                price: Price::new(10000),
+                visible_quantity: Quantity::new(1),
+                hidden_quantity: Quantity::new(4),
                 side: Side::Sell,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000000,
+                timestamp: TimestampMs::new(1616823000000),
                 time_in_force: TimeInForce::Gtc,
-                replenish_threshold: 0,
-                replenish_amount: Some(1),
+                replenish_threshold: Quantity::new(0),
+                replenish_amount: Some(Quantity::new(1)),
                 auto_replenish: false,
                 extra_fields: (),
             },
             OrderType::MarketToLimit {
                 id: Id::from_u64(128),
-                price: 10000u128,
-                quantity: 5,
+                price: Price::new(10000),
+                quantity: Quantity::new(5),
                 side: Side::Buy,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000000,
+                timestamp: TimestampMs::new(1616823000000),
                 time_in_force: TimeInForce::Ioc,
                 extra_fields: (),
             },
             OrderType::PeggedOrder {
                 id: Id::from_u64(127),
-                price: 10000u128,
-                quantity: 5,
+                price: Price::new(10000),
+                quantity: Quantity::new(5),
                 side: Side::Buy,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000000,
+                timestamp: TimestampMs::new(1616823000000),
                 time_in_force: TimeInForce::Gtc,
                 reference_price_offset: -50,
                 reference_price_type: PegReferenceType::MidPrice,

--- a/src/orders/tests/update.rs
+++ b/src/orders/tests/update.rs
@@ -3,6 +3,7 @@ mod tests_order_update {
     use crate::errors::PriceLevelError;
     use crate::orders::update::OrderUpdate;
     use crate::orders::{Id, Side};
+    use crate::utils::{Price, Quantity};
     use std::str::FromStr;
 
     #[test]
@@ -16,7 +17,7 @@ mod tests_order_update {
                 new_price,
             } => {
                 assert_eq!(order_id, Id::from_u64(123));
-                assert_eq!(new_price, 1000);
+                assert_eq!(new_price, Price::new(1000));
             }
             _ => panic!("Expected UpdatePrice variant"),
         }
@@ -32,7 +33,7 @@ mod tests_order_update {
                 new_quantity,
             } => {
                 assert_eq!(order_id, Id::from_u64(456));
-                assert_eq!(new_quantity, 50);
+                assert_eq!(new_quantity, Quantity::new(50));
             }
             _ => panic!("Expected UpdateQuantity variant"),
         }
@@ -49,8 +50,8 @@ mod tests_order_update {
                 new_quantity,
             } => {
                 assert_eq!(order_id, Id::from_u64(789));
-                assert_eq!(new_price, 2000);
-                assert_eq!(new_quantity, 30);
+                assert_eq!(new_price, Price::new(2000));
+                assert_eq!(new_quantity, Quantity::new(30));
             }
             _ => panic!("Expected UpdatePriceAndQuantity variant"),
         }
@@ -83,8 +84,8 @@ mod tests_order_update {
                 side,
             } => {
                 assert_eq!(order_id, Id::from_u64(202));
-                assert_eq!(price, 3000);
-                assert_eq!(quantity, 40);
+                assert_eq!(price, Price::new(3000));
+                assert_eq!(quantity, Quantity::new(40));
                 assert_eq!(side, Side::Buy);
             }
             _ => panic!("Expected Replace variant"),
@@ -104,8 +105,8 @@ mod tests_order_update {
                 side,
             } => {
                 assert_eq!(order_id, Id::from_u64(303));
-                assert_eq!(price, 4000);
-                assert_eq!(quantity, 60);
+                assert_eq!(price, Price::new(4000));
+                assert_eq!(quantity, Quantity::new(60));
                 assert_eq!(side, Side::Sell);
             }
             _ => panic!("Expected Replace variant"),
@@ -171,7 +172,7 @@ mod tests_order_update {
     fn test_display_update_price() {
         let update = OrderUpdate::UpdatePrice {
             order_id: Id::from_u64(123),
-            new_price: 1000,
+            new_price: Price::new(1000),
         };
 
         assert_eq!(
@@ -184,7 +185,7 @@ mod tests_order_update {
     fn test_display_update_quantity() {
         let update = OrderUpdate::UpdateQuantity {
             order_id: Id::from_u64(456),
-            new_quantity: 50,
+            new_quantity: Quantity::new(50),
         };
 
         assert_eq!(
@@ -197,8 +198,8 @@ mod tests_order_update {
     fn test_display_update_price_and_quantity() {
         let update = OrderUpdate::UpdatePriceAndQuantity {
             order_id: Id::from_u64(789),
-            new_price: 2000,
-            new_quantity: 30,
+            new_price: Price::new(2000),
+            new_quantity: Quantity::new(30),
         };
 
         assert_eq!(
@@ -223,8 +224,8 @@ mod tests_order_update {
     fn test_display_replace() {
         let update = OrderUpdate::Replace {
             order_id: Id::from_u64(202),
-            price: 3000,
-            quantity: 40,
+            price: Price::new(3000),
+            quantity: Quantity::new(40),
             side: Side::Buy,
         };
 
@@ -240,30 +241,30 @@ mod tests_order_update {
         let updates = vec![
             OrderUpdate::UpdatePrice {
                 order_id: Id::from_u64(123),
-                new_price: 1000,
+                new_price: Price::new(1000),
             },
             OrderUpdate::UpdateQuantity {
                 order_id: Id::from_u64(456),
-                new_quantity: 50,
+                new_quantity: Quantity::new(50),
             },
             OrderUpdate::UpdatePriceAndQuantity {
                 order_id: Id::from_u64(789),
-                new_price: 2000,
-                new_quantity: 30,
+                new_price: Price::new(2000),
+                new_quantity: Quantity::new(30),
             },
             OrderUpdate::Cancel {
                 order_id: Id::from_u64(101),
             },
             OrderUpdate::Replace {
                 order_id: Id::from_u64(202),
-                price: 3000,
-                quantity: 40,
+                price: Price::new(3000),
+                quantity: Quantity::new(40),
                 side: Side::Buy,
             },
             OrderUpdate::Replace {
                 order_id: Id::from_u64(303),
-                price: 4000,
-                quantity: 60,
+                price: Price::new(4000),
+                quantity: Quantity::new(60),
                 side: Side::Sell,
             },
         ];
@@ -283,7 +284,7 @@ mod tests_order_update {
         // Test display of UpdatePrice
         let update = OrderUpdate::UpdatePrice {
             order_id: Id::from_u64(123),
-            new_price: 10500,
+            new_price: Price::new(10500),
         };
         let display_string = update.to_string();
         assert_eq!(
@@ -294,7 +295,7 @@ mod tests_order_update {
         // Test display of UpdateQuantity
         let update = OrderUpdate::UpdateQuantity {
             order_id: Id::from_u64(456),
-            new_quantity: 75,
+            new_quantity: Quantity::new(75),
         };
         let display_string = update.to_string();
         assert_eq!(
@@ -305,8 +306,8 @@ mod tests_order_update {
         // Test display of UpdatePriceAndQuantity
         let update = OrderUpdate::UpdatePriceAndQuantity {
             order_id: Id::from_u64(789),
-            new_price: 11000,
-            new_quantity: 50,
+            new_price: Price::new(11000),
+            new_quantity: Quantity::new(50),
         };
         let display_string = update.to_string();
         assert_eq!(
@@ -317,8 +318,8 @@ mod tests_order_update {
         // Test display of Replace
         let update = OrderUpdate::Replace {
             order_id: Id::from_u64(202),
-            price: 12000,
-            quantity: 60,
+            price: Price::new(12000),
+            quantity: Quantity::new(60),
             side: Side::Sell,
         };
         let display_string = update.to_string();
@@ -342,8 +343,8 @@ mod tests_order_update {
                 side,
             } => {
                 assert_eq!(order_id, Id::from_u64(202));
-                assert_eq!(price, 12000);
-                assert_eq!(quantity, 60);
+                assert_eq!(price, Price::new(12000));
+                assert_eq!(quantity, Quantity::new(60));
                 assert_eq!(side, Side::Buy);
             }
             _ => panic!("Expected Replace variant"),
@@ -361,8 +362,8 @@ mod tests_order_update {
                 side,
             } => {
                 assert_eq!(order_id, Id::from_u64(202));
-                assert_eq!(price, 12000);
-                assert_eq!(quantity, 60);
+                assert_eq!(price, Price::new(12000));
+                assert_eq!(quantity, Quantity::new(60));
                 assert_eq!(side, Side::Sell);
             }
             _ => panic!("Expected Replace variant"),

--- a/src/orders/update.rs
+++ b/src/orders/update.rs
@@ -1,5 +1,6 @@
 use crate::errors::PriceLevelError;
 use crate::orders::{Id, Side};
+use crate::utils::{Price, Quantity};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -11,7 +12,7 @@ pub enum OrderUpdate {
         /// ID of the order to update
         order_id: Id,
         /// New price for the order
-        new_price: u128,
+        new_price: Price,
     },
 
     /// Update the quantity of an order
@@ -19,7 +20,7 @@ pub enum OrderUpdate {
         /// ID of the order to update
         order_id: Id,
         /// New quantity for the order
-        new_quantity: u64,
+        new_quantity: Quantity,
     },
 
     /// Update both price and quantity of an order
@@ -27,9 +28,9 @@ pub enum OrderUpdate {
         /// ID of the order to update
         order_id: Id,
         /// New price for the order
-        new_price: u128,
+        new_price: Price,
         /// New quantity for the order
-        new_quantity: u64,
+        new_quantity: Quantity,
     },
 
     /// Cancel an order
@@ -43,9 +44,9 @@ pub enum OrderUpdate {
         /// ID of the order to replace
         order_id: Id,
         /// New price for the replacement order
-        price: u128,
+        price: Price,
         /// New quantity for the replacement order
-        quantity: u64,
+        quantity: Quantity,
         /// Side of the market (unchanged)
         side: Side,
     },
@@ -78,22 +79,18 @@ impl FromStr for OrderUpdate {
             }
         };
 
-        let parse_u64 = |field: &str, value: &str| -> Result<u64, PriceLevelError> {
-            value
-                .parse::<u64>()
-                .map_err(|_| PriceLevelError::InvalidFieldValue {
-                    field: field.to_string(),
-                    value: value.to_string(),
-                })
+        let parse_price = |field: &str, value: &str| -> Result<Price, PriceLevelError> {
+            Price::from_str(value).map_err(|_| PriceLevelError::InvalidFieldValue {
+                field: field.to_string(),
+                value: value.to_string(),
+            })
         };
 
-        let parse_u128 = |field: &str, value: &str| -> Result<u128, PriceLevelError> {
-            value
-                .parse::<u128>()
-                .map_err(|_| PriceLevelError::InvalidFieldValue {
-                    field: field.to_string(),
-                    value: value.to_string(),
-                })
+        let parse_quantity = |field: &str, value: &str| -> Result<Quantity, PriceLevelError> {
+            Quantity::from_str(value).map_err(|_| PriceLevelError::InvalidFieldValue {
+                field: field.to_string(),
+                value: value.to_string(),
+            })
         };
 
         // Parse order_id field which is common to all update types
@@ -107,7 +104,7 @@ impl FromStr for OrderUpdate {
         match update_type {
             "UpdatePrice" => {
                 let new_price_str = get_field("new_price")?;
-                let new_price = parse_u128("new_price", new_price_str)?;
+                let new_price = parse_price("new_price", new_price_str)?;
 
                 Ok(OrderUpdate::UpdatePrice {
                     order_id,
@@ -116,7 +113,7 @@ impl FromStr for OrderUpdate {
             }
             "UpdateQuantity" => {
                 let new_quantity_str = get_field("new_quantity")?;
-                let new_quantity = parse_u64("new_quantity", new_quantity_str)?;
+                let new_quantity = parse_quantity("new_quantity", new_quantity_str)?;
 
                 Ok(OrderUpdate::UpdateQuantity {
                     order_id,
@@ -125,10 +122,10 @@ impl FromStr for OrderUpdate {
             }
             "UpdatePriceAndQuantity" => {
                 let new_price_str = get_field("new_price")?;
-                let new_price = parse_u128("new_price", new_price_str)?;
+                let new_price = parse_price("new_price", new_price_str)?;
 
                 let new_quantity_str = get_field("new_quantity")?;
-                let new_quantity = parse_u64("new_quantity", new_quantity_str)?;
+                let new_quantity = parse_quantity("new_quantity", new_quantity_str)?;
 
                 Ok(OrderUpdate::UpdatePriceAndQuantity {
                     order_id,
@@ -139,10 +136,10 @@ impl FromStr for OrderUpdate {
             "Cancel" => Ok(OrderUpdate::Cancel { order_id }),
             "Replace" => {
                 let price_str = get_field("price")?;
-                let price = parse_u128("price", price_str)?;
+                let price = parse_price("price", price_str)?;
 
                 let quantity_str = get_field("quantity")?;
-                let quantity = parse_u64("quantity", quantity_str)?;
+                let quantity = parse_quantity("quantity", quantity_str)?;
 
                 let side_str = get_field("side")?;
                 let side =

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,4 +12,4 @@ pub use crate::orders::DEFAULT_RESERVE_REPLENISH_AMOUNT;
 pub use crate::orders::PegReferenceType;
 pub use crate::orders::{Hash32, Id, OrderType, OrderUpdate, Side, TimeInForce};
 pub use crate::price_level::{OrderQueue, PriceLevel, PriceLevelData, PriceLevelSnapshot};
-pub use crate::utils::{UuidGenerator, setup_logger};
+pub use crate::utils::{Price, Quantity, TimestampMs, UuidGenerator, setup_logger};

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -6,6 +6,7 @@ use crate::execution::{MatchResult, Trade};
 use crate::orders::{Id, OrderType, OrderUpdate};
 use crate::price_level::order_queue::OrderQueue;
 use crate::price_level::{PriceLevelSnapshot, PriceLevelSnapshotPackage, PriceLevelStatistics};
+use crate::utils::{Price, Quantity};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::FromStr;
@@ -183,8 +184,8 @@ impl PriceLevel {
                         trade_id,
                         taker_order_id,
                         order_arc.id(),
-                        self.price,
-                        consumed,
+                        Price::new(self.price),
+                        Quantity::new(consumed),
                         order_arc.side().opposite(),
                     );
 
@@ -199,8 +200,11 @@ impl PriceLevel {
                 remaining = new_remaining;
 
                 // update statistics
-                self.stats
-                    .record_execution(consumed, order_arc.price(), order_arc.timestamp());
+                self.stats.record_execution(
+                    consumed,
+                    order_arc.price().as_u128(),
+                    order_arc.timestamp(),
+                );
 
                 if let Some(updated) = updated_order {
                     if hidden_reduced > 0 {
@@ -217,17 +221,17 @@ impl PriceLevel {
                         OrderType::IcebergOrder {
                             hidden_quantity, ..
                         } => {
-                            if *hidden_quantity > 0 && hidden_reduced == 0 {
+                            if hidden_quantity.as_u64() > 0 && hidden_reduced == 0 {
                                 self.hidden_quantity
-                                    .fetch_sub(*hidden_quantity, Ordering::AcqRel);
+                                    .fetch_sub(hidden_quantity.as_u64(), Ordering::AcqRel);
                             }
                         }
                         OrderType::ReserveOrder {
                             hidden_quantity, ..
                         } => {
-                            if *hidden_quantity > 0 && hidden_reduced == 0 {
+                            if hidden_quantity.as_u64() > 0 && hidden_reduced == 0 {
                                 self.hidden_quantity
-                                    .fetch_sub(*hidden_quantity, Ordering::AcqRel);
+                                    .fetch_sub(hidden_quantity.as_u64(), Ordering::AcqRel);
                             }
                         }
                         _ => {}
@@ -283,7 +287,7 @@ impl PriceLevel {
             } => {
                 // If price changes, this order needs to be moved to a different price level
                 // So we remove it from this level and return it for re-insertion elsewhere
-                if new_price != self.price {
+                if new_price != Price::new(self.price) {
                     let order = self.orders.remove(order_id);
 
                     if let Some(ref order_arc) = order {
@@ -327,7 +331,7 @@ impl PriceLevel {
                     };
 
                     // Create updated order with new quantity
-                    let new_order = old_order.with_reduced_quantity(new_quantity);
+                    let new_order = old_order.with_reduced_quantity(new_quantity.as_u64());
 
                     // Calculate the new quantities
                     let new_visible = new_order.visible_quantity();
@@ -370,7 +374,7 @@ impl PriceLevel {
                 new_quantity,
             } => {
                 // If price changes, remove the order and let the order book handle re-insertion
-                if new_price != self.price {
+                if new_price != Price::new(self.price) {
                     let order = self.orders.remove(order_id);
 
                     if let Some(ref order_arc) = order {
@@ -424,7 +428,7 @@ impl PriceLevel {
                 side: _,
             } => {
                 // For replacement, check if the price is changing
-                if price != self.price {
+                if price != Price::new(self.price) {
                     // If price is different, remove the order and let order book handle re-insertion
                     let order = self.orders.remove(order_id);
 

--- a/src/price_level/tests/entry.rs
+++ b/src/price_level/tests/entry.rs
@@ -2,6 +2,7 @@
 mod tests {
     use crate::price_level::entry::OrderBookEntry;
     use crate::price_level::level::PriceLevel;
+    use crate::utils::{Price, Quantity, TimestampMs};
     use crate::{Hash32, Id, OrderType, Side, TimeInForce};
     use std::str::FromStr;
     use std::sync::Arc;
@@ -125,11 +126,11 @@ mod tests {
         // Add an order to make the test more meaningful
         let order = OrderType::Standard {
             id: Id::from_u64(1),
-            price: 1000u128,
-            quantity: 10,
+            price: Price::new(1000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -194,6 +195,7 @@ mod tests_order_book_entry {
     use crate::orders::Hash32;
     use crate::price_level::entry::OrderBookEntry;
     use crate::price_level::level::PriceLevel;
+    use crate::utils::{Price, Quantity, TimestampMs};
     use std::cmp::Ordering;
     use std::sync::Arc;
 
@@ -216,11 +218,11 @@ mod tests_order_book_entry {
         // Add some orders and check again
         let order_type = crate::orders::OrderType::Standard {
             id: crate::orders::Id::from_u64(1),
-            price: 1000u128,
-            quantity: 10,
+            price: Price::new(1000),
+            quantity: Quantity::new(10),
             side: crate::orders::Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: crate::orders::TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -231,11 +233,11 @@ mod tests_order_book_entry {
         // Add another order
         let order_type2 = crate::orders::OrderType::Standard {
             id: crate::orders::Id::from_u64(2),
-            price: 1000u128,
-            quantity: 20,
+            price: Price::new(1000),
+            quantity: Quantity::new(20),
             side: crate::orders::Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000001,
+            timestamp: TimestampMs::new(1616823000001),
             time_in_force: crate::orders::TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -363,11 +365,11 @@ mod tests_order_book_entry {
         // Add an order with visible quantity
         let standard_order = crate::orders::OrderType::Standard {
             id: crate::orders::Id::from_u64(1),
-            price: 1000u128,
-            quantity: 10,
+            price: Price::new(1000),
+            quantity: Quantity::new(10),
             side: crate::orders::Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: crate::orders::TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -380,12 +382,12 @@ mod tests_order_book_entry {
         // Add an iceberg order with hidden quantity
         let iceberg_order = crate::orders::OrderType::IcebergOrder {
             id: crate::orders::Id::from_u64(2),
-            price: 1000u128,
-            visible_quantity: 5,
-            hidden_quantity: 15,
+            price: Price::new(1000),
+            visible_quantity: Quantity::new(5),
+            hidden_quantity: Quantity::new(15),
             side: crate::orders::Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000001,
+            timestamp: TimestampMs::new(1616823000001),
             time_in_force: crate::orders::TimeInForce::Gtc,
             extra_fields: (),
         };

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -4,6 +4,7 @@ mod tests {
     use crate::orders::{Hash32, Id, OrderType, OrderUpdate, PegReferenceType, Side, TimeInForce};
     use crate::price_level::level::{PriceLevel, PriceLevelData};
     use crate::price_level::snapshot::SNAPSHOT_FORMAT_VERSION;
+    use crate::utils::{Price, Quantity, TimestampMs};
     use crate::{DEFAULT_RESERVE_REPLENISH_AMOUNT, UuidGenerator};
     use std::str::FromStr;
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -19,11 +20,11 @@ mod tests {
         let timestamp = TIMESTAMP_COUNTER.fetch_add(1, Ordering::SeqCst);
         OrderType::Standard {
             id: order_id,
-            price,
-            quantity,
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp,
+            timestamp: TimestampMs::new(timestamp),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         }
@@ -156,12 +157,12 @@ mod tests {
         let timestamp = TIMESTAMP_COUNTER.fetch_add(1, Ordering::SeqCst);
         OrderType::IcebergOrder {
             id: Id::from_u64(id),
-            price,
-            visible_quantity: visible,
-            hidden_quantity: hidden,
+            price: Price::new(price),
+            visible_quantity: Quantity::new(visible),
+            hidden_quantity: Quantity::new(hidden),
             side: Side::Sell,
             user_id: Hash32::zero(),
-            timestamp,
+            timestamp: TimestampMs::new(timestamp),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         }
@@ -171,11 +172,11 @@ mod tests {
         let timestamp = TIMESTAMP_COUNTER.fetch_add(1, Ordering::SeqCst);
         OrderType::PostOnly {
             id: Id::from_u64(id),
-            price,
-            quantity,
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp,
+            timestamp: TimestampMs::new(timestamp),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         }
@@ -185,14 +186,14 @@ mod tests {
         let timestamp = TIMESTAMP_COUNTER.fetch_add(1, Ordering::SeqCst);
         OrderType::TrailingStop {
             id: Id::from_u64(id),
-            price,
-            quantity,
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
             side: Side::Sell,
             user_id: Hash32::zero(),
-            timestamp,
+            timestamp: TimestampMs::new(timestamp),
             time_in_force: TimeInForce::Gtc,
-            trail_amount: 100,
-            last_reference_price: price + 100u128,
+            trail_amount: Quantity::new(100),
+            last_reference_price: Price::new(price + 100u128),
             extra_fields: (),
         }
     }
@@ -201,11 +202,11 @@ mod tests {
         let timestamp = TIMESTAMP_COUNTER.fetch_add(1, Ordering::SeqCst);
         OrderType::PeggedOrder {
             id: Id::from_u64(id),
-            price,
-            quantity,
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp,
+            timestamp: TimestampMs::new(timestamp),
             time_in_force: TimeInForce::Gtc,
             reference_price_offset: -50,
             reference_price_type: PegReferenceType::BestAsk,
@@ -217,11 +218,11 @@ mod tests {
         let timestamp = TIMESTAMP_COUNTER.fetch_add(1, Ordering::SeqCst);
         OrderType::MarketToLimit {
             id: Id::from_u64(id),
-            price,
-            quantity,
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp,
+            timestamp: TimestampMs::new(timestamp),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         }
@@ -239,15 +240,15 @@ mod tests {
         let timestamp = TIMESTAMP_COUNTER.fetch_add(1, Ordering::SeqCst);
         OrderType::ReserveOrder {
             id: Id::from_u64(id),
-            price,
-            visible_quantity: visible,
-            hidden_quantity: hidden,
+            price: Price::new(price),
+            visible_quantity: Quantity::new(visible),
+            hidden_quantity: Quantity::new(hidden),
             side: Side::Sell,
             user_id: Hash32::zero(),
-            timestamp,
+            timestamp: TimestampMs::new(timestamp),
             time_in_force: TimeInForce::Gtc,
-            replenish_threshold: threshold,
-            replenish_amount,
+            replenish_threshold: Quantity::new(threshold),
+            replenish_amount: replenish_amount.map(Quantity::new),
             auto_replenish,
             extra_fields: (),
         }
@@ -257,11 +258,11 @@ mod tests {
         let timestamp = TIMESTAMP_COUNTER.fetch_add(1, Ordering::SeqCst);
         OrderType::Standard {
             id: Id::from_u64(id),
-            price,
-            quantity,
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp,
+            timestamp: TimestampMs::new(timestamp),
             time_in_force: TimeInForce::Fok,
             extra_fields: (),
         }
@@ -271,11 +272,11 @@ mod tests {
         let timestamp = TIMESTAMP_COUNTER.fetch_add(1, Ordering::SeqCst);
         OrderType::Standard {
             id: Id::from_u64(id),
-            price,
-            quantity,
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp,
+            timestamp: TimestampMs::new(timestamp),
             time_in_force: TimeInForce::Ioc,
             extra_fields: (),
         }
@@ -290,11 +291,11 @@ mod tests {
         let timestamp = TIMESTAMP_COUNTER.fetch_add(1, Ordering::SeqCst);
         OrderType::Standard {
             id: Id::from_u64(id),
-            price,
-            quantity,
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp,
+            timestamp: TimestampMs::new(timestamp),
             time_in_force: TimeInForce::Gtd(expiry),
             extra_fields: (),
         }
@@ -331,7 +332,7 @@ mod tests {
 
         // Verify the returned Arc contains the expected order
         assert_eq!(order_arc.id(), Id::from_u64(1));
-        assert_eq!(order_arc.price(), 10000);
+        assert_eq!(order_arc.price(), Price::new(10000));
         assert_eq!(order_arc.visible_quantity(), 100);
 
         // Verify stats
@@ -454,8 +455,8 @@ mod tests {
         let transaction = &match_result.trades.as_vec()[0];
         assert_eq!(transaction.taker_order_id, taker_id);
         assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, 10000);
-        assert_eq!(transaction.quantity, 100);
+        assert_eq!(transaction.price, Price::new(10000));
+        assert_eq!(transaction.quantity, Quantity::new(100));
         assert_eq!(transaction.taker_side, Side::Sell); // Taker is a market order, so it's a sell side opposite of maker
 
         assert_eq!(match_result.filled_order_ids.len(), 1);
@@ -491,8 +492,8 @@ mod tests {
         let transaction = &match_result.trades.as_vec()[0];
         assert_eq!(transaction.taker_order_id, taker_id);
         assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, 10000);
-        assert_eq!(transaction.quantity, 60);
+        assert_eq!(transaction.price, Price::new(10000));
+        assert_eq!(transaction.quantity, Quantity::new(60));
         assert_eq!(transaction.taker_side, Side::Sell);
 
         // Verificar que no hay órdenes completadas
@@ -525,8 +526,8 @@ mod tests {
         let transaction = &match_result.trades.as_vec()[0];
         assert_eq!(transaction.taker_order_id, taker_id);
         assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, 10000);
-        assert_eq!(transaction.quantity, 100);
+        assert_eq!(transaction.price, Price::new(10000));
+        assert_eq!(transaction.quantity, Quantity::new(100));
 
         assert_eq!(match_result.filled_order_ids.len(), 1);
         assert_eq!(match_result.filled_order_ids[0], Id::from_u64(1));
@@ -564,8 +565,8 @@ mod tests {
         let transaction = &match_result.trades.as_vec()[0];
         assert_eq!(transaction.taker_order_id, taker_id);
         assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, 10000);
-        assert_eq!(transaction.quantity, 50);
+        assert_eq!(transaction.price, Price::new(10000));
+        assert_eq!(transaction.quantity, Quantity::new(50));
         assert_eq!(transaction.taker_side, Side::Buy);
         assert_eq!(match_result.filled_order_ids.len(), 0);
 
@@ -581,8 +582,8 @@ mod tests {
 
         assert_eq!(transaction.taker_order_id, taker_id);
         assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, 10000);
-        assert_eq!(transaction.quantity, 50);
+        assert_eq!(transaction.price, Price::new(10000));
+        assert_eq!(transaction.quantity, Quantity::new(50));
         assert_eq!(transaction.taker_side, Side::Buy);
         assert_eq!(match_result.filled_order_ids.len(), 0);
 
@@ -624,8 +625,8 @@ mod tests {
         let transaction = &match_result.trades.as_vec()[0];
         assert_eq!(transaction.taker_order_id, taker_id);
         assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, 10000);
-        assert_eq!(transaction.quantity, 50);
+        assert_eq!(transaction.price, Price::new(10000));
+        assert_eq!(transaction.quantity, Quantity::new(50));
         assert_eq!(transaction.taker_side, Side::Buy);
         assert_eq!(match_result.filled_order_ids.len(), 0);
 
@@ -641,8 +642,8 @@ mod tests {
 
         assert_eq!(transaction.taker_order_id, taker_id);
         assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, 10000);
-        assert_eq!(transaction.quantity, 50);
+        assert_eq!(transaction.price, Price::new(10000));
+        assert_eq!(transaction.quantity, Quantity::new(50));
         assert_eq!(transaction.taker_side, Side::Buy);
         assert_eq!(match_result.filled_order_ids.len(), 0);
 
@@ -933,8 +934,8 @@ mod tests {
         let transaction = &match_result.trades.as_vec()[0];
         assert_eq!(transaction.taker_order_id, taker_id);
         assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, 10000);
-        assert_eq!(transaction.quantity, 80);
+        assert_eq!(transaction.price, Price::new(10000));
+        assert_eq!(transaction.quantity, Quantity::new(80));
         assert_eq!(transaction.taker_side, Side::Buy);
         assert_eq!(match_result.filled_order_ids.len(), 0);
 
@@ -951,8 +952,8 @@ mod tests {
         let transaction = &match_result.trades.as_vec()[0];
         assert_eq!(transaction.taker_order_id, taker_id);
         assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, 10000);
-        assert_eq!(transaction.quantity, 10);
+        assert_eq!(transaction.price, Price::new(10000));
+        assert_eq!(transaction.quantity, Quantity::new(10));
         assert_eq!(transaction.taker_side, Side::Buy);
         assert_eq!(match_result.filled_order_ids.len(), 0);
 
@@ -974,15 +975,15 @@ mod tests {
         let transaction1 = &match_result.trades.as_vec()[0];
         assert_eq!(transaction1.taker_order_id, taker_id);
         assert_eq!(transaction1.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction1.price, 10000);
-        assert_eq!(transaction1.quantity, 90); // First consumes all visible
+        assert_eq!(transaction1.price, Price::new(10000));
+        assert_eq!(transaction1.quantity, Quantity::new(90)); // First consumes all visible
         assert_eq!(transaction1.taker_side, Side::Buy);
 
         let transaction2 = &match_result.trades.as_vec()[1];
         assert_eq!(transaction2.taker_order_id, taker_id);
         assert_eq!(transaction2.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction2.price, 10000);
-        assert_eq!(transaction2.quantity, 20); // Then consumes all hidden
+        assert_eq!(transaction2.price, Price::new(10000));
+        assert_eq!(transaction2.quantity, Quantity::new(20)); // Then consumes all hidden
         assert_eq!(transaction2.taker_side, Side::Buy);
     }
 
@@ -1140,17 +1141,17 @@ mod tests {
         let transaction1 = &match_result.trades.as_vec()[0];
         assert_eq!(transaction1.taker_order_id, taker_id);
         assert_eq!(transaction1.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction1.quantity, 50);
+        assert_eq!(transaction1.quantity, Quantity::new(50));
 
         let transaction2 = &match_result.trades.as_vec()[1];
         assert_eq!(transaction2.taker_order_id, taker_id);
         assert_eq!(transaction2.maker_order_id, Id::from_u64(2));
-        assert_eq!(transaction2.quantity, 75);
+        assert_eq!(transaction2.quantity, Quantity::new(75));
 
         let transaction3 = &match_result.trades.as_vec()[2];
         assert_eq!(transaction3.taker_order_id, taker_id);
         assert_eq!(transaction3.maker_order_id, Id::from_u64(3));
-        assert_eq!(transaction3.quantity, 15);
+        assert_eq!(transaction3.quantity, Quantity::new(15));
 
         assert_eq!(match_result.filled_order_ids.len(), 2);
         assert!(match_result.filled_order_ids.contains(&Id::from_u64(1)));
@@ -1203,7 +1204,7 @@ mod tests {
         // Update the price to a different value
         let update = OrderUpdate::UpdatePrice {
             order_id: Id::from_u64(1),
-            new_price: 11000,
+            new_price: Price::new(11000),
         };
 
         let result = price_level.update_order(update);
@@ -1224,7 +1225,7 @@ mod tests {
 
         let same_price_update = OrderUpdate::UpdatePrice {
             order_id: Id::from_u64(2),
-            new_price: 10000,
+            new_price: Price::new(10000),
         };
 
         let result = price_level.update_order(same_price_update);
@@ -1246,7 +1247,7 @@ mod tests {
         // Update to increase quantity
         let update = OrderUpdate::UpdateQuantity {
             order_id: Id::from_u64(1),
-            new_quantity: 150,
+            new_quantity: Quantity::new(150),
         };
 
         let result = price_level.update_order(update);
@@ -1264,7 +1265,7 @@ mod tests {
         // Update to decrease quantity
         let update = OrderUpdate::UpdateQuantity {
             order_id: Id::from_u64(1),
-            new_quantity: 50,
+            new_quantity: Quantity::new(50),
         };
 
         let result = price_level.update_order(update);
@@ -1282,7 +1283,7 @@ mod tests {
         // Test updating non-existent order
         let update = OrderUpdate::UpdateQuantity {
             order_id: Id::from_u64(999),
-            new_quantity: 50,
+            new_quantity: Quantity::new(50),
         };
 
         let result = price_level.update_order(update);
@@ -1301,8 +1302,8 @@ mod tests {
         // Update both price and quantity with different price
         let update = OrderUpdate::UpdatePriceAndQuantity {
             order_id: Id::from_u64(1),
-            new_price: 11000,
-            new_quantity: 150,
+            new_price: Price::new(11000),
+            new_quantity: Quantity::new(150),
         };
 
         let result = price_level.update_order(update);
@@ -1323,8 +1324,8 @@ mod tests {
 
         let update = OrderUpdate::UpdatePriceAndQuantity {
             order_id: Id::from_u64(2),
-            new_price: 10000,
-            new_quantity: 150,
+            new_price: Price::new(10000),
+            new_quantity: Quantity::new(150),
         };
 
         let result = price_level.update_order(update);
@@ -1351,8 +1352,8 @@ mod tests {
         // Replace with different price
         let update = OrderUpdate::Replace {
             order_id: Id::from_u64(1),
-            price: 11000,
-            quantity: 150,
+            price: Price::new(11000),
+            quantity: Quantity::new(150),
             side: Side::Buy,
         };
 
@@ -1374,8 +1375,8 @@ mod tests {
 
         let update = OrderUpdate::Replace {
             order_id: Id::from_u64(2),
-            price: 10000,
-            quantity: 150,
+            price: Price::new(10000),
+            quantity: Quantity::new(150),
             side: Side::Buy,
         };
 
@@ -1501,7 +1502,7 @@ mod tests {
         let orders = price_level.iter_orders();
         assert_eq!(orders.len(), 5);
         assert_eq!(orders[0].id(), Id::from_u64(1));
-        assert_eq!(orders[0].price(), 10000);
+        assert_eq!(orders[0].price(), Price::new(10000));
         assert_eq!(orders[0].visible_quantity(), 50);
     }
 
@@ -1534,7 +1535,7 @@ mod tests {
         let orders = deserialized.iter_orders();
         assert_eq!(orders.len(), 1);
         assert_eq!(orders[0].id(), Id::from_u64(1));
-        assert_eq!(orders[0].price(), 10000);
+        assert_eq!(orders[0].price(), Price::new(10000));
         assert_eq!(orders[0].visible_quantity(), 100);
     }
 
@@ -1569,7 +1570,7 @@ mod tests {
         // Update to a different price (should remove from this level)
         let result = price_level.update_order(OrderUpdate::UpdatePrice {
             order_id: Id::from_u64(1),
-            new_price: 10100, // Different price
+            new_price: Price::new(10100), // Different price
         });
 
         assert!(result.is_ok());
@@ -1588,8 +1589,8 @@ mod tests {
         // Update the quantity but keep the same price
         let result = price_level.update_order(OrderUpdate::UpdatePriceAndQuantity {
             order_id: Id::from_u64(1),
-            new_price: 10000, // Same price
-            new_quantity: 150,
+            new_price: Price::new(10000), // Same price
+            new_quantity: Quantity::new(150),
         });
 
         assert!(result.is_ok());
@@ -1632,11 +1633,11 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let order = OrderType::<()>::Standard {
             id: Id::from_u64(1),
-            price: 10000u128,
-            quantity: 10,
+            price: Price::new(10000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -1645,7 +1646,7 @@ mod tests {
         // Try to update price to the same value
         let update = OrderUpdate::UpdatePrice {
             order_id: Id::from_u64(1),
-            new_price: 10000,
+            new_price: Price::new(10000),
         };
 
         // This should return an error
@@ -1668,7 +1669,7 @@ mod tests {
         // Try to update quantity of a non-existent order
         let update = OrderUpdate::UpdateQuantity {
             order_id: Id::from_u64(123),
-            new_quantity: 20,
+            new_quantity: Quantity::new(20),
         };
 
         let result = price_level.update_order(update);
@@ -1685,11 +1686,11 @@ mod tests {
         // Add an order
         let order = OrderType::<()>::Standard {
             id: Id::from_u64(1),
-            price: 10000u128,
-            quantity: 10,
+            price: Price::new(10000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -1715,7 +1716,7 @@ mod tests {
         // Now try to update it after it's been removed
         let update = OrderUpdate::UpdateQuantity {
             order_id: Id::from_u64(1),
-            new_quantity: 20,
+            new_quantity: Quantity::new(20),
         };
 
         let result = price_level.update_order(update);
@@ -1731,11 +1732,11 @@ mod tests {
         // Add an order
         let order = OrderType::<()>::Standard {
             id: Id::from_u64(1),
-            price: 10000u128,
-            quantity: 50,
+            price: Price::new(10000),
+            quantity: Quantity::new(50),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -1744,7 +1745,7 @@ mod tests {
         // Update to increase quantity (old visible < new visible)
         let update = OrderUpdate::UpdateQuantity {
             order_id: Id::from_u64(1),
-            new_quantity: 100,
+            new_quantity: Quantity::new(100),
         };
 
         let result = price_level.update_order(update);
@@ -1763,12 +1764,12 @@ mod tests {
         // Add an iceberg order with visible and hidden quantities
         let order = OrderType::IcebergOrder {
             id: Id::from_u64(1),
-            price: 10000u128,
-            visible_quantity: 50,
-            hidden_quantity: 150,
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(50),
+            hidden_quantity: Quantity::new(150),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -1781,12 +1782,12 @@ mod tests {
         // Create a new iceberg order with different quantities
         let new_order = OrderType::IcebergOrder {
             id: Id::from_u64(1),
-            price: 10000u128,
-            visible_quantity: 40,
-            hidden_quantity: 200,
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(40),
+            hidden_quantity: Quantity::new(200),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -1811,11 +1812,11 @@ mod tests {
         // Add an order
         let order = OrderType::<()>::Standard {
             id: Id::from_u64(1),
-            price: 10000u128,
-            quantity: 50,
+            price: Price::new(10000),
+            quantity: Quantity::new(50),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -1824,8 +1825,8 @@ mod tests {
         // Update both price and quantity with same price
         let update = OrderUpdate::UpdatePriceAndQuantity {
             order_id: Id::from_u64(1),
-            new_price: 10000, // Same price
-            new_quantity: 100,
+            new_price: Price::new(10000), // Same price
+            new_quantity: Quantity::new(100),
         };
 
         let result = price_level.update_order(update);
@@ -1847,11 +1848,11 @@ mod tests {
         // Add some orders
         let order1 = OrderType::<()>::Standard {
             id: Id::from_u64(1),
-            price: 10000u128,
-            quantity: 50,
+            price: Price::new(10000),
+            quantity: Quantity::new(50),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -1859,12 +1860,12 @@ mod tests {
 
         let order2 = OrderType::<()>::IcebergOrder {
             id: Id::from_u64(2),
-            price: 10000u128,
-            visible_quantity: 30,
-            hidden_quantity: 70,
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(30),
+            hidden_quantity: Quantity::new(70),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000001,
+            timestamp: TimestampMs::new(1616823000001),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };

--- a/src/price_level/tests/order_queue.rs
+++ b/src/price_level/tests/order_queue.rs
@@ -2,6 +2,7 @@
 mod tests {
     use crate::orders::{Hash32, Id, OrderType, Side, TimeInForce};
     use crate::price_level::order_queue::OrderQueue;
+    use crate::utils::{Price, Quantity, TimestampMs};
     use std::str::FromStr;
     use std::sync::Arc;
     use tracing::info;
@@ -9,11 +10,11 @@ mod tests {
     fn create_test_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
         OrderType::<()>::Standard {
             id: Id::from_u64(id),
-            price,
-            quantity,
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         }
@@ -74,10 +75,10 @@ mod tests {
 
         // Verify individual orders (order might not be preserved)
         let has_order1 = orders.iter().any(|o| {
-            o.id() == Id::from_u64(1) && o.price() == 1000u128 && o.visible_quantity() == 10
+            o.id() == Id::from_u64(1) && o.price() == Price::new(1000) && o.visible_quantity() == 10
         });
         let has_order2 = orders.iter().any(|o| {
-            o.id() == Id::from_u64(2) && o.price() == 1100u128 && o.visible_quantity() == 20
+            o.id() == Id::from_u64(2) && o.price() == Price::new(1100) && o.visible_quantity() == 20
         });
 
         assert!(has_order1, "First order not found or incorrect");
@@ -94,10 +95,10 @@ mod tests {
         );
 
         let round_trip_has_order1 = round_trip_orders.iter().any(|o| {
-            o.id() == Id::from_u64(1) && o.price() == 1000u128 && o.visible_quantity() == 10
+            o.id() == Id::from_u64(1) && o.price() == Price::new(1000) && o.visible_quantity() == 10
         });
         let round_trip_has_order2 = round_trip_orders.iter().any(|o| {
-            o.id() == Id::from_u64(2) && o.price() == 1100u128 && o.visible_quantity() == 20
+            o.id() == Id::from_u64(2) && o.price() == Price::new(1100) && o.visible_quantity() == 20
         });
 
         assert!(
@@ -202,8 +203,8 @@ mod tests {
         } = **order
         {
             assert_eq!(id, Id::from_u64(1));
-            assert_eq!(price, 10000);
-            assert_eq!(quantity, 100);
+            assert_eq!(price, Price::new(10000));
+            assert_eq!(quantity, Quantity::new(100));
             assert!(matches!(time_in_force, TimeInForce::Gtd(1617000000000)));
         } else {
             panic!("Expected Standard order");
@@ -224,11 +225,11 @@ mod tests {
         fn create_standard_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
             OrderType::Standard {
                 id: Id::from_u64(id),
-                price,
-                quantity,
+                price: Price::new(price),
+                quantity: Quantity::new(quantity),
                 side: Side::Buy,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000000,
+                timestamp: TimestampMs::new(1616823000000),
                 time_in_force: TimeInForce::Gtc,
                 extra_fields: (),
             }
@@ -262,8 +263,8 @@ mod tests {
         } = **deserialized_order
         {
             assert_eq!(id, Id::from_u64(1));
-            assert_eq!(price, 10000u128);
-            assert_eq!(quantity, 100);
+            assert_eq!(price, Price::new(10000));
+            assert_eq!(quantity, Quantity::new(100));
         } else {
             panic!("Expected Standard order");
         }
@@ -280,11 +281,11 @@ mod tests {
         // Add an order and check again
         let order = OrderType::Standard {
             id: Id::from_u64(1),
-            price: 1000u128,
-            quantity: 10,
+            price: Price::new(1000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
@@ -308,22 +309,22 @@ mod tests {
         // Create a vector of orders
         let order1 = Arc::new(OrderType::Standard {
             id: Id::from_u64(1),
-            price: 1000u128,
-            quantity: 10,
+            price: Price::new(1000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         });
 
         let order2 = Arc::new(OrderType::Standard {
             id: Id::from_u64(2),
-            price: 1000u128,
-            quantity: 20,
+            price: Price::new(1000),
+            quantity: Quantity::new(20),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000001,
+            timestamp: TimestampMs::new(1616823000001),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         });
@@ -398,23 +399,23 @@ mod tests {
 
         let order1 = OrderType::Standard {
             id: Id::from_u64(1),
-            price: 1000u128,
-            quantity: 10,
+            price: Price::new(1000),
+            quantity: Quantity::new(10),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: 1616823000000,
+            timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
 
         let order2 = OrderType::IcebergOrder {
             id: Id::from_u64(2),
-            price: 1000u128,
-            visible_quantity: 5,
-            hidden_quantity: 15,
+            price: Price::new(1000),
+            visible_quantity: Quantity::new(5),
+            hidden_quantity: Quantity::new(15),
             side: Side::Sell,
             user_id: Hash32::zero(),
-            timestamp: 1616823000001,
+            timestamp: TimestampMs::new(1616823000001),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };

--- a/src/price_level/tests/snapshot.rs
+++ b/src/price_level/tests/snapshot.rs
@@ -4,6 +4,7 @@ mod tests {
     use crate::orders::{Hash32, Id, OrderType, Side, TimeInForce};
     use crate::price_level::snapshot::SNAPSHOT_FORMAT_VERSION;
     use crate::price_level::{PriceLevelSnapshot, PriceLevelSnapshotPackage};
+    use crate::utils::{Price, Quantity, TimestampMs};
     use serde_json::Value;
     use std::str::FromStr;
     use std::sync::Arc;
@@ -12,22 +13,22 @@ mod tests {
         vec![
             Arc::new(OrderType::Standard {
                 id: Id::from_u64(1),
-                price: 1000u128,
-                quantity: 10,
+                price: Price::new(1000),
+                quantity: Quantity::new(10),
                 side: Side::Buy,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000000,
+                timestamp: TimestampMs::new(1616823000000),
                 time_in_force: TimeInForce::Gtc,
                 extra_fields: (),
             }),
             Arc::new(OrderType::IcebergOrder {
                 id: Id::from_u64(2),
-                price: 1000u128,
-                visible_quantity: 5,
-                hidden_quantity: 15,
+                price: Price::new(1000),
+                visible_quantity: Quantity::new(5),
+                hidden_quantity: Quantity::new(15),
                 side: Side::Buy,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000001,
+                timestamp: TimestampMs::new(1616823000001),
                 time_in_force: TimeInForce::Gtc,
                 extra_fields: (),
             }),
@@ -298,11 +299,11 @@ mod tests {
         fn create_standard_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
             OrderType::<()>::Standard {
                 id: Id::from_u64(id),
-                price,
-                quantity,
+                price: Price::new(price),
+                quantity: Quantity::new(quantity),
                 side: Side::Buy,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000000,
+                timestamp: TimestampMs::new(1616823000000),
                 time_in_force: TimeInForce::Gtc,
                 extra_fields: (),
             }
@@ -316,12 +317,12 @@ mod tests {
         ) -> OrderType<()> {
             OrderType::<()>::IcebergOrder {
                 id: Id::from_u64(id),
-                price,
-                visible_quantity,
-                hidden_quantity,
+                price: Price::new(price),
+                visible_quantity: Quantity::new(visible_quantity),
+                hidden_quantity: Quantity::new(hidden_quantity),
                 side: Side::Buy,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000000,
+                timestamp: TimestampMs::new(1616823000000),
                 time_in_force: TimeInForce::Gtc,
                 extra_fields: (),
             }
@@ -363,7 +364,7 @@ mod tests {
         // Verify order types
         if let OrderType::Standard { id, quantity, .. } = &*deserialized.orders[0] {
             assert_eq!(*id, Id::from_u64(1));
-            assert_eq!(*quantity, 100);
+            assert_eq!(*quantity, Quantity::new(100));
         } else {
             panic!("Expected Standard order");
         }
@@ -376,8 +377,8 @@ mod tests {
         } = &*deserialized.orders[1]
         {
             assert_eq!(*id, Id::from_u64(2));
-            assert_eq!(*visible_quantity, 50);
-            assert_eq!(*hidden_quantity, 250);
+            assert_eq!(*visible_quantity, Quantity::new(50));
+            assert_eq!(*hidden_quantity, Quantity::new(250));
         } else {
             panic!("Expected IcebergOrder");
         }
@@ -388,6 +389,7 @@ mod tests {
 mod pricelevel_snapshot_serialization_tests {
     use crate::orders::{Hash32, Id, OrderType, Side, TimeInForce};
     use crate::price_level::PriceLevelSnapshot;
+    use crate::utils::{Price, Quantity, TimestampMs};
 
     use std::str::FromStr;
     use std::sync::Arc;
@@ -397,32 +399,32 @@ mod pricelevel_snapshot_serialization_tests {
         vec![
             Arc::new(OrderType::Standard {
                 id: Id::from_u64(1),
-                price: 1000u128,
-                quantity: 10,
+                price: Price::new(1000),
+                quantity: Quantity::new(10),
                 side: Side::Buy,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000000,
+                timestamp: TimestampMs::new(1616823000000),
                 time_in_force: TimeInForce::Gtc,
                 extra_fields: (),
             }),
             Arc::new(OrderType::IcebergOrder {
                 id: Id::from_u64(2),
-                price: 1000u128,
-                visible_quantity: 5,
-                hidden_quantity: 15,
+                price: Price::new(1000),
+                visible_quantity: Quantity::new(5),
+                hidden_quantity: Quantity::new(15),
                 side: Side::Sell,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000001,
+                timestamp: TimestampMs::new(1616823000001),
                 time_in_force: TimeInForce::Gtc,
                 extra_fields: (),
             }),
             Arc::new(OrderType::PostOnly {
                 id: Id::from_u64(3),
-                price: 1000u128,
-                quantity: 8,
+                price: Price::new(1000),
+                quantity: Quantity::new(8),
                 side: Side::Buy,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000002,
+                timestamp: TimestampMs::new(1616823000002),
                 time_in_force: TimeInForce::Ioc,
                 extra_fields: (),
             }),
@@ -497,8 +499,8 @@ mod pricelevel_snapshot_serialization_tests {
                 ..
             } => {
                 assert_eq!(id, Id::from_u64(1));
-                assert_eq!(price, 1000);
-                assert_eq!(quantity, 10);
+                assert_eq!(price, Price::new(1000));
+                assert_eq!(quantity, Quantity::new(10));
                 assert_eq!(side, Side::Buy);
             }
             _ => panic!("Expected Standard order"),
@@ -514,8 +516,8 @@ mod pricelevel_snapshot_serialization_tests {
                 ..
             } => {
                 assert_eq!(id, Id::from_u64(2));
-                assert_eq!(visible_quantity, 5);
-                assert_eq!(hidden_quantity, 15);
+                assert_eq!(visible_quantity, Quantity::new(5));
+                assert_eq!(hidden_quantity, Quantity::new(15));
                 assert_eq!(side, Side::Sell);
             }
             _ => panic!("Expected IcebergOrder"),
@@ -527,7 +529,7 @@ mod pricelevel_snapshot_serialization_tests {
                 id, quantity, side, ..
             } => {
                 assert_eq!(id, Id::from_u64(3));
-                assert_eq!(quantity, 8);
+                assert_eq!(quantity, Quantity::new(8));
                 assert_eq!(side, Side::Buy);
             }
             _ => panic!("Expected PostOnly order"),
@@ -716,71 +718,71 @@ mod pricelevel_snapshot_serialization_tests {
             // Standard order
             Arc::new(OrderType::Standard {
                 id: Id::from_u64(1),
-                price: 1000u128,
-                quantity: 10,
+                price: Price::new(1000),
+                quantity: Quantity::new(10),
                 side: Side::Buy,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000000,
+                timestamp: TimestampMs::new(1616823000000),
                 time_in_force: TimeInForce::Gtc,
                 extra_fields: (),
             }),
             // Iceberg order
             Arc::new(OrderType::IcebergOrder {
                 id: Id::from_u64(2),
-                price: 1000u128,
-                visible_quantity: 5,
-                hidden_quantity: 15,
+                price: Price::new(1000),
+                visible_quantity: Quantity::new(5),
+                hidden_quantity: Quantity::new(15),
                 side: Side::Sell,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000001,
+                timestamp: TimestampMs::new(1616823000001),
                 time_in_force: TimeInForce::Gtc,
                 extra_fields: (),
             }),
             // Post-only order
             Arc::new(OrderType::PostOnly {
                 id: Id::from_u64(3),
-                price: 1000u128,
-                quantity: 8,
+                price: Price::new(1000),
+                quantity: Quantity::new(8),
                 side: Side::Buy,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000002,
+                timestamp: TimestampMs::new(1616823000002),
                 time_in_force: TimeInForce::Ioc,
                 extra_fields: (),
             }),
             // Fill-or-kill order (as Standard with FOK time-in-force)
             Arc::new(OrderType::Standard {
                 id: Id::from_u64(4),
-                price: 1000u128,
-                quantity: 12,
+                price: Price::new(1000),
+                quantity: Quantity::new(12),
                 side: Side::Buy,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000003,
+                timestamp: TimestampMs::new(1616823000003),
                 time_in_force: TimeInForce::Fok,
                 extra_fields: (),
             }),
             // Good-till-date order (as Standard with GTD time-in-force)
             Arc::new(OrderType::Standard {
                 id: Id::from_u64(5),
-                price: 1000u128,
-                quantity: 7,
+                price: Price::new(1000),
+                quantity: Quantity::new(7),
                 side: Side::Sell,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000004,
+                timestamp: TimestampMs::new(1616823000004),
                 time_in_force: TimeInForce::Gtd(1617000000000),
                 extra_fields: (),
             }),
             // Reserve order
             Arc::new(OrderType::ReserveOrder {
                 id: Id::from_u64(6),
-                price: 1000u128,
-                visible_quantity: 3,
-                hidden_quantity: 12,
+                price: Price::new(1000),
+                visible_quantity: Quantity::new(3),
+                hidden_quantity: Quantity::new(12),
                 side: Side::Buy,
                 user_id: Hash32::zero(),
-                timestamp: 1616823000005,
+                timestamp: TimestampMs::new(1616823000005),
                 time_in_force: TimeInForce::Gtc,
-                replenish_threshold: 1,
-                replenish_amount: Some(2),
+                replenish_threshold: Quantity::new(1),
+                replenish_amount: Some(Quantity::new(2)),
                 auto_replenish: true,
                 extra_fields: (),
             }),
@@ -842,7 +844,7 @@ mod pricelevel_snapshot_serialization_tests {
             ..
         } = **reserve_order
         {
-            assert_eq!(replenish_threshold, 1);
+            assert_eq!(replenish_threshold, Quantity::new(1));
             assert!(auto_replenish);
         }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,7 +7,9 @@
 mod id;
 mod logger;
 mod uuid;
+mod value;
 
 pub use id::Id;
 pub use logger::setup_logger;
 pub use uuid::UuidGenerator;
+pub use value::{Price, Quantity, TimestampMs};

--- a/src/utils/value.rs
+++ b/src/utils/value.rs
@@ -1,0 +1,218 @@
+use crate::errors::PriceLevelError;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// Domain value type representing a price.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct Price(u128);
+
+impl Price {
+    /// Zero price value.
+    pub const ZERO: Self = Self(0);
+
+    /// Creates a new price from a raw integer value.
+    #[must_use]
+    pub const fn new(value: u128) -> Self {
+        Self(value)
+    }
+
+    /// Creates a validated price from a raw integer value.
+    pub fn try_new(value: u128) -> Result<Self, PriceLevelError> {
+        Ok(Self(value))
+    }
+
+    /// Creates a price from an `f64` value.
+    pub fn from_f64(value: f64) -> Result<Self, PriceLevelError> {
+        if !value.is_finite() || value < 0.0 {
+            return Err(PriceLevelError::InvalidOperation {
+                message: format!("invalid price from f64: {value}"),
+            });
+        }
+
+        Ok(Self(value.round() as u128))
+    }
+
+    /// Converts the price to `f64` with potential precision loss.
+    #[must_use]
+    pub fn to_f64_lossy(self) -> f64 {
+        self.0 as f64
+    }
+
+    /// Returns the inner raw value.
+    #[must_use]
+    pub const fn as_u128(self) -> u128 {
+        self.0
+    }
+}
+
+impl fmt::Display for Price {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for Price {
+    type Err = PriceLevelError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<u128>()
+            .map(Self)
+            .map_err(|_| PriceLevelError::InvalidFieldValue {
+                field: "price".to_string(),
+                value: s.to_string(),
+            })
+    }
+}
+
+/// Domain value type representing a quantity.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct Quantity(u64);
+
+impl Quantity {
+    /// Zero quantity value.
+    pub const ZERO: Self = Self(0);
+
+    /// Creates a new quantity from a raw integer value.
+    #[must_use]
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Creates a validated quantity from a raw integer value.
+    pub fn try_new(value: u64) -> Result<Self, PriceLevelError> {
+        Ok(Self(value))
+    }
+
+    /// Creates a quantity from an `f64` value.
+    pub fn from_f64(value: f64) -> Result<Self, PriceLevelError> {
+        if !value.is_finite() || value < 0.0 {
+            return Err(PriceLevelError::InvalidOperation {
+                message: format!("invalid quantity from f64: {value}"),
+            });
+        }
+
+        Ok(Self(value.round() as u64))
+    }
+
+    /// Converts the quantity to `f64` with potential precision loss.
+    #[must_use]
+    pub fn to_f64_lossy(self) -> f64 {
+        self.0 as f64
+    }
+
+    /// Returns the inner raw value.
+    #[must_use]
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for Quantity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for Quantity {
+    type Err = PriceLevelError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<u64>()
+            .map(Self)
+            .map_err(|_| PriceLevelError::InvalidFieldValue {
+                field: "quantity".to_string(),
+                value: s.to_string(),
+            })
+    }
+}
+
+/// Domain value type representing a timestamp in milliseconds.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct TimestampMs(u64);
+
+impl TimestampMs {
+    /// Zero timestamp value.
+    pub const ZERO: Self = Self(0);
+
+    /// Creates a new timestamp from milliseconds.
+    #[must_use]
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Creates a validated timestamp from milliseconds.
+    pub fn try_new(value: u64) -> Result<Self, PriceLevelError> {
+        Ok(Self(value))
+    }
+
+    /// Returns the inner raw milliseconds value.
+    #[must_use]
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for TimestampMs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for TimestampMs {
+    type Err = PriceLevelError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<u64>()
+            .map(Self)
+            .map_err(|_| PriceLevelError::InvalidFieldValue {
+                field: "timestamp".to_string(),
+                value: s.to_string(),
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Price, Quantity, TimestampMs};
+    use std::str::FromStr;
+
+    #[test]
+    fn price_roundtrip() {
+        let value = Price::new(1_000);
+        let parsed = Price::from_str(&value.to_string());
+        assert!(parsed.is_ok());
+        assert_eq!(parsed.unwrap_or_default(), value);
+    }
+
+    #[test]
+    fn quantity_roundtrip() {
+        let value = Quantity::new(42);
+        let parsed = Quantity::from_str(&value.to_string());
+        assert!(parsed.is_ok());
+        assert_eq!(parsed.unwrap_or_default(), value);
+    }
+
+    #[test]
+    fn timestamp_roundtrip() {
+        let value = TimestampMs::new(1_716_000_000_000);
+        let parsed = TimestampMs::from_str(&value.to_string());
+        assert!(parsed.is_ok());
+        assert_eq!(parsed.unwrap_or_default(), value);
+    }
+
+    #[test]
+    fn from_f64_rejects_negative() {
+        assert!(Price::from_f64(-1.0).is_err());
+        assert!(Quantity::from_f64(-1.0).is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `Price`, `Quantity`, and `TimestampMs` domain newtypes in `src/utils/value.rs`
- migrate public API surfaces (`OrderType`, `OrderUpdate`, `Trade`, `MatchResult`, and `PriceLevel` interactions) to typed values
- update parsing/serialization paths and tests to compare and construct typed values
- migrate benchmark helpers and update operations to typed values so all targets compile
- export value newtypes from crate root and `prelude` for ergonomic imports

## Validation
- `cargo test --all-features`
- `make lint-fix`
- `make pre-push`

Closes #19
