### PR TITLE
feat: harden public API invariants by privatizing struct fields

### DIFF
--- a/examples/src/bin/hft_simulation.rs
+++ b/examples/src/bin/hft_simulation.rs
@@ -140,7 +140,7 @@ fn main() {
                 let result = thread_price_level.match_order(quantity, taker_id, &thread_tx_id_gen);
 
                 // Count successful matches
-                if result.executed_quantity() > 0 {
+                if result.executed_quantity().unwrap_or(0) > 0 {
                     local_counter += 1;
                 }
 
@@ -402,7 +402,7 @@ fn print_price_level_info(price_level: &PriceLevel) {
     info!("Price: {}", price_level.price());
     info!("Visible quantity: {}", price_level.visible_quantity());
     info!("Hidden quantity: {}", price_level.hidden_quantity());
-    info!("Total quantity: {}", price_level.total_quantity());
+    info!("Total quantity: {:?}", price_level.total_quantity());
     info!("Order count: {}", price_level.order_count());
     info!("Statistics: {}", price_level.stats());
 }

--- a/examples/src/bin/simple.rs
+++ b/examples/src/bin/simple.rs
@@ -77,9 +77,9 @@ fn main() {
                             info!(
                                 "Thread {} match result: executed={}, remaining={}, complete={}",
                                 thread_id,
-                                match_result.executed_quantity(),
-                                match_result.remaining_quantity,
-                                match_result.is_complete
+                                match_result.executed_quantity().unwrap_or(0),
+                                match_result.remaining_quantity(),
+                                match_result.is_complete()
                             );
                         }
 
@@ -311,6 +311,6 @@ fn print_price_level_info(price_level: &PriceLevel) {
     info!("Price: {}", price_level.price());
     info!("Visible quantity: {}", price_level.visible_quantity());
     info!("Hidden quantity: {}", price_level.hidden_quantity());
-    info!("Total quantity: {}", price_level.total_quantity());
+    info!("Total quantity: {:?}", price_level.total_quantity());
     info!("Order count: {}", price_level.order_count());
 }

--- a/src/execution/list.rs
+++ b/src/execution/list.rs
@@ -4,11 +4,15 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 
-/// A wrapper for a vector of trades to implement custom serialization
+/// A wrapper for a vector of trades to implement custom serialization.
+///
+/// The inner collection is private to enforce append-only semantics
+/// during matching. Use [`Self::add`] to append and [`Self::as_vec`]
+/// or [`Self::into_vec`] to read.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TradeList {
     /// Ordered collection of trades.
-    pub trades: Vec<Trade>,
+    trades: Vec<Trade>,
 }
 
 impl TradeList {

--- a/src/execution/match_result.rs
+++ b/src/execution/match_result.rs
@@ -6,23 +6,27 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 
-/// Represents the result of a matching operation
+/// Represents the result of a matching operation.
+///
+/// Fields are private to enforce invariant consistency between
+/// `remaining_quantity`, `is_complete`, and `trades`.
+/// Use the provided accessor methods and mutation helpers.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MatchResult {
     /// The ID of the incoming order that initiated the match
-    pub order_id: Id,
+    order_id: Id,
 
     /// List of trades that resulted from the match
-    pub trades: TradeList,
+    trades: TradeList,
 
     /// Remaining quantity of the incoming order after matching
-    pub remaining_quantity: u64,
+    remaining_quantity: u64,
 
     /// Whether the order was completely filled
-    pub is_complete: bool,
+    is_complete: bool,
 
     /// Any orders that were completely filled and removed from the book
-    pub filled_order_ids: Vec<Id>,
+    filled_order_ids: Vec<Id>,
 }
 
 impl MatchResult {
@@ -42,11 +46,11 @@ impl MatchResult {
     pub fn add_trade(&mut self, trade: Trade) -> Result<(), PriceLevelError> {
         self.remaining_quantity = self
             .remaining_quantity
-            .checked_sub(trade.quantity.as_u64())
+            .checked_sub(trade.quantity().as_u64())
             .ok_or_else(|| PriceLevelError::InvalidOperation {
                 message: format!(
                     "trade quantity {} exceeds remaining quantity {}",
-                    trade.quantity.as_u64(),
+                    trade.quantity().as_u64(),
                     self.remaining_quantity
                 ),
             })?;
@@ -60,10 +64,48 @@ impl MatchResult {
         self.filled_order_ids.push(order_id);
     }
 
+    /// Returns the ID of the incoming order that initiated the match.
+    #[must_use]
+    pub fn order_id(&self) -> Id {
+        self.order_id
+    }
+
+    /// Returns a reference to the list of trades.
+    #[must_use]
+    pub fn trades(&self) -> &TradeList {
+        &self.trades
+    }
+
+    /// Returns the remaining quantity of the incoming order after matching.
+    #[must_use]
+    pub fn remaining_quantity(&self) -> u64 {
+        self.remaining_quantity
+    }
+
+    /// Returns whether the order was completely filled.
+    #[must_use]
+    pub fn is_complete(&self) -> bool {
+        self.is_complete
+    }
+
+    /// Returns the IDs of orders that were completely filled during matching.
+    #[must_use]
+    pub fn filled_order_ids(&self) -> &[Id] {
+        &self.filled_order_ids
+    }
+
+    /// Sets the final remaining quantity and completion flag.
+    ///
+    /// This is used internally by the matching engine after the matching loop.
+    pub(crate) fn finalize(&mut self, remaining_quantity: u64) {
+        self.remaining_quantity = remaining_quantity;
+        self.is_complete = remaining_quantity == 0;
+    }
+
     /// Get the total executed quantity
     pub fn executed_quantity(&self) -> Result<u64, PriceLevelError> {
         self.trades.as_vec().iter().try_fold(0u64, |acc, trade| {
-            acc.checked_add(trade.quantity.as_u64()).ok_or_else(|| {
+            acc.checked_add(trade.quantity().as_u64()).ok_or_else(|| {
                 PriceLevelError::InvalidOperation {
                     message: "executed quantity overflow".to_string(),
                 }
@@ -75,9 +117,9 @@ impl MatchResult {
     pub fn executed_value(&self) -> Result<u128, PriceLevelError> {
         self.trades.as_vec().iter().try_fold(0u128, |acc, trade| {
             let trade_value = trade
-                .price
+                .price()
                 .as_u128()
-                .checked_mul(u128::from(trade.quantity.as_u64()))
+                .checked_mul(u128::from(trade.quantity().as_u64()))
                 .ok_or_else(|| PriceLevelError::InvalidOperation {
                     message: "executed value multiplication overflow".to_string(),
                 })?;

--- a/src/execution/tests/list_trade.rs
+++ b/src/execution/tests/list_trade.rs
@@ -15,15 +15,15 @@ mod tests {
     }
 
     fn sample_trade() -> Trade {
-        Trade {
-            trade_id: Id::from_uuid(parse_uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
-            taker_order_id: Id::from_u64(1),
-            maker_order_id: Id::from_u64(2),
-            price: Price::new(10_000),
-            quantity: Quantity::new(5),
-            taker_side: Side::Buy,
-            timestamp: TimestampMs::new(1_616_823_000_000),
-        }
+        Trade::with_timestamp(
+            Id::from_uuid(parse_uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
+            Id::from_u64(1),
+            Id::from_u64(2),
+            Price::new(10_000),
+            Quantity::new(5),
+            Side::Buy,
+            TimestampMs::new(1_616_823_000_000),
+        )
     }
 
     #[test]
@@ -41,7 +41,7 @@ mod tests {
         };
 
         assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed.as_vec()[0].trade_id, list.as_vec()[0].trade_id);
+        assert_eq!(parsed.as_vec()[0].trade_id(), list.as_vec()[0].trade_id());
     }
 
     #[test]

--- a/src/execution/tests/match_result_trade.rs
+++ b/src/execution/tests/match_result_trade.rs
@@ -15,15 +15,15 @@ mod tests {
     }
 
     fn sample_trade(quantity: u64) -> Trade {
-        Trade {
-            trade_id: Id::from_uuid(parse_uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
-            taker_order_id: Id::from_u64(10),
-            maker_order_id: Id::from_u64(20),
-            price: Price::new(1_000),
-            quantity: Quantity::new(quantity),
-            taker_side: Side::Buy,
-            timestamp: TimestampMs::new(1_616_823_000_000),
-        }
+        Trade::with_timestamp(
+            Id::from_uuid(parse_uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
+            Id::from_u64(10),
+            Id::from_u64(20),
+            Price::new(1_000),
+            Quantity::new(quantity),
+            Side::Buy,
+            TimestampMs::new(1_616_823_000_000),
+        )
     }
 
     #[test]
@@ -31,9 +31,9 @@ mod tests {
         let mut result = MatchResult::new(Id::from_u64(10), 100);
         assert!(result.add_trade(sample_trade(25)).is_ok());
 
-        assert_eq!(result.remaining_quantity, 75);
-        assert_eq!(result.trades.len(), 1);
-        assert!(!result.is_complete);
+        assert_eq!(result.remaining_quantity(), 75);
+        assert_eq!(result.trades().len(), 1);
+        assert!(!result.is_complete());
     }
 
     #[test]
@@ -49,8 +49,8 @@ mod tests {
             Err(error) => panic!("failed to parse match result: {error:?}"),
         };
 
-        assert_eq!(parsed.trades.len(), 1);
-        assert_eq!(parsed.remaining_quantity, 60);
+        assert_eq!(parsed.trades().len(), 1);
+        assert_eq!(parsed.remaining_quantity(), 60);
     }
 
     #[test]
@@ -65,23 +65,23 @@ mod tests {
         let mut result = MatchResult::new(Id::from_u64(10), 10);
         let error = result.add_trade(sample_trade(11));
         assert!(error.is_err());
-        assert_eq!(result.remaining_quantity, 10);
-        assert_eq!(result.trades.len(), 0);
+        assert_eq!(result.remaining_quantity(), 10);
+        assert_eq!(result.trades().len(), 0);
     }
 
     #[test]
     fn executed_value_rejects_overflow() {
         let mut result = MatchResult::new(Id::from_u64(10), 4);
 
-        let trade = Trade {
-            trade_id: Id::from_uuid(parse_uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
-            taker_order_id: Id::from_u64(10),
-            maker_order_id: Id::from_u64(20),
-            price: Price::new(u128::MAX),
-            quantity: Quantity::new(2),
-            taker_side: Side::Buy,
-            timestamp: TimestampMs::new(1_616_823_000_000),
-        };
+        let trade = Trade::with_timestamp(
+            Id::from_uuid(parse_uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
+            Id::from_u64(10),
+            Id::from_u64(20),
+            Price::new(u128::MAX),
+            Quantity::new(2),
+            Side::Buy,
+            TimestampMs::new(1_616_823_000_000),
+        );
 
         assert!(result.add_trade(trade).is_ok());
         assert!(result.executed_value().is_err());

--- a/src/execution/tests/transaction.rs
+++ b/src/execution/tests/transaction.rs
@@ -10,16 +10,15 @@ mod tests {
 
     fn create_test_trade() -> Trade {
         let uuid = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
-
-        Trade {
-            trade_id: Id::from_uuid(uuid),
-            taker_order_id: Id::from_u64(1),
-            maker_order_id: Id::from_u64(2),
-            price: Price::new(10000),
-            quantity: Quantity::new(5),
-            taker_side: Side::Buy,
-            timestamp: TimestampMs::new(1616823000000),
-        }
+        Trade::with_timestamp(
+            Id::from_uuid(uuid),
+            Id::from_u64(1),
+            Id::from_u64(2),
+            Price::new(10000),
+            Quantity::new(5),
+            Side::Buy,
+            TimestampMs::new(1616823000000),
+        )
     }
 
     #[test]
@@ -42,13 +41,13 @@ mod tests {
         let input = "Trade:trade_id=6ba7b810-9dad-11d1-80b4-00c04fd430c8;taker_order_id=00000000-0000-0001-0000-000000000000;maker_order_id=00000000-0000-0002-0000-000000000000;price=10000;quantity=5;taker_side=BUY;timestamp=1616823000000";
         let transaction = Trade::from_str(input).unwrap();
         let uuid = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
-        assert_eq!(transaction.trade_id, Id::from_uuid(uuid));
-        assert_eq!(transaction.taker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.maker_order_id, Id::from_u64(2));
-        assert_eq!(transaction.price, Price::new(10000));
-        assert_eq!(transaction.quantity, Quantity::new(5));
-        assert_eq!(transaction.taker_side, Side::Buy);
-        assert_eq!(transaction.timestamp, TimestampMs::new(1616823000000));
+        assert_eq!(transaction.trade_id(), Id::from_uuid(uuid));
+        assert_eq!(transaction.taker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction.maker_order_id(), Id::from_u64(2));
+        assert_eq!(transaction.price(), Price::new(10000));
+        assert_eq!(transaction.quantity(), Quantity::new(5));
+        assert_eq!(transaction.taker_side(), Side::Buy);
+        assert_eq!(transaction.timestamp(), TimestampMs::new(1616823000000));
     }
 
     #[test]
@@ -109,39 +108,53 @@ mod tests {
         let string_representation = original.to_string();
         let parsed = Trade::from_str(&string_representation).unwrap();
 
-        assert_eq!(parsed.trade_id, original.trade_id);
-        assert_eq!(parsed.taker_order_id, original.taker_order_id);
-        assert_eq!(parsed.maker_order_id, original.maker_order_id);
-        assert_eq!(parsed.price, original.price);
-        assert_eq!(parsed.quantity, original.quantity);
-        assert_eq!(parsed.taker_side, original.taker_side);
-        assert_eq!(parsed.timestamp, original.timestamp);
+        assert_eq!(parsed.trade_id(), original.trade_id());
+        assert_eq!(parsed.taker_order_id(), original.taker_order_id());
+        assert_eq!(parsed.maker_order_id(), original.maker_order_id());
+        assert_eq!(parsed.price(), original.price());
+        assert_eq!(parsed.quantity(), original.quantity());
+        assert_eq!(parsed.taker_side(), original.taker_side());
+        assert_eq!(parsed.timestamp(), original.timestamp());
     }
 
     #[test]
     fn test_maker_side() {
         // Test when taker is buyer
-        let mut transaction = create_test_trade();
-        transaction.taker_side = Side::Buy;
-        assert_eq!(transaction.maker_side(), Side::Sell);
+        let buy_trade = create_test_trade();
+        assert_eq!(buy_trade.taker_side(), Side::Buy);
+        assert_eq!(buy_trade.maker_side(), Side::Sell);
 
         // Test when taker is seller
-        transaction.taker_side = Side::Sell;
-        assert_eq!(transaction.maker_side(), Side::Buy);
+        let uuid = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let sell_trade = Trade::with_timestamp(
+            Id::from_uuid(uuid),
+            Id::from_u64(1),
+            Id::from_u64(2),
+            Price::new(10000),
+            Quantity::new(5),
+            Side::Sell,
+            TimestampMs::new(1616823000000),
+        );
+        assert_eq!(sell_trade.maker_side(), Side::Buy);
     }
 
     #[test]
     fn test_total_value() {
-        let mut transaction = create_test_trade();
-        transaction.price = Price::new(10000);
-        transaction.quantity = Quantity::new(5);
-
+        let transaction = create_test_trade();
         assert_eq!(transaction.total_value(), 50000);
 
         // Test with larger values
-        transaction.price = Price::new(123456);
-        transaction.quantity = Quantity::new(789);
-        assert_eq!(transaction.total_value(), 97406784);
+        let uuid = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let large_trade = Trade::with_timestamp(
+            Id::from_uuid(uuid),
+            Id::from_u64(1),
+            Id::from_u64(2),
+            Price::new(123456),
+            Quantity::new(789),
+            Side::Buy,
+            TimestampMs::new(1616823000000),
+        );
+        assert_eq!(large_trade.total_value(), 97406784);
     }
 
     #[test]
@@ -161,15 +174,15 @@ mod tests {
             Side::Buy,
         );
 
-        assert_eq!(transaction.trade_id, Id::from_uuid(uuid));
-        assert_eq!(transaction.taker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.maker_order_id, Id::from_u64(2));
-        assert_eq!(transaction.price, Price::new(10000));
-        assert_eq!(transaction.quantity, Quantity::new(5));
-        assert_eq!(transaction.taker_side, Side::Buy);
+        assert_eq!(transaction.trade_id(), Id::from_uuid(uuid));
+        assert_eq!(transaction.taker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction.maker_order_id(), Id::from_u64(2));
+        assert_eq!(transaction.price(), Price::new(10000));
+        assert_eq!(transaction.quantity(), Quantity::new(5));
+        assert_eq!(transaction.taker_side(), Side::Buy);
 
         // The timestamp should be approximately now
-        let timestamp_diff = transaction.timestamp.as_u64().abs_diff(now);
+        let timestamp_diff = transaction.timestamp().as_u64().abs_diff(now);
 
         // Timestamp should be within 100ms of current time
         assert!(
@@ -187,13 +200,13 @@ mod tests {
         let transaction = Trade::from_str(input).unwrap();
 
         let uuid = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
-        assert_eq!(transaction.trade_id, Id::from_uuid(uuid));
-        assert_eq!(transaction.taker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.maker_order_id, Id::from_u64(2));
-        assert_eq!(transaction.price, Price::new(10000));
-        assert_eq!(transaction.quantity, Quantity::new(5));
-        assert_eq!(transaction.taker_side, Side::Buy);
-        assert_eq!(transaction.timestamp, TimestampMs::new(1616823000000));
+        assert_eq!(transaction.trade_id(), Id::from_uuid(uuid));
+        assert_eq!(transaction.taker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction.maker_order_id(), Id::from_u64(2));
+        assert_eq!(transaction.price(), Price::new(10000));
+        assert_eq!(transaction.quantity(), Quantity::new(5));
+        assert_eq!(transaction.taker_side(), Side::Buy);
+        assert_eq!(transaction.timestamp(), TimestampMs::new(1616823000000));
     }
 
     #[test]
@@ -264,15 +277,15 @@ mod transaction_serialization_tests {
 
     fn create_test_trade() -> Trade {
         let uuid = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
-        Trade {
-            trade_id: Id::from_uuid(uuid),
-            taker_order_id: Id::from_u64(1),
-            maker_order_id: Id::from_u64(2),
-            price: Price::new(10000),
-            quantity: Quantity::new(5),
-            taker_side: Side::Buy,
-            timestamp: TimestampMs::new(1616823000000),
-        }
+        Trade::with_timestamp(
+            Id::from_uuid(uuid),
+            Id::from_u64(1),
+            Id::from_u64(2),
+            Price::new(10000),
+            Quantity::new(5),
+            Side::Buy,
+            TimestampMs::new(1616823000000),
+        )
     }
 
     #[test]
@@ -302,13 +315,13 @@ mod transaction_serialization_tests {
 
         let transaction: Trade = serde_json::from_str(json).unwrap();
         let uuid = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
-        assert_eq!(transaction.trade_id, Id::from_uuid(uuid));
-        assert_eq!(transaction.taker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.maker_order_id, Id::from_u64(2));
-        assert_eq!(transaction.price, Price::new(10000));
-        assert_eq!(transaction.quantity, Quantity::new(5));
-        assert_eq!(transaction.taker_side, Side::Buy);
-        assert_eq!(transaction.timestamp, TimestampMs::new(1616823000000));
+        assert_eq!(transaction.trade_id(), Id::from_uuid(uuid));
+        assert_eq!(transaction.taker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction.maker_order_id(), Id::from_u64(2));
+        assert_eq!(transaction.price(), Price::new(10000));
+        assert_eq!(transaction.quantity(), Quantity::new(5));
+        assert_eq!(transaction.taker_side(), Side::Buy);
+        assert_eq!(transaction.timestamp(), TimestampMs::new(1616823000000));
     }
 
     #[test]
@@ -319,13 +332,13 @@ mod transaction_serialization_tests {
 
         let deserialized: Trade = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(deserialized.trade_id, original.trade_id);
-        assert_eq!(deserialized.taker_order_id, original.taker_order_id);
-        assert_eq!(deserialized.maker_order_id, original.maker_order_id);
-        assert_eq!(deserialized.price, original.price);
-        assert_eq!(deserialized.quantity, original.quantity);
-        assert_eq!(deserialized.taker_side, original.taker_side);
-        assert_eq!(deserialized.timestamp, original.timestamp);
+        assert_eq!(deserialized.trade_id(), original.trade_id());
+        assert_eq!(deserialized.taker_order_id(), original.taker_order_id());
+        assert_eq!(deserialized.maker_order_id(), original.maker_order_id());
+        assert_eq!(deserialized.price(), original.price());
+        assert_eq!(deserialized.quantity(), original.quantity());
+        assert_eq!(deserialized.taker_side(), original.taker_side());
+        assert_eq!(deserialized.timestamp(), original.timestamp());
     }
 
     #[test]
@@ -348,13 +361,13 @@ mod transaction_serialization_tests {
         let input = "Trade:trade_id=6ba7b810-9dad-11d1-80b4-00c04fd430c8;taker_order_id=00000000-0000-0001-0000-000000000000;maker_order_id=00000000-0000-0002-0000-000000000000;price=10000;quantity=5;taker_side=BUY;timestamp=1616823000000";
         let transaction = Trade::from_str(input).unwrap();
         let uuid = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
-        assert_eq!(transaction.trade_id, Id::from_uuid(uuid));
-        assert_eq!(transaction.taker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.maker_order_id, Id::from_u64(2));
-        assert_eq!(transaction.price, Price::new(10000));
-        assert_eq!(transaction.quantity, Quantity::new(5));
-        assert_eq!(transaction.taker_side, Side::Buy);
-        assert_eq!(transaction.timestamp, TimestampMs::new(1616823000000));
+        assert_eq!(transaction.trade_id(), Id::from_uuid(uuid));
+        assert_eq!(transaction.taker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction.maker_order_id(), Id::from_u64(2));
+        assert_eq!(transaction.price(), Price::new(10000));
+        assert_eq!(transaction.quantity(), Quantity::new(5));
+        assert_eq!(transaction.taker_side(), Side::Buy);
+        assert_eq!(transaction.timestamp(), TimestampMs::new(1616823000000));
     }
 
     #[test]
@@ -400,42 +413,52 @@ mod transaction_serialization_tests {
         let string_representation = original.to_string();
         let parsed = Trade::from_str(&string_representation).unwrap();
 
-        assert_eq!(parsed.trade_id, original.trade_id);
-        assert_eq!(parsed.taker_order_id, original.taker_order_id);
-        assert_eq!(parsed.maker_order_id, original.maker_order_id);
-        assert_eq!(parsed.price, original.price);
-        assert_eq!(parsed.quantity, original.quantity);
-        assert_eq!(parsed.taker_side, original.taker_side);
-        assert_eq!(parsed.timestamp, original.timestamp);
+        assert_eq!(parsed.trade_id(), original.trade_id());
+        assert_eq!(parsed.taker_order_id(), original.taker_order_id());
+        assert_eq!(parsed.maker_order_id(), original.maker_order_id());
+        assert_eq!(parsed.price(), original.price());
+        assert_eq!(parsed.quantity(), original.quantity());
+        assert_eq!(parsed.taker_side(), original.taker_side());
+        assert_eq!(parsed.timestamp(), original.timestamp());
     }
 
     #[test]
     fn test_maker_side_when_taker_is_buyer() {
-        let mut transaction = create_test_trade();
-        transaction.taker_side = Side::Buy;
-
+        let transaction = create_test_trade();
+        assert_eq!(transaction.taker_side(), Side::Buy);
         assert_eq!(transaction.maker_side(), Side::Sell);
     }
 
     #[test]
     fn test_maker_side_when_taker_is_seller() {
-        let mut transaction = create_test_trade();
-        transaction.taker_side = Side::Sell;
-
+        let uuid = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let transaction = Trade::with_timestamp(
+            Id::from_uuid(uuid),
+            Id::from_u64(1),
+            Id::from_u64(2),
+            Price::new(10000),
+            Quantity::new(5),
+            Side::Sell,
+            TimestampMs::new(1616823000000),
+        );
         assert_eq!(transaction.maker_side(), Side::Buy);
     }
 
     #[test]
     fn test_total_value_calculation() {
-        let mut transaction = create_test_trade();
-        transaction.price = Price::new(10000);
-        transaction.quantity = Quantity::new(5);
-
+        let transaction = create_test_trade();
         assert_eq!(transaction.total_value(), 50000);
 
-        transaction.price = Price::new(12345);
-        transaction.quantity = Quantity::new(67);
-
-        assert_eq!(transaction.total_value(), 827115);
+        let uuid = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let large_trade = Trade::with_timestamp(
+            Id::from_uuid(uuid),
+            Id::from_u64(1),
+            Id::from_u64(2),
+            Price::new(12345),
+            Quantity::new(67),
+            Side::Buy,
+            TimestampMs::new(1616823000000),
+        );
+        assert_eq!(large_trade.total_value(), 827115);
     }
 }

--- a/src/execution/trade.rs
+++ b/src/execution/trade.rs
@@ -6,29 +6,32 @@ use std::fmt;
 use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Represents a completed trade between two orders
+/// Represents a completed trade between two orders.
+///
+/// All fields are private to enforce immutability after construction.
+/// Use the provided accessor methods to read trade data.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct Trade {
     /// Unique trade ID
-    pub trade_id: Id,
+    trade_id: Id,
 
     /// ID of the aggressive order that caused the match
-    pub taker_order_id: Id,
+    taker_order_id: Id,
 
     /// ID of the passive order that was in the book
-    pub maker_order_id: Id,
+    maker_order_id: Id,
 
     /// Price at which the trade occurred
-    pub price: Price,
+    price: Price,
 
     /// Quantity traded
-    pub quantity: Quantity,
+    quantity: Quantity,
 
     /// Side of the taker order
-    pub taker_side: Side,
+    taker_side: Side,
 
-    /// Timestamp when the trade occurred
-    pub timestamp: TimestampMs,
+    /// Timestamp when the trade occurred in milliseconds since epoch
+    timestamp: TimestampMs,
 }
 
 impl Trade {
@@ -58,7 +61,73 @@ impl Trade {
         }
     }
 
-    /// Returns the side of the maker order
+    /// Returns the unique trade identifier.
+    #[must_use]
+    pub fn trade_id(&self) -> Id {
+        self.trade_id
+    }
+
+    /// Returns the taker (aggressive) order identifier.
+    #[must_use]
+    pub fn taker_order_id(&self) -> Id {
+        self.taker_order_id
+    }
+
+    /// Returns the maker (passive) order identifier.
+    #[must_use]
+    pub fn maker_order_id(&self) -> Id {
+        self.maker_order_id
+    }
+
+    /// Returns the trade price.
+    #[must_use]
+    pub fn price(&self) -> Price {
+        self.price
+    }
+
+    /// Returns the traded quantity.
+    #[must_use]
+    pub fn quantity(&self) -> Quantity {
+        self.quantity
+    }
+
+    /// Returns the side of the taker order.
+    #[must_use]
+    pub fn taker_side(&self) -> Side {
+        self.taker_side
+    }
+
+    /// Returns the trade timestamp in milliseconds since epoch.
+    #[must_use]
+    pub fn timestamp(&self) -> TimestampMs {
+        self.timestamp
+    }
+
+    /// Creates a trade with an explicit timestamp.
+    ///
+    /// Intended for deserialization and testing where the timestamp is already known.
+    #[must_use]
+    pub fn with_timestamp(
+        trade_id: Id,
+        taker_order_id: Id,
+        maker_order_id: Id,
+        price: Price,
+        quantity: Quantity,
+        taker_side: Side,
+        timestamp: TimestampMs,
+    ) -> Self {
+        Self {
+            trade_id,
+            taker_order_id,
+            maker_order_id,
+            price,
+            quantity,
+            taker_side,
+            timestamp,
+        }
+    }
+
+    /// Returns the side of the maker order.
     #[must_use]
     pub fn maker_side(&self) -> Side {
         match self.taker_side {

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -41,13 +41,16 @@ impl PriceLevel {
     pub fn from_snapshot(mut snapshot: PriceLevelSnapshot) -> Result<Self, PriceLevelError> {
         snapshot.refresh_aggregates()?;
 
-        let order_count = snapshot.orders.len();
-        let queue = OrderQueue::from(snapshot.orders.clone());
+        let order_count = snapshot.orders().len();
+        let visible_quantity = snapshot.visible_quantity();
+        let hidden_quantity = snapshot.hidden_quantity();
+        let price = snapshot.price();
+        let queue = OrderQueue::from(snapshot.into_orders());
 
         Ok(Self {
-            price: snapshot.price,
-            visible_quantity: AtomicU64::new(snapshot.visible_quantity),
-            hidden_quantity: AtomicU64::new(snapshot.hidden_quantity),
+            price,
+            visible_quantity: AtomicU64::new(visible_quantity),
+            hidden_quantity: AtomicU64::new(hidden_quantity),
             order_count: AtomicUsize::new(order_count),
             orders: queue,
             stats: Arc::new(PriceLevelStatistics::new()),
@@ -268,8 +271,7 @@ impl PriceLevel {
             }
         }
 
-        result.remaining_quantity = remaining;
-        result.is_complete = remaining == 0;
+        result.finalize(remaining);
 
         result
     }
@@ -277,13 +279,13 @@ impl PriceLevel {
     /// Create a snapshot of the current price level state
     #[must_use]
     pub fn snapshot(&self) -> PriceLevelSnapshot {
-        PriceLevelSnapshot {
-            price: self.price,
-            visible_quantity: self.visible_quantity(),
-            hidden_quantity: self.hidden_quantity(),
-            order_count: self.order_count(),
-            orders: self.snapshot_orders(),
-        }
+        PriceLevelSnapshot::from_raw_parts(
+            self.price,
+            self.visible_quantity(),
+            self.hidden_quantity(),
+            self.order_count(),
+            self.snapshot_orders(),
+        )
     }
 
     /// Serialize the current price level state into a checksum-protected snapshot package.
@@ -517,13 +519,16 @@ impl From<&PriceLevelSnapshot> for PriceLevel {
         let mut snapshot = value.clone();
         let _ = snapshot.refresh_aggregates();
 
-        let order_count = snapshot.orders.len();
-        let queue = OrderQueue::from(snapshot.orders.clone());
+        let order_count = snapshot.orders().len();
+        let visible_quantity = snapshot.visible_quantity();
+        let hidden_quantity = snapshot.hidden_quantity();
+        let price = snapshot.price();
+        let queue = OrderQueue::from(snapshot.into_orders());
 
         Self {
-            price: snapshot.price,
-            visible_quantity: AtomicU64::new(snapshot.visible_quantity),
-            hidden_quantity: AtomicU64::new(snapshot.hidden_quantity),
+            price,
+            visible_quantity: AtomicU64::new(visible_quantity),
+            hidden_quantity: AtomicU64::new(hidden_quantity),
             order_count: AtomicUsize::new(order_count),
             orders: queue,
             stats: Arc::new(PriceLevelStatistics::new()),

--- a/src/price_level/snapshot.rs
+++ b/src/price_level/snapshot.rs
@@ -14,19 +14,19 @@ use std::sync::Arc;
 #[derive(Debug, Default, Clone)]
 pub struct PriceLevelSnapshot {
     /// The price of this level.
-    pub price: u128,
-    /// Total visible quantity at this level. This represents the sum of the visible quantities of all orders at this price level.
-    pub visible_quantity: u64,
-    /// Total hidden quantity at this level. This represents the sum of the hidden quantities of all orders at this price level.
-    pub hidden_quantity: u64,
+    price: u128,
+    /// Total visible quantity at this level in the smallest unit.
+    visible_quantity: u64,
+    /// Total hidden quantity at this level in the smallest unit.
+    hidden_quantity: u64,
     /// Number of orders at this level.
-    pub order_count: usize,
-    /// Orders at this level.  This is a vector of `Arc<OrderType<()>>` representing each individual order at this price level.
-    pub orders: Vec<Arc<OrderType<()>>>,
+    order_count: usize,
+    /// Orders at this level.
+    orders: Vec<Arc<OrderType<()>>>,
 }
 
 impl PriceLevelSnapshot {
-    /// Create a new empty snapshot
+    /// Create a new empty snapshot at the given price.
     #[must_use]
     pub fn new(price: u128) -> Self {
         Self {
@@ -38,7 +38,80 @@ impl PriceLevelSnapshot {
         }
     }
 
-    /// Get the total quantity (visible + hidden) at this price level
+    /// Creates a snapshot populated with orders, computing aggregates automatically.
+    pub fn with_orders(
+        price: u128,
+        orders: Vec<Arc<OrderType<()>>>,
+    ) -> Result<Self, PriceLevelError> {
+        let mut snapshot = Self {
+            price,
+            visible_quantity: 0,
+            hidden_quantity: 0,
+            order_count: 0,
+            orders,
+        };
+        snapshot.refresh_aggregates()?;
+        Ok(snapshot)
+    }
+
+    /// Returns the price of this level.
+    #[must_use]
+    pub fn price(&self) -> u128 {
+        self.price
+    }
+
+    /// Returns the total visible quantity.
+    #[must_use]
+    pub fn visible_quantity(&self) -> u64 {
+        self.visible_quantity
+    }
+
+    /// Returns the total hidden quantity.
+    #[must_use]
+    pub fn hidden_quantity(&self) -> u64 {
+        self.hidden_quantity
+    }
+
+    /// Returns the number of orders.
+    #[must_use]
+    pub fn order_count(&self) -> usize {
+        self.order_count
+    }
+
+    /// Returns a reference to the orders in this snapshot.
+    #[must_use]
+    pub fn orders(&self) -> &[Arc<OrderType<()>>] {
+        &self.orders
+    }
+
+    /// Consumes the snapshot and returns the inner orders vector.
+    #[must_use]
+    pub fn into_orders(self) -> Vec<Arc<OrderType<()>>> {
+        self.orders
+    }
+
+    /// Constructs a snapshot with pre-computed aggregates.
+    ///
+    /// This is intended for internal crate use where the caller has already
+    /// computed the aggregate values (e.g., from atomic counters).
+    #[must_use]
+    pub(crate) fn from_raw_parts(
+        price: u128,
+        visible_quantity: u64,
+        hidden_quantity: u64,
+        order_count: usize,
+        orders: Vec<Arc<OrderType<()>>>,
+    ) -> Self {
+        Self {
+            price,
+            visible_quantity,
+            hidden_quantity,
+            order_count,
+            orders,
+        }
+    }
+
+    /// Get the total quantity (visible + hidden) at this price level.
     pub fn total_quantity(&self) -> Result<u64, PriceLevelError> {
         self.visible_quantity
             .checked_add(self.hidden_quantity)
@@ -84,14 +157,37 @@ impl PriceLevelSnapshot {
 pub const SNAPSHOT_FORMAT_VERSION: u32 = 1;
 
 /// Serialized representation of a price level snapshot including checksum validation metadata.
+///
+/// All fields are private to protect checksum integrity.
+/// Use the provided accessor methods to read package data.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PriceLevelSnapshotPackage {
     /// Version of the serialized snapshot schema to support future migrations.
-    pub version: u32,
+    version: u32,
     /// Captured snapshot data.
-    pub snapshot: PriceLevelSnapshot,
+    snapshot: PriceLevelSnapshot,
     /// Hex-encoded checksum used to validate the snapshot integrity.
-    pub checksum: String,
+    checksum: String,
+}
+
+impl PriceLevelSnapshotPackage {
+    /// Returns the schema version of this package.
+    #[must_use]
+    pub fn version(&self) -> u32 {
+        self.version
+    }
+
+    /// Returns a reference to the contained snapshot.
+    #[must_use]
+    pub fn snapshot(&self) -> &PriceLevelSnapshot {
+        &self.snapshot
+    }
+
+    /// Returns the hex-encoded checksum.
+    #[must_use]
+    pub fn checksum(&self) -> &str {
+        &self.checksum
+    }
 }
 
 impl PriceLevelSnapshotPackage {

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -2,6 +2,7 @@
 mod tests {
     use crate::errors::PriceLevelError;
     use crate::orders::{Hash32, Id, OrderType, OrderUpdate, PegReferenceType, Side, TimeInForce};
+    use crate::price_level::PriceLevelSnapshotPackage;
     use crate::price_level::level::{PriceLevel, PriceLevelData};
     use crate::price_level::snapshot::SNAPSHOT_FORMAT_VERSION;
     use crate::utils::{Price, Quantity, TimestampMs};
@@ -40,7 +41,7 @@ mod tests {
             .snapshot_package()
             .expect("Failed to create snapshot package");
 
-        assert_eq!(package.version, SNAPSHOT_FORMAT_VERSION);
+        assert_eq!(package.version(), SNAPSHOT_FORMAT_VERSION);
         package.validate().expect("Snapshot validation failed");
 
         let json = package
@@ -72,15 +73,27 @@ mod tests {
         let price_level = PriceLevel::new(20000);
         price_level.add_order(create_standard_order(1, 20000, 100));
 
-        let mut package = price_level
+        let package = price_level
             .snapshot_package()
             .expect("Failed to create snapshot package");
 
         package.validate().expect("Snapshot validation should pass");
 
-        // Corrupt the checksum and ensure validation fails
-        package.checksum = "deadbeef".to_string();
-        let err = PriceLevel::from_snapshot_package(package)
+        // Corrupt the checksum via JSON manipulation and ensure validation fails
+        let json = package.to_json().expect("Failed to serialize package");
+        let mut value: serde_json::Value =
+            serde_json::from_str(&json).expect("JSON parsing failed");
+        if let Some(obj) = value.as_object_mut() {
+            obj.insert(
+                "checksum".to_string(),
+                serde_json::Value::String("deadbeef".to_string()),
+            );
+        }
+        let tampered_json = serde_json::to_string(&value).expect("JSON serialization failed");
+        let tampered_package = PriceLevelSnapshotPackage::from_json(&tampered_json)
+            .expect("Deserialization should still succeed");
+
+        let err = PriceLevel::from_snapshot_package(tampered_package)
             .expect_err("Restoration should fail due to checksum mismatch");
 
         assert!(matches!(err, PriceLevelError::ChecksumMismatch { .. }));
@@ -445,22 +458,22 @@ mod tests {
         let taker_id = Id::from_u64(999); // market order ID
         let match_result = price_level.match_order(100, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.order_id, taker_id);
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.order_id(), taker_id);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.order_count(), 0);
 
-        assert_eq!(match_result.trades.len(), 1);
-        let transaction = &match_result.trades.as_vec()[0];
-        assert_eq!(transaction.taker_order_id, taker_id);
-        assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, Price::new(10000));
-        assert_eq!(transaction.quantity, Quantity::new(100));
-        assert_eq!(transaction.taker_side, Side::Sell); // Taker is a market order, so it's a sell side opposite of maker
+        assert_eq!(match_result.trades().len(), 1);
+        let transaction = &match_result.trades().as_vec()[0];
+        assert_eq!(transaction.taker_order_id(), taker_id);
+        assert_eq!(transaction.maker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction.price(), Price::new(10000));
+        assert_eq!(transaction.quantity(), Quantity::new(100));
+        assert_eq!(transaction.taker_side(), Side::Sell); // Taker is a market order, so it's a sell side opposite of maker
 
-        assert_eq!(match_result.filled_order_ids.len(), 1);
-        assert_eq!(match_result.filled_order_ids[0], Id::from_u64(1));
+        assert_eq!(match_result.filled_order_ids().len(), 1);
+        assert_eq!(match_result.filled_order_ids()[0], Id::from_u64(1));
 
         // Verify stats
         assert_eq!(price_level.stats().orders_executed(), 1);
@@ -481,23 +494,23 @@ mod tests {
         let match_result = price_level.match_order(60, taker_id, &transaction_id_generator);
 
         // Verificar el resultado de matching
-        assert_eq!(match_result.order_id, taker_id);
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.order_id(), taker_id);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 40);
         assert_eq!(price_level.order_count(), 1);
 
         // Verificar las transacciones generadas
-        assert_eq!(match_result.trades.len(), 1);
-        let transaction = &match_result.trades.as_vec()[0];
-        assert_eq!(transaction.taker_order_id, taker_id);
-        assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, Price::new(10000));
-        assert_eq!(transaction.quantity, Quantity::new(60));
-        assert_eq!(transaction.taker_side, Side::Sell);
+        assert_eq!(match_result.trades().len(), 1);
+        let transaction = &match_result.trades().as_vec()[0];
+        assert_eq!(transaction.taker_order_id(), taker_id);
+        assert_eq!(transaction.maker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction.price(), Price::new(10000));
+        assert_eq!(transaction.quantity(), Quantity::new(60));
+        assert_eq!(transaction.taker_side(), Side::Sell);
 
         // Verificar que no hay órdenes completadas
-        assert_eq!(match_result.filled_order_ids.len(), 0);
+        assert_eq!(match_result.filled_order_ids().len(), 0);
 
         // Verify stats
         assert_eq!(price_level.stats().orders_executed(), 1);
@@ -516,21 +529,21 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(150, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.order_id, taker_id);
-        assert_eq!(match_result.remaining_quantity, 50); // 150 - 100 = 50 remaining
-        assert!(!match_result.is_complete);
+        assert_eq!(match_result.order_id(), taker_id);
+        assert_eq!(match_result.remaining_quantity(), 50); // 150 - 100 = 50 remaining
+        assert!(!match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.order_count(), 0);
 
-        assert_eq!(match_result.trades.len(), 1);
-        let transaction = &match_result.trades.as_vec()[0];
-        assert_eq!(transaction.taker_order_id, taker_id);
-        assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, Price::new(10000));
-        assert_eq!(transaction.quantity, Quantity::new(100));
+        assert_eq!(match_result.trades().len(), 1);
+        let transaction = &match_result.trades().as_vec()[0];
+        assert_eq!(transaction.taker_order_id(), taker_id);
+        assert_eq!(transaction.maker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction.price(), Price::new(10000));
+        assert_eq!(transaction.quantity(), Quantity::new(100));
 
-        assert_eq!(match_result.filled_order_ids.len(), 1);
-        assert_eq!(match_result.filled_order_ids[0], Id::from_u64(1));
+        assert_eq!(match_result.filled_order_ids().len(), 1);
+        assert_eq!(match_result.filled_order_ids()[0], Id::from_u64(1));
     }
 
     // ------------------------------------------- ICEBERG ORDERS -------------------------------------------
@@ -553,50 +566,50 @@ mod tests {
         let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
 
         // Assertions to validate the match result.
-        assert_eq!(match_result.order_id, taker_id);
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.order_id(), taker_id);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 50);
         assert_eq!(price_level.hidden_quantity(), 50); // Hidden quantity reduced
         assert_eq!(price_level.order_count(), 1);
-        assert_eq!(match_result.trades.len(), 1);
+        assert_eq!(match_result.trades().len(), 1);
 
         // Assertions about the generated transaction
-        let transaction = &match_result.trades.as_vec()[0];
-        assert_eq!(transaction.taker_order_id, taker_id);
-        assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, Price::new(10000));
-        assert_eq!(transaction.quantity, Quantity::new(50));
-        assert_eq!(transaction.taker_side, Side::Buy);
-        assert_eq!(match_result.filled_order_ids.len(), 0);
+        let transaction = &match_result.trades().as_vec()[0];
+        assert_eq!(transaction.taker_order_id(), taker_id);
+        assert_eq!(transaction.maker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction.price(), Price::new(10000));
+        assert_eq!(transaction.quantity(), Quantity::new(50));
+        assert_eq!(transaction.taker_side(), Side::Buy);
+        assert_eq!(match_result.filled_order_ids().len(), 0);
 
         // Match another 50 units, which should deplete the visible portion and reveal more.
         let taker_id = Id::from_u64(1000);
         let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 50); // Visible quantity replenished
         assert_eq!(price_level.hidden_quantity(), 0); // Hidden quantity reduced
         assert_eq!(price_level.order_count(), 1);
-        let transaction = &match_result.trades.as_vec()[0];
+        let transaction = &match_result.trades().as_vec()[0];
 
-        assert_eq!(transaction.taker_order_id, taker_id);
-        assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, Price::new(10000));
-        assert_eq!(transaction.quantity, Quantity::new(50));
-        assert_eq!(transaction.taker_side, Side::Buy);
-        assert_eq!(match_result.filled_order_ids.len(), 0);
+        assert_eq!(transaction.taker_order_id(), taker_id);
+        assert_eq!(transaction.maker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction.price(), Price::new(10000));
+        assert_eq!(transaction.quantity(), Quantity::new(50));
+        assert_eq!(transaction.taker_side(), Side::Buy);
+        assert_eq!(match_result.filled_order_ids().len(), 0);
 
         // Match the remaining 50 units (50 visible + 0 hidden).
         let taker_id = Id::from_u64(1001);
         let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.hidden_quantity(), 0);
         assert_eq!(price_level.order_count(), 0);
-        assert_eq!(match_result.filled_order_ids.len(), 1);
-        assert_eq!(match_result.filled_order_ids[0], Id::from_u64(1));
+        assert_eq!(match_result.filled_order_ids().len(), 1);
+        assert_eq!(match_result.filled_order_ids()[0], Id::from_u64(1));
     }
 
     #[test]
@@ -613,52 +626,52 @@ mod tests {
         let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
 
         // Assertions to validate the match result.
-        assert_eq!(match_result.order_id, taker_id);
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.order_id(), taker_id);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 50);
         assert_eq!(price_level.hidden_quantity(), 100); // Hidden quantity reduced
         assert_eq!(price_level.order_count(), 1);
-        assert_eq!(match_result.trades.len(), 1);
+        assert_eq!(match_result.trades().len(), 1);
 
         // Assertions about the generated transaction
-        let transaction = &match_result.trades.as_vec()[0];
-        assert_eq!(transaction.taker_order_id, taker_id);
-        assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, Price::new(10000));
-        assert_eq!(transaction.quantity, Quantity::new(50));
-        assert_eq!(transaction.taker_side, Side::Buy);
-        assert_eq!(match_result.filled_order_ids.len(), 0);
+        let transaction = &match_result.trades().as_vec()[0];
+        assert_eq!(transaction.taker_order_id(), taker_id);
+        assert_eq!(transaction.maker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction.price(), Price::new(10000));
+        assert_eq!(transaction.quantity(), Quantity::new(50));
+        assert_eq!(transaction.taker_side(), Side::Buy);
+        assert_eq!(match_result.filled_order_ids().len(), 0);
 
         // Match another 50 units, which should deplete the visible portion and reveal more.
         let taker_id = Id::from_u64(1000);
         let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 50); // Visible quantity replenished
         assert_eq!(price_level.hidden_quantity(), 50); // Hidden quantity reduced
         assert_eq!(price_level.order_count(), 1);
-        let transaction = &match_result.trades.as_vec()[0];
+        let transaction = &match_result.trades().as_vec()[0];
 
-        assert_eq!(transaction.taker_order_id, taker_id);
-        assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, Price::new(10000));
-        assert_eq!(transaction.quantity, Quantity::new(50));
-        assert_eq!(transaction.taker_side, Side::Buy);
-        assert_eq!(match_result.filled_order_ids.len(), 0);
+        assert_eq!(transaction.taker_order_id(), taker_id);
+        assert_eq!(transaction.maker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction.price(), Price::new(10000));
+        assert_eq!(transaction.quantity(), Quantity::new(50));
+        assert_eq!(transaction.taker_side(), Side::Buy);
+        assert_eq!(match_result.filled_order_ids().len(), 0);
 
         // Match the remaining 50 units (50 visible + 0 hidden).
         let taker_id = Id::from_u64(1001);
 
         // This should match the remaining visible quantity and deplete the hidden quantity.
         let match_result = price_level.match_order(150, taker_id, &transaction_id_generator);
-        assert_eq!(match_result.remaining_quantity, 50);
-        assert!(!match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 50);
+        assert!(!match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.hidden_quantity(), 0);
         assert_eq!(price_level.order_count(), 0);
-        assert_eq!(match_result.filled_order_ids.len(), 1);
-        assert_eq!(match_result.filled_order_ids[0], Id::from_u64(1));
+        assert_eq!(match_result.filled_order_ids().len(), 1);
+        assert_eq!(match_result.filled_order_ids()[0], Id::from_u64(1));
     }
 
     #[test]
@@ -673,8 +686,8 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(30, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 20);
         assert_eq!(price_level.hidden_quantity(), 150); // Hidden unchanged
         assert_eq!(price_level.order_count(), 1);
@@ -698,8 +711,8 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         // The order should be removed since the visible quantity reached 0 and auto_replenish is false
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.hidden_quantity(), 0);
@@ -722,8 +735,8 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         // The order should be replenished with the default amount
         assert_eq!(
             price_level.visible_quantity(),
@@ -752,8 +765,8 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(25, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 25); // 50 - 25 = 25
         assert_eq!(price_level.hidden_quantity(), 150); // No change to hidden quantity
 
@@ -761,8 +774,8 @@ mod tests {
         let taker_id = Id::from_u64(1000);
         let match_result = price_level.match_order(10, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         // No automatic replenishment because auto_replenish is false
         assert_eq!(price_level.visible_quantity(), 15); // 25 - 10 = 15, no replenishment
         assert_eq!(price_level.hidden_quantity(), 150); // No change to hidden quantity
@@ -793,8 +806,8 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         // The order should be replenished with the custom amount
         assert_eq!(price_level.visible_quantity(), custom_amount);
         assert_eq!(price_level.hidden_quantity(), 150 - custom_amount);
@@ -817,8 +830,8 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(49, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         // 1 visible unit will remain, which equals the safe threshold (1), so no replenishment occurs
         assert_eq!(price_level.visible_quantity(), 1);
         assert_eq!(price_level.hidden_quantity(), 150);
@@ -840,8 +853,8 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         // The order should be removed from the price level
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.hidden_quantity(), 0);
@@ -863,8 +876,8 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         // The order should be removed from the price level
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.hidden_quantity(), 0);
@@ -886,8 +899,8 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(25, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 25); // 50 - 25 = 25
         assert_eq!(price_level.hidden_quantity(), 150); // No replenishment yet
 
@@ -895,8 +908,8 @@ mod tests {
         let taker_id = Id::from_u64(1000);
         let match_result = price_level.match_order(10, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         // No automatic replenishment because auto_replenish is false
         assert_eq!(price_level.visible_quantity(), 15); // 25 - 10 = 15
         assert_eq!(price_level.hidden_quantity(), 150); // No change to hidden quantity
@@ -922,69 +935,69 @@ mod tests {
         let match_result = price_level.match_order(80, taker_id, &transaction_id_generator);
 
         // Validate the match result
-        assert_eq!(match_result.order_id, taker_id);
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.order_id(), taker_id);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 20); // 100 - 80 = 20
         assert_eq!(price_level.hidden_quantity(), 100); // Hidden quantity unchanged (still above threshold)
         assert_eq!(price_level.order_count(), 1);
-        assert_eq!(match_result.trades.len(), 1);
+        assert_eq!(match_result.trades().len(), 1);
 
         // Validate the transaction details
-        let transaction = &match_result.trades.as_vec()[0];
-        assert_eq!(transaction.taker_order_id, taker_id);
-        assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, Price::new(10000));
-        assert_eq!(transaction.quantity, Quantity::new(80));
-        assert_eq!(transaction.taker_side, Side::Buy);
-        assert_eq!(match_result.filled_order_ids.len(), 0);
+        let transaction = &match_result.trades().as_vec()[0];
+        assert_eq!(transaction.taker_order_id(), taker_id);
+        assert_eq!(transaction.maker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction.price(), Price::new(10000));
+        assert_eq!(transaction.quantity(), Quantity::new(80));
+        assert_eq!(transaction.taker_side(), Side::Buy);
+        assert_eq!(match_result.filled_order_ids().len(), 0);
 
         // Match 10 more units, which will take us below the replenish threshold
         let taker_id = Id::from_u64(1000);
         let match_result = price_level.match_order(10, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 90); // 20 - 10 = 10, then replenished to 90 (10 + 80)
         assert_eq!(price_level.hidden_quantity(), 20); // 100 - 80 (replenish amount) = 20
         assert_eq!(price_level.order_count(), 1);
 
-        let transaction = &match_result.trades.as_vec()[0];
-        assert_eq!(transaction.taker_order_id, taker_id);
-        assert_eq!(transaction.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction.price, Price::new(10000));
-        assert_eq!(transaction.quantity, Quantity::new(10));
-        assert_eq!(transaction.taker_side, Side::Buy);
-        assert_eq!(match_result.filled_order_ids.len(), 0);
+        let transaction = &match_result.trades().as_vec()[0];
+        assert_eq!(transaction.taker_order_id(), taker_id);
+        assert_eq!(transaction.maker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction.price(), Price::new(10000));
+        assert_eq!(transaction.quantity(), Quantity::new(10));
+        assert_eq!(transaction.taker_side(), Side::Buy);
+        assert_eq!(match_result.filled_order_ids().len(), 0);
 
         // Match with a larger amount than what's available
         let taker_id = Id::from_u64(1001);
         let match_result = price_level.match_order(150, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 40); // 150 - 90 - 20 = 40
-        assert!(!match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 40); // 150 - 90 - 20 = 40
+        assert!(!match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.hidden_quantity(), 0);
         assert_eq!(price_level.order_count(), 0);
-        assert_eq!(match_result.filled_order_ids.len(), 1);
-        assert_eq!(match_result.filled_order_ids[0], Id::from_u64(1));
+        assert_eq!(match_result.filled_order_ids().len(), 1);
+        assert_eq!(match_result.filled_order_ids()[0], Id::from_u64(1));
 
         // Verify the correct number and sizes of transactions
-        assert_eq!(match_result.trades.len(), 2); // One for visible, one for hidden
+        assert_eq!(match_result.trades().len(), 2); // One for visible, one for hidden
 
-        let transaction1 = &match_result.trades.as_vec()[0];
-        assert_eq!(transaction1.taker_order_id, taker_id);
-        assert_eq!(transaction1.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction1.price, Price::new(10000));
-        assert_eq!(transaction1.quantity, Quantity::new(90)); // First consumes all visible
-        assert_eq!(transaction1.taker_side, Side::Buy);
+        let transaction1 = &match_result.trades().as_vec()[0];
+        assert_eq!(transaction1.taker_order_id(), taker_id);
+        assert_eq!(transaction1.maker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction1.price(), Price::new(10000));
+        assert_eq!(transaction1.quantity(), Quantity::new(90)); // First consumes all visible
+        assert_eq!(transaction1.taker_side(), Side::Buy);
 
-        let transaction2 = &match_result.trades.as_vec()[1];
-        assert_eq!(transaction2.taker_order_id, taker_id);
-        assert_eq!(transaction2.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction2.price, Price::new(10000));
-        assert_eq!(transaction2.quantity, Quantity::new(20)); // Then consumes all hidden
-        assert_eq!(transaction2.taker_side, Side::Buy);
+        let transaction2 = &match_result.trades().as_vec()[1];
+        assert_eq!(transaction2.taker_order_id(), taker_id);
+        assert_eq!(transaction2.maker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction2.price(), Price::new(10000));
+        assert_eq!(transaction2.quantity(), Quantity::new(20)); // Then consumes all hidden
+        assert_eq!(transaction2.taker_side(), Side::Buy);
     }
 
     // ------------------------------------------- POST-ONLY, TRAILING STOP, PEGGED, MARKET TO LIMIT, FOK, IOC, GTD ORDERS -------------------------------------------
@@ -1001,8 +1014,8 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(60, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 40);
         assert_eq!(price_level.order_count(), 1);
     }
@@ -1019,8 +1032,8 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(100, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.order_count(), 0);
     }
@@ -1037,8 +1050,8 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 50);
         assert_eq!(price_level.order_count(), 1);
     }
@@ -1055,8 +1068,8 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(100, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.order_count(), 0);
     }
@@ -1073,8 +1086,8 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(100, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.order_count(), 0);
     }
@@ -1091,8 +1104,8 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 50);
         assert_eq!(price_level.order_count(), 1);
     }
@@ -1109,8 +1122,8 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(100, taker_id, &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.order_count(), 0);
     }
@@ -1130,32 +1143,32 @@ mod tests {
         let match_result = price_level.match_order(140, taker_id, &transaction_id_generator);
 
         // Verificar el resultado de matching
-        assert_eq!(match_result.order_id, taker_id);
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.order_id(), taker_id);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 10); // 25 - (140 - 50 - 75) = 10
         assert_eq!(price_level.order_count(), 1);
 
-        assert_eq!(match_result.trades.len(), 3);
+        assert_eq!(match_result.trades().len(), 3);
 
-        let transaction1 = &match_result.trades.as_vec()[0];
-        assert_eq!(transaction1.taker_order_id, taker_id);
-        assert_eq!(transaction1.maker_order_id, Id::from_u64(1));
-        assert_eq!(transaction1.quantity, Quantity::new(50));
+        let transaction1 = &match_result.trades().as_vec()[0];
+        assert_eq!(transaction1.taker_order_id(), taker_id);
+        assert_eq!(transaction1.maker_order_id(), Id::from_u64(1));
+        assert_eq!(transaction1.quantity(), Quantity::new(50));
 
-        let transaction2 = &match_result.trades.as_vec()[1];
-        assert_eq!(transaction2.taker_order_id, taker_id);
-        assert_eq!(transaction2.maker_order_id, Id::from_u64(2));
-        assert_eq!(transaction2.quantity, Quantity::new(75));
+        let transaction2 = &match_result.trades().as_vec()[1];
+        assert_eq!(transaction2.taker_order_id(), taker_id);
+        assert_eq!(transaction2.maker_order_id(), Id::from_u64(2));
+        assert_eq!(transaction2.quantity(), Quantity::new(75));
 
-        let transaction3 = &match_result.trades.as_vec()[2];
-        assert_eq!(transaction3.taker_order_id, taker_id);
-        assert_eq!(transaction3.maker_order_id, Id::from_u64(3));
-        assert_eq!(transaction3.quantity, Quantity::new(15));
+        let transaction3 = &match_result.trades().as_vec()[2];
+        assert_eq!(transaction3.taker_order_id(), taker_id);
+        assert_eq!(transaction3.maker_order_id(), Id::from_u64(3));
+        assert_eq!(transaction3.quantity(), Quantity::new(15));
 
-        assert_eq!(match_result.filled_order_ids.len(), 2);
-        assert!(match_result.filled_order_ids.contains(&Id::from_u64(1)));
-        assert!(match_result.filled_order_ids.contains(&Id::from_u64(2)));
+        assert_eq!(match_result.filled_order_ids().len(), 2);
+        assert!(match_result.filled_order_ids().contains(&Id::from_u64(1)));
+        assert!(match_result.filled_order_ids().contains(&Id::from_u64(2)));
 
         let orders = price_level.snapshot_orders();
         assert_eq!(orders.len(), 1);
@@ -1176,19 +1189,19 @@ mod tests {
         let snapshot = price_level.snapshot();
 
         // Verify snapshot data
-        assert_eq!(snapshot.price, 10000);
-        assert_eq!(snapshot.visible_quantity, 150); // 100 + 50
-        assert_eq!(snapshot.hidden_quantity, 0);
-        assert_eq!(snapshot.order_count, 2);
-        assert_eq!(snapshot.orders.len(), 2);
+        assert_eq!(snapshot.price(), 10000);
+        assert_eq!(snapshot.visible_quantity(), 150); // 100 + 50
+        assert_eq!(snapshot.hidden_quantity(), 0);
+        assert_eq!(snapshot.order_count(), 2);
+        assert_eq!(snapshot.orders().len(), 2);
 
         // Verify that orders in the snapshot match those in the price level
         let orders_from_level = price_level.snapshot_orders();
-        assert_eq!(snapshot.orders.len(), orders_from_level.len());
+        assert_eq!(snapshot.orders().len(), orders_from_level.len());
 
         // Check that all orders from the price level are in the snapshot
         for order in orders_from_level {
-            let found = snapshot.orders.iter().any(|o| o.id() == order.id());
+            let found = snapshot.orders().iter().any(|o| o.id() == order.id());
             assert!(found, "Order with ID {} not found in snapshot", order.id());
         }
     }
@@ -1554,8 +1567,8 @@ mod tests {
         let match_result =
             price_level.match_order(100, Id::from_u64(999), &transaction_id_generator);
 
-        assert_eq!(match_result.remaining_quantity, 0);
-        assert!(match_result.is_complete);
+        assert_eq!(match_result.remaining_quantity(), 0);
+        assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 100); // 200 - 100 = 100
         assert_eq!(price_level.order_count(), 1);
     }

--- a/src/price_level/tests/snapshot.rs
+++ b/src/price_level/tests/snapshot.rs
@@ -37,14 +37,13 @@ mod tests {
 
     #[test]
     fn test_snapshot_package_roundtrip() {
-        let mut snapshot = PriceLevelSnapshot::new(42);
-        snapshot.orders = create_sample_orders();
-        assert!(snapshot.refresh_aggregates().is_ok());
+        let snapshot = PriceLevelSnapshot::with_orders(42, create_sample_orders())
+            .expect("Failed to create snapshot with orders");
 
         let package =
             PriceLevelSnapshotPackage::new(snapshot.clone()).expect("Failed to create package");
 
-        assert_eq!(package.version, SNAPSHOT_FORMAT_VERSION);
+        assert_eq!(package.version(), SNAPSHOT_FORMAT_VERSION);
         package.validate().expect("Package validation failed");
 
         let json = package.to_json().expect("Failed to serialize package");
@@ -59,21 +58,23 @@ mod tests {
             .into_snapshot()
             .expect("Snapshot extraction failed");
 
-        assert_eq!(restored_snapshot.price, snapshot.price);
-        assert_eq!(restored_snapshot.order_count, snapshot.order_count);
+        assert_eq!(restored_snapshot.price(), snapshot.price());
+        assert_eq!(restored_snapshot.order_count(), snapshot.order_count());
         assert_eq!(
-            restored_snapshot.visible_quantity,
-            snapshot.visible_quantity
+            restored_snapshot.visible_quantity(),
+            snapshot.visible_quantity()
         );
-        assert_eq!(restored_snapshot.hidden_quantity, snapshot.hidden_quantity);
-        assert_eq!(restored_snapshot.orders.len(), snapshot.orders.len());
+        assert_eq!(
+            restored_snapshot.hidden_quantity(),
+            snapshot.hidden_quantity()
+        );
+        assert_eq!(restored_snapshot.orders().len(), snapshot.orders().len());
     }
 
     #[test]
     fn test_snapshot_package_checksum_mismatch() {
-        let mut snapshot = PriceLevelSnapshot::new(99);
-        snapshot.orders = create_sample_orders();
-        assert!(snapshot.refresh_aggregates().is_ok());
+        let snapshot = PriceLevelSnapshot::with_orders(99, create_sample_orders())
+            .expect("Failed to create snapshot with orders");
 
         let package = PriceLevelSnapshotPackage::new(snapshot).expect("Failed to create package");
         let json = package.to_json().expect("Failed to serialize package");
@@ -100,37 +101,34 @@ mod tests {
     #[test]
     fn test_new() {
         let snapshot = PriceLevelSnapshot::new(1000);
-        assert_eq!(snapshot.price, 1000);
-        assert_eq!(snapshot.visible_quantity, 0);
-        assert_eq!(snapshot.hidden_quantity, 0);
-        assert_eq!(snapshot.order_count, 0);
-        assert!(snapshot.orders.is_empty());
+        assert_eq!(snapshot.price(), 1000);
+        assert_eq!(snapshot.visible_quantity(), 0);
+        assert_eq!(snapshot.hidden_quantity(), 0);
+        assert_eq!(snapshot.order_count(), 0);
+        assert!(snapshot.orders().is_empty());
     }
 
     #[test]
     fn test_default() {
         let snapshot = PriceLevelSnapshot::default();
-        assert_eq!(snapshot.price, 0);
-        assert_eq!(snapshot.visible_quantity, 0);
-        assert_eq!(snapshot.hidden_quantity, 0);
-        assert_eq!(snapshot.order_count, 0);
-        assert!(snapshot.orders.is_empty());
+        assert_eq!(snapshot.price(), 0);
+        assert_eq!(snapshot.visible_quantity(), 0);
+        assert_eq!(snapshot.hidden_quantity(), 0);
+        assert_eq!(snapshot.order_count(), 0);
+        assert!(snapshot.orders().is_empty());
     }
 
     #[test]
     fn test_total_quantity() {
-        let mut snapshot = PriceLevelSnapshot::new(1000);
-        snapshot.visible_quantity = 50;
-        snapshot.hidden_quantity = 150;
+        let snapshot = PriceLevelSnapshot::from_raw_parts(1000, 50, 150, 0, Vec::new());
         assert!(matches!(snapshot.total_quantity(), Ok(200)));
     }
 
     #[test]
     fn test_iter_orders() {
-        let mut snapshot = PriceLevelSnapshot::new(1000);
         let orders = create_sample_orders();
-        snapshot.orders = orders.clone();
-        snapshot.order_count = orders.len();
+        let order_count = orders.len();
+        let snapshot = PriceLevelSnapshot::from_raw_parts(1000, 0, 0, order_count, orders);
 
         let collected: Vec<_> = snapshot.iter_orders().collect();
         assert_eq!(collected.len(), 2);
@@ -152,26 +150,19 @@ mod tests {
 
     #[test]
     fn test_clone() {
-        let mut original = PriceLevelSnapshot::new(1000);
-        original.visible_quantity = 50;
-        original.hidden_quantity = 150;
-        original.order_count = 2;
-        original.orders = create_sample_orders();
+        let original = PriceLevelSnapshot::from_raw_parts(1000, 50, 150, 2, create_sample_orders());
 
         let cloned = original.clone();
-        assert_eq!(cloned.price, 1000);
-        assert_eq!(cloned.visible_quantity, 50);
-        assert_eq!(cloned.hidden_quantity, 150);
-        assert_eq!(cloned.order_count, 2);
-        assert_eq!(cloned.orders.len(), 2);
+        assert_eq!(cloned.price(), 1000);
+        assert_eq!(cloned.visible_quantity(), 50);
+        assert_eq!(cloned.hidden_quantity(), 150);
+        assert_eq!(cloned.order_count(), 2);
+        assert_eq!(cloned.orders().len(), 2);
     }
 
     #[test]
     fn test_display() {
-        let mut snapshot = PriceLevelSnapshot::new(1000);
-        snapshot.visible_quantity = 50;
-        snapshot.hidden_quantity = 150;
-        snapshot.order_count = 2;
+        let snapshot = PriceLevelSnapshot::from_raw_parts(1000, 50, 150, 2, Vec::new());
 
         let display_str = snapshot.to_string();
         assert!(display_str.contains("price=1000"));
@@ -186,11 +177,11 @@ mod tests {
             "PriceLevelSnapshot:price=1000;visible_quantity=50;hidden_quantity=150;order_count=2";
         let snapshot = PriceLevelSnapshot::from_str(input).unwrap();
 
-        assert_eq!(snapshot.price, 1000);
-        assert_eq!(snapshot.visible_quantity, 50);
-        assert_eq!(snapshot.hidden_quantity, 150);
-        assert_eq!(snapshot.order_count, 2);
-        assert!(snapshot.orders.is_empty()); // Orders can't be parsed from string representation
+        assert_eq!(snapshot.price(), 1000);
+        assert_eq!(snapshot.visible_quantity(), 50);
+        assert_eq!(snapshot.hidden_quantity(), 150);
+        assert_eq!(snapshot.order_count(), 2);
+        assert!(snapshot.orders().is_empty()); // Orders can't be parsed from string representation
     }
 
     #[test]
@@ -216,18 +207,15 @@ mod tests {
 
     #[test]
     fn test_roundtrip_display_fromstr() {
-        let mut original = PriceLevelSnapshot::new(1000);
-        original.visible_quantity = 50;
-        original.hidden_quantity = 150;
-        original.order_count = 2;
+        let original = PriceLevelSnapshot::from_raw_parts(1000, 50, 150, 2, Vec::new());
 
         let string_representation = original.to_string();
         let parsed = PriceLevelSnapshot::from_str(&string_representation).unwrap();
 
-        assert_eq!(parsed.price, original.price);
-        assert_eq!(parsed.visible_quantity, original.visible_quantity);
-        assert_eq!(parsed.hidden_quantity, original.hidden_quantity);
-        assert_eq!(parsed.order_count, original.order_count);
+        assert_eq!(parsed.price(), original.price());
+        assert_eq!(parsed.visible_quantity(), original.visible_quantity());
+        assert_eq!(parsed.hidden_quantity(), original.hidden_quantity());
+        assert_eq!(parsed.order_count(), original.order_count());
     }
 
     // In price_level/snapshot.rs test module or in a separate test file
@@ -235,10 +223,7 @@ mod tests {
     #[test]
     fn test_snapshot_serialization_fields() {
         // Create a snapshot with specific field values
-        let mut snapshot = PriceLevelSnapshot::new(10000);
-        snapshot.visible_quantity = 200;
-        snapshot.hidden_quantity = 300;
-        snapshot.order_count = 5;
+        let snapshot = PriceLevelSnapshot::from_raw_parts(10000, 200, 300, 5, Vec::new());
 
         // Add some orders (empty for now, we'll test orders separately)
 
@@ -287,11 +272,11 @@ mod tests {
 
         let snapshot: PriceLevelSnapshot = serde_json::from_str(json).unwrap();
 
-        assert_eq!(snapshot.price, 10000);
-        assert_eq!(snapshot.visible_quantity, 200);
-        assert_eq!(snapshot.hidden_quantity, 300);
-        assert_eq!(snapshot.order_count, 5);
-        assert!(snapshot.orders.is_empty());
+        assert_eq!(snapshot.price(), 10000);
+        assert_eq!(snapshot.visible_quantity(), 200);
+        assert_eq!(snapshot.hidden_quantity(), 300);
+        assert_eq!(snapshot.order_count(), 5);
+        assert!(snapshot.orders().is_empty());
     }
 
     #[test]
@@ -328,17 +313,11 @@ mod tests {
             }
         }
         // Create a snapshot with orders
-        let mut snapshot = PriceLevelSnapshot::new(10000);
-        snapshot.visible_quantity = 150;
-        snapshot.hidden_quantity = 250;
-        snapshot.order_count = 2;
-
         let orders = vec![
             Arc::new(create_standard_order(1, 10000u128, 100)),
             Arc::new(create_iceberg_order(2, 10000u128, 50, 250)),
         ];
-
-        snapshot.orders = orders;
+        let snapshot = PriceLevelSnapshot::from_raw_parts(10000, 150, 250, 2, orders);
 
         // Serialize to JSON
         let serialized = serde_json::to_string(&snapshot).unwrap();
@@ -355,14 +334,14 @@ mod tests {
         // Deserialize back
         let deserialized: PriceLevelSnapshot = serde_json::from_str(&serialized).unwrap();
 
-        assert_eq!(deserialized.price, 10000);
-        assert_eq!(deserialized.visible_quantity, 150);
-        assert_eq!(deserialized.hidden_quantity, 250);
-        assert_eq!(deserialized.order_count, 2);
-        assert_eq!(deserialized.orders.len(), 2);
+        assert_eq!(deserialized.price(), 10000);
+        assert_eq!(deserialized.visible_quantity(), 150);
+        assert_eq!(deserialized.hidden_quantity(), 250);
+        assert_eq!(deserialized.order_count(), 2);
+        assert_eq!(deserialized.orders().len(), 2);
 
         // Verify order types
-        if let OrderType::Standard { id, quantity, .. } = &*deserialized.orders[0] {
+        if let OrderType::Standard { id, quantity, .. } = &*deserialized.orders()[0] {
             assert_eq!(*id, Id::from_u64(1));
             assert_eq!(*quantity, Quantity::new(100));
         } else {
@@ -374,7 +353,7 @@ mod tests {
             visible_quantity,
             hidden_quantity,
             ..
-        } = &*deserialized.orders[1]
+        } = &*deserialized.orders()[1]
         {
             assert_eq!(*id, Id::from_u64(2));
             assert_eq!(*visible_quantity, Quantity::new(50));
@@ -433,12 +412,13 @@ mod pricelevel_snapshot_serialization_tests {
 
     // Helper function to create a sample snapshot for testing
     fn create_sample_snapshot() -> PriceLevelSnapshot {
-        let mut snapshot = PriceLevelSnapshot::new(1000);
-        snapshot.visible_quantity = 15; // 10 + 5 (first two orders)
-        snapshot.hidden_quantity = 15; // hidden quantity from iceberg order
-        snapshot.order_count = 3;
-        snapshot.orders = create_sample_orders();
-        snapshot
+        PriceLevelSnapshot::from_raw_parts(
+            1000,
+            15, // 10 + 5 (first two orders)
+            15, // hidden quantity from iceberg order
+            3,
+            create_sample_orders(),
+        )
     }
 
     #[test]
@@ -480,16 +460,16 @@ mod pricelevel_snapshot_serialization_tests {
             .expect("Failed to deserialize PriceLevelSnapshot from JSON");
 
         // Verify basic fields
-        assert_eq!(deserialized.price, 1000);
-        assert_eq!(deserialized.visible_quantity, 15);
-        assert_eq!(deserialized.hidden_quantity, 15);
-        assert_eq!(deserialized.order_count, 3);
+        assert_eq!(deserialized.price(), 1000);
+        assert_eq!(deserialized.visible_quantity(), 15);
+        assert_eq!(deserialized.hidden_quantity(), 15);
+        assert_eq!(deserialized.order_count(), 3);
 
         // Verify orders array length
-        assert_eq!(deserialized.orders.len(), 3);
+        assert_eq!(deserialized.orders().len(), 3);
 
         // Check specific order details
-        let standard_order = &deserialized.orders[0];
+        let standard_order = &deserialized.orders()[0];
         match **standard_order {
             OrderType::Standard {
                 id,
@@ -506,7 +486,7 @@ mod pricelevel_snapshot_serialization_tests {
             _ => panic!("Expected Standard order"),
         }
 
-        let iceberg_order = &deserialized.orders[1];
+        let iceberg_order = &deserialized.orders()[1];
         match **iceberg_order {
             OrderType::IcebergOrder {
                 id,
@@ -523,7 +503,7 @@ mod pricelevel_snapshot_serialization_tests {
             _ => panic!("Expected IcebergOrder"),
         }
 
-        let post_only_order = &deserialized.orders[2];
+        let post_only_order = &deserialized.orders()[2];
         match **post_only_order {
             OrderType::<()>::PostOnly {
                 id, quantity, side, ..
@@ -564,13 +544,13 @@ mod pricelevel_snapshot_serialization_tests {
             PriceLevelSnapshot::from_str(input).expect("Failed to parse PriceLevelSnapshot");
 
         // Verify basic fields
-        assert_eq!(snapshot.price, 1000);
-        assert_eq!(snapshot.visible_quantity, 15);
-        assert_eq!(snapshot.hidden_quantity, 15);
-        assert_eq!(snapshot.order_count, 3);
+        assert_eq!(snapshot.price(), 1000);
+        assert_eq!(snapshot.visible_quantity(), 15);
+        assert_eq!(snapshot.hidden_quantity(), 15);
+        assert_eq!(snapshot.order_count(), 3);
 
         // Orders array should be empty when deserialized from string format (per FromStr implementation)
-        assert!(snapshot.orders.is_empty());
+        assert!(snapshot.orders().is_empty());
     }
 
     #[test]
@@ -607,10 +587,7 @@ mod pricelevel_snapshot_serialization_tests {
     #[test]
     fn test_snapshot_string_format_roundtrip() {
         // Create a snapshot with only basic fields (no orders)
-        let mut original = PriceLevelSnapshot::new(1000);
-        original.visible_quantity = 15;
-        original.hidden_quantity = 15;
-        original.order_count = 3;
+        let original = PriceLevelSnapshot::from_raw_parts(1000, 15, 15, 3, Vec::new());
 
         // Convert to string
         let string_representation = original.to_string();
@@ -620,43 +597,43 @@ mod pricelevel_snapshot_serialization_tests {
             .expect("Failed to parse PriceLevelSnapshot");
 
         // Verify all fields match
-        assert_eq!(parsed.price, original.price);
-        assert_eq!(parsed.visible_quantity, original.visible_quantity);
-        assert_eq!(parsed.hidden_quantity, original.hidden_quantity);
-        assert_eq!(parsed.order_count, original.order_count);
+        assert_eq!(parsed.price(), original.price());
+        assert_eq!(parsed.visible_quantity(), original.visible_quantity());
+        assert_eq!(parsed.hidden_quantity(), original.hidden_quantity());
+        assert_eq!(parsed.order_count(), original.order_count());
     }
 
     #[test]
     fn test_snapshot_edge_cases() {
         // Test with zero values
-        let mut snapshot = PriceLevelSnapshot::new(0);
-        snapshot.visible_quantity = 0;
-        snapshot.hidden_quantity = 0;
-        snapshot.order_count = 0;
+        let snapshot = PriceLevelSnapshot::new(0);
 
         let json = serde_json::to_string(&snapshot).expect("Failed to serialize");
         let deserialized: PriceLevelSnapshot =
             serde_json::from_str(&json).expect("Failed to deserialize");
 
-        assert_eq!(deserialized.price, 0);
-        assert_eq!(deserialized.visible_quantity, 0);
-        assert_eq!(deserialized.hidden_quantity, 0);
-        assert_eq!(deserialized.order_count, 0);
+        assert_eq!(deserialized.price(), 0);
+        assert_eq!(deserialized.visible_quantity(), 0);
+        assert_eq!(deserialized.hidden_quantity(), 0);
+        assert_eq!(deserialized.order_count(), 0);
 
         // Test with maximum values
-        let mut snapshot = PriceLevelSnapshot::new(u128::MAX);
-        snapshot.visible_quantity = u64::MAX;
-        snapshot.hidden_quantity = u64::MAX;
-        snapshot.order_count = usize::MAX;
+        let snapshot = PriceLevelSnapshot::from_raw_parts(
+            u128::MAX,
+            u64::MAX,
+            u64::MAX,
+            usize::MAX,
+            Vec::new(),
+        );
 
         let json = serde_json::to_string(&snapshot).expect("Failed to serialize max values");
         let deserialized: PriceLevelSnapshot =
             serde_json::from_str(&json).expect("Failed to deserialize max values");
 
-        assert_eq!(deserialized.price, u128::MAX);
-        assert_eq!(deserialized.visible_quantity, u64::MAX);
-        assert_eq!(deserialized.hidden_quantity, u64::MAX);
-        assert_eq!(deserialized.order_count, usize::MAX);
+        assert_eq!(deserialized.price(), u128::MAX);
+        assert_eq!(deserialized.visible_quantity(), u64::MAX);
+        assert_eq!(deserialized.hidden_quantity(), u64::MAX);
+        assert_eq!(deserialized.order_count(), usize::MAX);
     }
 
     #[test]
@@ -694,27 +671,20 @@ mod pricelevel_snapshot_serialization_tests {
     #[test]
     fn test_snapshot_empty_orders() {
         // Test with an empty orders array
-        let mut snapshot = PriceLevelSnapshot::new(1000);
-        snapshot.visible_quantity = 15;
-        snapshot.hidden_quantity = 15;
-        snapshot.order_count = 0;
-        snapshot.orders = Vec::new();
+        let snapshot = PriceLevelSnapshot::from_raw_parts(1000, 15, 15, 0, Vec::new());
 
         let json = serde_json::to_string(&snapshot).expect("Failed to serialize");
         let deserialized: PriceLevelSnapshot =
             serde_json::from_str(&json).expect("Failed to deserialize");
 
-        assert_eq!(deserialized.price, 1000);
-        assert_eq!(deserialized.orders.len(), 0);
+        assert_eq!(deserialized.price(), 1000);
+        assert_eq!(deserialized.orders().len(), 0);
     }
 
     #[test]
     fn test_snapshot_with_many_order_types() {
         // Create a snapshot with all supported order types
-        let mut snapshot = PriceLevelSnapshot::new(1000);
-
-        // Add sample orders of different types
-        snapshot.orders = vec![
+        let many_orders = vec![
             // Standard order
             Arc::new(OrderType::Standard {
                 id: Id::from_u64(1),
@@ -788,9 +758,13 @@ mod pricelevel_snapshot_serialization_tests {
             }),
         ];
 
-        snapshot.order_count = snapshot.orders.len();
-        snapshot.visible_quantity = 45; // Sum of all visible quantities
-        snapshot.hidden_quantity = 27; // Sum of all hidden quantities
+        let snapshot = PriceLevelSnapshot::from_raw_parts(
+            1000,
+            45, // Sum of all visible quantities
+            27, // Sum of all hidden quantities
+            many_orders.len(),
+            many_orders,
+        );
 
         // Serialize to JSON
         let json = serde_json::to_string(&snapshot).expect("Failed to serialize complex snapshot");
@@ -800,15 +774,15 @@ mod pricelevel_snapshot_serialization_tests {
             serde_json::from_str(&json).expect("Failed to deserialize complex snapshot");
 
         // Verify basic fields
-        assert_eq!(deserialized.price, 1000);
-        assert_eq!(deserialized.visible_quantity, 45);
-        assert_eq!(deserialized.hidden_quantity, 27);
-        assert_eq!(deserialized.order_count, 6);
-        assert_eq!(deserialized.orders.len(), 6);
+        assert_eq!(deserialized.price(), 1000);
+        assert_eq!(deserialized.visible_quantity(), 45);
+        assert_eq!(deserialized.hidden_quantity(), 27);
+        assert_eq!(deserialized.order_count(), 6);
+        assert_eq!(deserialized.orders().len(), 6);
 
         // Verify specific order types were preserved
         let order_types = deserialized
-            .orders
+            .orders()
             .iter()
             .map(|order| match **order {
                 OrderType::Standard { .. } => "Standard",
@@ -833,7 +807,7 @@ mod pricelevel_snapshot_serialization_tests {
 
         // Check a few specific properties to ensure proper deserialization
         let reserve_order = deserialized
-            .orders
+            .orders()
             .iter()
             .find(|order| matches!(***order, OrderType::ReserveOrder { .. }))
             .expect("Reserve order not found");
@@ -849,7 +823,7 @@ mod pricelevel_snapshot_serialization_tests {
         }
 
         let gtd_order = deserialized
-            .orders
+            .orders()
             .iter()
             .find(|order| {
                 matches!(


### PR DESCRIPTION
## Summary

Privatize struct fields that protect invariants across the execution and price_level modules. Add read-only accessors, validated constructors, and internal mutation helpers to enforce consistency without exposing mutable state to consumers.

## Changes

### Structs Hardened

| Struct | Fields Privatized | New API |
|--------|------------------|---------|
| `Trade` | all 7 fields | accessors + `with_timestamp()` constructor |
| `TradeList` | `trades` | (existing `add()`, `as_vec()`, `into_vec()`) |
| `MatchResult` | all 5 fields | accessors + `pub(crate) finalize()` |
| `PriceLevelSnapshot` | all 5 fields | accessors + `with_orders()` builder + `pub(crate) from_raw_parts()` |
| `PriceLevelSnapshotPackage` | all 3 fields | accessors (`version()`, `snapshot()`, `checksum()`) |

### Key Design Decisions

- **`Trade::with_timestamp()`**: Public constructor for deserialization and testing where timestamp is known. `Trade::new()` auto-generates timestamp for production use.
- **`MatchResult::finalize()`**: `pub(crate)` method used by the matching engine to set final remaining quantity and completion flag atomically.
- **`PriceLevelSnapshot::from_raw_parts()`**: `pub(crate)` constructor for internal use where aggregates are pre-computed from atomic counters.
- **`PriceLevelSnapshot::with_orders()`**: Public builder that computes aggregates automatically via `refresh_aggregates()`.
- **Checksum integrity**: `PriceLevelSnapshotPackage` fields are fully private; corruption tests now use JSON manipulation.

### Files Modified

- `src/execution/trade.rs` — privatize fields, add accessors + `with_timestamp`
- `src/execution/list.rs` — privatize `trades` field
- `src/execution/match_result.rs` — privatize fields, add accessors + `finalize()`
- `src/price_level/snapshot.rs` — privatize fields, add accessors/builders
- `src/price_level/level.rs` — use accessors and `finalize()` instead of direct field access
- `src/execution/tests/*.rs` — migrate to constructors and accessors
- `src/price_level/tests/*.rs` — migrate to `from_raw_parts`/`with_orders` and accessors

## Testing

- [x] All 323 unit tests pass
- [x] All 5 doc-tests pass
- [x] Serde roundtrips verified
- [x] FromStr roundtrips verified
- [x] Checksum validation verified via JSON manipulation

## Checklist

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `make lint-fix`
- [x] `make pre-push`
- [x] `cargo doc --no-deps`
- [x] No files from `.windsurf/` or `.internalDoc/` committed

Closes #24