### PR TITLE
fix: keep price-time priority on partial fill (issue #39)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pricelevel"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."
@@ -32,7 +32,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-crossbeam = { workspace = true }
+crossbeam-skiplist = { workspace = true }
 uuid = { workspace = true, features = ["v4", "v5", "serde"] }
 ulid = { workspace = true, features = ["serde"] }
 dashmap = { workspace = true }
@@ -67,7 +67,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3" }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-crossbeam = "0.8"
+crossbeam-skiplist = "0.1"
 uuid = { version = "1.21", features = ["v4", "v5", "serde"] }
 ulid = { version = "1.2", features = ["serde"] }
 dashmap = "6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pricelevel"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The simulation demonstrates the library's exceptional performance capabilities:
 
 The performance characteristics demonstrate that the `pricelevel` library is suitable for production use in high-performance trading systems, matching engines, and other financial applications where microsecond-level performance is critical.
 
-### Fixed in v0.7.1
+### Changes in v0.8.0
 
 - **Price-time priority across partial fills** (issue #39). A partial fill
   previously re-queued the resting maker's residual at the *back* of its
@@ -151,9 +151,21 @@ The performance characteristics demonstrate that the `pricelevel` library is sui
   instead of the older, partially-filled maker (a wrong `maker_order_id` in
   the trade stream). The order queue now keeps strict price-time priority:
   the residual stays at the front. Iceberg / reserve replenishment keeps its
-  existing semantics (a refreshed tranche still loses time priority). This is
-  a behavioral bug fix with **no public API change**; the internal queue is
-  now backed by a lock-free `crossbeam-skiplist` ordered index.
+  existing semantics (a refreshed tranche still loses time priority).
+- **Internal queue moved to a lock-free `crossbeam-skiplist` ordered
+  index.** The method surface of [`OrderQueue`] is unchanged, but because
+  the new index relies on interior mutability, [`OrderQueue`] and
+  [`PriceLevel`] no longer implement [`std::panic::UnwindSafe`] /
+  [`std::panic::RefUnwindSafe`] (they remain `Send + Sync`). This is the
+  only breaking change and is why this release is `0.8.0` rather than a
+  patch. Callers that wrapped these types in [`std::panic::catch_unwind`]
+  are affected; nothing else is.
+- **Matching concurrency contract.** [`PriceLevel::match_order`] assumes a
+  single logical matcher per level at a time. Concurrent `add_order` /
+  `cancel` from other threads are safe, but two concurrent `match_order`
+  calls on the *same* level — or a `match_order` racing a `cancel` of the
+  resting order it is currently matching — are the caller's responsibility
+  to serialize.
 
 ### Migration Guide (v0.6 → v0.7)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
  - Efficient order matching and execution logic
  - Designed with domain-driven principles for financial markets
  - Comprehensive test suite demonstrating concurrent usage scenarios
- - Built with crossbeam's lock-free data structures
+ - Built with crossbeam's lock-free data structures (`crossbeam-skiplist`)
  - Optimized statistics tracking for each price level
  - Memory-efficient implementations suitable for high-frequency trading systems
 
@@ -53,7 +53,7 @@
  ## Implementation Details
 
  - **Thread Safety**: Uses atomic operations and lock-free data structures to ensure thread safety without mutex locks
- - **Order Queue Management**: Specialized order queue implementation based on crossbeam's SegQueue
+ - **Order Queue Management**: Specialized order queue keeping strict price-time priority via a lock-free `crossbeam-skiplist` ordered index
  - **Statistics Tracking**: Each price level tracks execution statistics in real-time
  - **Snapshot Capabilities**: Create point-in-time snapshots of price levels for market data distribution
  - **Efficient Matching**: Optimized algorithms for matching incoming orders against existing orders
@@ -142,6 +142,18 @@ The simulation demonstrates the library's exceptional performance capabilities:
 - **Lock-Free Architecture**: Maintains high throughput with minimal contention overhead
 
 The performance characteristics demonstrate that the `pricelevel` library is suitable for production use in high-performance trading systems, matching engines, and other financial applications where microsecond-level performance is critical.
+
+### Fixed in v0.7.1
+
+- **Price-time priority across partial fills** (issue #39). A partial fill
+  previously re-queued the resting maker's residual at the *back* of its
+  price level, so the next aggressor at that price matched a later arrival
+  instead of the older, partially-filled maker (a wrong `maker_order_id` in
+  the trade stream). The order queue now keeps strict price-time priority:
+  the residual stays at the front. Iceberg / reserve replenishment keeps its
+  existing semantics (a refreshed tranche still loses time priority). This is
+  a behavioral bug fix with **no public API change**; the internal queue is
+  now backed by a lock-free `crossbeam-skiplist` ordered index.
 
 ### Migration Guide (v0.6 → v0.7)
 

--- a/benches/price_level/match_orders.rs
+++ b/benches/price_level/match_orders.rs
@@ -51,6 +51,37 @@ pub fn register_benchmarks(c: &mut Criterion) {
         })
     });
 
+    // Benchmark the partial-fill path: a sub-head-quantity match partially
+    // fills the head order and re-inserts the residual at the front (the
+    // price-time-priority path added for issue #39). Guards the O(log n)
+    // ordered-index push/pop against the previous O(1) tail FIFO.
+    group.bench_function("match_partial_fill_reinsert", |b| {
+        b.iter(|| {
+            let price_level = setup_standard_orders(100);
+            let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+            let transaction_id_generator = UuidGenerator::new(namespace);
+            // 5 < head quantity (10): partial fill + front re-insert.
+            black_box(price_level.match_order(5, Id::from_u64(999), &transaction_id_generator));
+        })
+    });
+
+    // Benchmark repeated partial fills (residual churn) against a deep level:
+    // each call re-inserts the head residual, stressing the ordered index.
+    group.bench_function("match_partial_fill_churn", |b| {
+        b.iter(|| {
+            let price_level = setup_standard_orders(100);
+            let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+            let transaction_id_generator = UuidGenerator::new(namespace);
+            for i in 0..50u64 {
+                black_box(price_level.match_order(
+                    3,
+                    Id::from_u64(1000 + i),
+                    &transaction_id_generator,
+                ));
+            }
+        })
+    });
+
     // Benchmark with different match quantities against standard orders
     for match_quantity in [10, 50, 100, 200, 500].iter() {
         group.bench_with_input(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@
 //!
 //! The performance characteristics demonstrate that the `pricelevel` library is suitable for production use in high-performance trading systems, matching engines, and other financial applications where microsecond-level performance is critical.
 //!
-//! ## Fixed in v0.7.1
+//! ## Changes in v0.8.0
 //!
 //! - **Price-time priority across partial fills** (issue #39). A partial fill
 //!   previously re-queued the resting maker's residual at the *back* of its
@@ -142,9 +142,21 @@
 //!   instead of the older, partially-filled maker (a wrong `maker_order_id` in
 //!   the trade stream). The order queue now keeps strict price-time priority:
 //!   the residual stays at the front. Iceberg / reserve replenishment keeps its
-//!   existing semantics (a refreshed tranche still loses time priority). This is
-//!   a behavioral bug fix with **no public API change**; the internal queue is
-//!   now backed by a lock-free `crossbeam-skiplist` ordered index.
+//!   existing semantics (a refreshed tranche still loses time priority).
+//! - **Internal queue moved to a lock-free `crossbeam-skiplist` ordered
+//!   index.** The method surface of [`OrderQueue`] is unchanged, but because
+//!   the new index relies on interior mutability, [`OrderQueue`] and
+//!   [`PriceLevel`] no longer implement [`std::panic::UnwindSafe`] /
+//!   [`std::panic::RefUnwindSafe`] (they remain `Send + Sync`). This is the
+//!   only breaking change and is why this release is `0.8.0` rather than a
+//!   patch. Callers that wrapped these types in [`std::panic::catch_unwind`]
+//!   are affected; nothing else is.
+//! - **Matching concurrency contract.** [`PriceLevel::match_order`] assumes a
+//!   single logical matcher per level at a time. Concurrent `add_order` /
+//!   `cancel` from other threads are safe, but two concurrent `match_order`
+//!   calls on the *same* level — or a `match_order` racing a `cancel` of the
+//!   resting order it is currently matching — are the caller's responsibility
+//!   to serialize.
 //!
 //! ## Migration Guide (v0.6 → v0.7)
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!  - Efficient order matching and execution logic
 //!  - Designed with domain-driven principles for financial markets
 //!  - Comprehensive test suite demonstrating concurrent usage scenarios
-//!  - Built with crossbeam's lock-free data structures
+//!  - Built with crossbeam's lock-free data structures (`crossbeam-skiplist`)
 //!  - Optimized statistics tracking for each price level
 //!  - Memory-efficient implementations suitable for high-frequency trading systems
 //!
@@ -44,7 +44,7 @@
 //!  ## Implementation Details
 //!
 //!  - **Thread Safety**: Uses atomic operations and lock-free data structures to ensure thread safety without mutex locks
-//!  - **Order Queue Management**: Specialized order queue implementation based on crossbeam's SegQueue
+//!  - **Order Queue Management**: Specialized order queue keeping strict price-time priority via a lock-free `crossbeam-skiplist` ordered index
 //!  - **Statistics Tracking**: Each price level tracks execution statistics in real-time
 //!  - **Snapshot Capabilities**: Create point-in-time snapshots of price levels for market data distribution
 //!  - **Efficient Matching**: Optimized algorithms for matching incoming orders against existing orders
@@ -133,6 +133,18 @@
 //! - **Lock-Free Architecture**: Maintains high throughput with minimal contention overhead
 //!
 //! The performance characteristics demonstrate that the `pricelevel` library is suitable for production use in high-performance trading systems, matching engines, and other financial applications where microsecond-level performance is critical.
+//!
+//! ## Fixed in v0.7.1
+//!
+//! - **Price-time priority across partial fills** (issue #39). A partial fill
+//!   previously re-queued the resting maker's residual at the *back* of its
+//!   price level, so the next aggressor at that price matched a later arrival
+//!   instead of the older, partially-filled maker (a wrong `maker_order_id` in
+//!   the trade stream). The order queue now keeps strict price-time priority:
+//!   the residual stays at the front. Iceberg / reserve replenishment keeps its
+//!   existing semantics (a refreshed tranche still loses time priority). This is
+//!   a behavioral bug fix with **no public API change**; the internal queue is
+//!   now backed by a lock-free `crossbeam-skiplist` ordered index.
 //!
 //! ## Migration Guide (v0.6 → v0.7)
 //!

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -191,7 +191,7 @@ impl PriceLevel {
         let mut remaining = incoming_quantity;
 
         while remaining > 0 {
-            if let Some(order_arc) = self.orders.pop() {
+            if let Some((order_seq, order_arc)) = self.orders.pop_entry() {
                 let (consumed, updated_order, hidden_reduced, new_remaining) =
                     order_arc.match_against(remaining);
 
@@ -233,31 +233,33 @@ impl PriceLevel {
 
                 if let Some(updated) = updated_order {
                     if hidden_reduced > 0 {
+                        // Iceberg/Reserve replenishment: a fresh tranche is
+                        // drawn from hidden into visible. By convention the
+                        // refreshed tranche loses time priority, so it is
+                        // appended to the tail via `push` (new sequence).
                         self.hidden_quantity
                             .fetch_sub(hidden_reduced, Ordering::AcqRel);
                         self.visible_quantity
                             .fetch_add(hidden_reduced, Ordering::AcqRel);
+                        self.orders.push(Arc::new(updated));
+                    } else {
+                        // Pure partial fill: the maker keeps its place in the
+                        // queue. Re-insert the residual at its original
+                        // sequence so it stays ahead of later arrivals,
+                        // preserving strict price-time priority.
+                        self.orders.reinsert(order_seq, Arc::new(updated));
                     }
-
-                    self.orders.push(Arc::new(updated));
                 } else {
                     self.order_count.fetch_sub(1, Ordering::AcqRel);
                     match &*order_arc {
                         OrderType::IcebergOrder {
                             hidden_quantity, ..
-                        } => {
-                            if hidden_quantity.as_u64() > 0 && hidden_reduced == 0 {
-                                self.hidden_quantity
-                                    .fetch_sub(hidden_quantity.as_u64(), Ordering::AcqRel);
-                            }
                         }
-                        OrderType::ReserveOrder {
+                        | OrderType::ReserveOrder {
                             hidden_quantity, ..
-                        } => {
-                            if hidden_quantity.as_u64() > 0 && hidden_reduced == 0 {
-                                self.hidden_quantity
-                                    .fetch_sub(hidden_quantity.as_u64(), Ordering::AcqRel);
-                            }
+                        } if hidden_quantity.as_u64() > 0 && hidden_reduced == 0 => {
+                            self.hidden_quantity
+                                .fetch_sub(hidden_quantity.as_u64(), Ordering::AcqRel);
                         }
                         _ => {}
                     }

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -181,6 +181,17 @@ impl PriceLevel {
     /// generated trades, the remaining unmatched quantity, a flag indicating whether the
     /// incoming order was completely filled, and a list of IDs of orders that were completely filled
     /// during the matching process.
+    ///
+    /// # Concurrency
+    ///
+    /// Resting orders are consumed in strict price-time (FIFO) order, and a
+    /// partially-filled maker keeps its position at the front of the queue.
+    /// This method assumes a **single logical matcher per level at a time**:
+    /// concurrent `add_order` / `cancel` from other threads are safe, but two
+    /// concurrent `match_order` calls on the *same* level — or a `match_order`
+    /// racing a `cancel` of the resting order it is currently matching — must
+    /// be serialized by the caller (an order book typically matches a level
+    /// from a single thread).
     pub fn match_order(
         &self,
         incoming_quantity: u64,

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -188,13 +188,24 @@ impl Serialize for OrderQueue {
     where
         S: Serializer,
     {
-        let mut seq = serializer.serialize_seq(Some(self.len()))?;
-        // Emit in insertion-sequence order so the round-trip preserves time
-        // priority (the DashMap alone has no deterministic iteration order).
-        for index_entry in self.index.iter() {
-            if let Some(order_entry) = self.orders.get(index_entry.value()) {
-                seq.serialize_element(order_entry.value().1.as_ref())?;
-            }
+        // Materialize the ordered view first so the length hint always matches
+        // the number of elements emitted. Iterating `index` while hinting
+        // `self.len()` (from `orders`) could disagree in a transient state
+        // where an order is in one structure but not yet the other.
+        // Insertion-sequence order keeps the round-trip price-time priority
+        // (the DashMap alone has no deterministic iteration order).
+        let ordered: Vec<Arc<OrderType<()>>> = self
+            .index
+            .iter()
+            .filter_map(|index_entry| {
+                self.orders
+                    .get(index_entry.value())
+                    .map(|order_entry| order_entry.value().1.clone())
+            })
+            .collect();
+        let mut seq = serializer.serialize_seq(Some(ordered.len()))?;
+        for order in &ordered {
+            seq.serialize_element(order.as_ref())?;
         }
         seq.end()
     }

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -1,6 +1,6 @@
 use crate::errors::PriceLevelError;
 use crate::orders::{Id, OrderType};
-use crossbeam::queue::SegQueue;
+use crossbeam_skiplist::SkipMap;
 use dashmap::DashMap;
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeSeq;
@@ -10,14 +10,26 @@ use std::fmt::Display;
 use std::marker::PhantomData;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
-/// A thread-safe queue of orders with specialized operations
+/// A thread-safe queue of orders with specialized operations.
+///
+/// Time priority (price-time / FIFO within the level) is maintained by an
+/// ordered index keyed by a monotonic insertion sequence rather than a plain
+/// tail-only FIFO. This lets a partially-filled maker keep its place at the
+/// front of the queue: the residual is re-inserted at its *original* sequence,
+/// instead of being appended to the tail.
 #[derive(Debug)]
 pub struct OrderQueue {
-    /// A map of order IDs to orders for quick lookups
-    orders: DashMap<Id, Arc<OrderType<()>>>,
-    /// A queue of order IDs to maintain FIFO order
-    order_ids: SegQueue<Id>,
+    /// A map of order IDs to `(insertion sequence, order)` for O(1) lookups.
+    /// The sequence travels with the value so it can be recovered on pop and
+    /// reused when re-inserting a partial-fill residual.
+    orders: DashMap<Id, (u64, Arc<OrderType<()>>)>,
+    /// Ordered index `sequence -> Id`. The lowest sequence is the front
+    /// (oldest) order, so iteration / pop honours strict time priority.
+    index: SkipMap<u64, Id>,
+    /// Monotonic source of insertion sequences.
+    next_seq: AtomicU64,
 }
 
 impl OrderQueue {
@@ -26,58 +38,90 @@ impl OrderQueue {
     pub fn new() -> Self {
         Self {
             orders: DashMap::new(),
-            order_ids: SegQueue::new(),
+            index: SkipMap::new(),
+            next_seq: AtomicU64::new(0),
         }
     }
 
-    /// Add an order to the queue
+    /// Add an order to the tail of the queue (newest time priority).
     pub fn push(&self, order: Arc<OrderType<()>>) {
+        // `Relaxed` is sufficient: only the uniqueness and monotonicity of the
+        // counter matter. The happens-before ordering between concurrent
+        // producers/consumers is provided by the lock-free `index`/`orders`
+        // structures, not by this counter, so no synchronization rides on it.
+        let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
         let order_id = order.id();
-        self.orders.insert(order_id, order);
-        self.order_ids.push(order_id);
+        self.orders.insert(order_id, (seq, order));
+        self.index.insert(seq, order_id);
     }
 
-    /// Attempt to pop an order from the queue
+    /// Pop the front (oldest) order together with its insertion sequence.
+    ///
+    /// The sequence is returned so the caller can re-insert a partial-fill
+    /// residual at the *same* position via [`OrderQueue::reinsert`], preserving
+    /// strict price-time priority.
     #[must_use]
-    pub fn pop(&self) -> Option<Arc<OrderType<()>>> {
+    pub(crate) fn pop_entry(&self) -> Option<(u64, Arc<OrderType<()>>)> {
         loop {
-            if let Some(order_id) = self.order_ids.pop() {
-                // If the order was removed, pop will return None, but the ID was in the queue.
-                // In this case, we loop and try to get the next one.
-                if let Some((_, order)) = self.orders.remove(&order_id) {
-                    return Some(order);
-                }
-            } else {
-                return None; // Queue is empty
+            // `pop_front` atomically removes the lowest-sequence index entry.
+            let entry = self.index.pop_front()?;
+            let order_id = *entry.value();
+            // The id may have been concurrently cancelled via `remove`; in that
+            // case the map no longer holds it, so skip it and try the next one.
+            if let Some((_, (seq, order))) = self.orders.remove(&order_id) {
+                return Some((seq, order));
             }
         }
+    }
+
+    /// Attempt to pop an order from the queue (front / oldest first).
+    #[must_use]
+    pub fn pop(&self) -> Option<Arc<OrderType<()>>> {
+        self.pop_entry().map(|(_, order)| order)
+    }
+
+    /// Re-insert an order at a given (previously assigned) insertion sequence.
+    ///
+    /// Used for a partial-fill residual: re-inserting at the maker's original
+    /// sequence returns it to the front of the queue, keeping its time priority
+    /// ahead of orders that arrived later.
+    pub(crate) fn reinsert(&self, seq: u64, order: Arc<OrderType<()>>) {
+        let order_id = order.id();
+        self.orders.insert(order_id, (seq, order));
+        self.index.insert(seq, order_id);
     }
 
     /// Search for an order with the given ID. O(1) operation.
     #[must_use]
     pub fn find(&self, order_id: Id) -> Option<Arc<OrderType<()>>> {
-        self.orders.get(&order_id).map(|o| o.value().clone())
+        self.orders.get(&order_id).map(|o| o.value().1.clone())
     }
 
-    /// Remove an order with the given ID
-    /// Returns the removed order if found. O(1) for the map, but the ID remains in the queue.
+    /// Remove an order with the given ID.
+    /// Returns the removed order if found. Cleans both the map and the index.
     #[must_use]
     pub fn remove(&self, order_id: Id) -> Option<Arc<OrderType<()>>> {
-        self.orders.remove(&order_id).map(|(_, order)| order)
+        let (_, (seq, order)) = self.orders.remove(&order_id)?;
+        self.index.remove(&seq);
+        Some(order)
     }
 
     /// Iterate through current orders without materializing an intermediate vector.
     pub fn iter_orders(&self) -> impl Iterator<Item = Arc<OrderType<()>>> + '_ {
-        self.orders.iter().map(|entry| entry.value().clone())
+        self.orders.iter().map(|entry| entry.value().1.clone())
     }
 
-    /// Materialize a stable snapshot vector sorted by timestamp.
+    /// Materialize a stable snapshot vector sorted by `(timestamp, sequence)`.
+    ///
+    /// The insertion sequence is used as a deterministic tiebreak so orders
+    /// sharing a millisecond timestamp are still ordered exactly as matching
+    /// would consume them.
     #[must_use]
     pub fn snapshot_vec(&self) -> Vec<Arc<OrderType<()>>> {
-        let mut orders: Vec<Arc<OrderType<()>>> =
+        let mut orders: Vec<(u64, Arc<OrderType<()>>)> =
             self.orders.iter().map(|o| o.value().clone()).collect();
-        orders.sort_by_key(|o| o.timestamp());
-        orders
+        orders.sort_by_key(|(seq, o)| (o.timestamp(), *seq));
+        orders.into_iter().map(|(_, o)| o).collect()
     }
 
     /// Convert the queue to a vector (for compatibility and snapshots).
@@ -142,8 +186,12 @@ impl Serialize for OrderQueue {
         S: Serializer,
     {
         let mut seq = serializer.serialize_seq(Some(self.len()))?;
-        for order_entry in self.orders.iter() {
-            seq.serialize_element(order_entry.value().as_ref())?;
+        // Emit in insertion-sequence order so the round-trip preserves time
+        // priority (the DashMap alone has no deterministic iteration order).
+        for index_entry in self.index.iter() {
+            if let Some(order_entry) = self.orders.get(index_entry.value()) {
+                seq.serialize_element(order_entry.value().1.as_ref())?;
+            }
         }
         seq.end()
     }

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -115,7 +115,10 @@ impl OrderQueue {
     ///
     /// The insertion sequence is used as a deterministic tiebreak so orders
     /// sharing a millisecond timestamp are still ordered exactly as matching
-    /// would consume them.
+    /// would consume them. Note the sequence itself is not serialized: a
+    /// snapshot round-trip reconstructs queue order from `(timestamp,
+    /// sequence)`, so exact price-time priority survives a round-trip only when
+    /// timestamps are monotonic with insertion order (the normal case).
     #[must_use]
     pub fn snapshot_vec(&self) -> Vec<Arc<OrderType<()>>> {
         let mut orders: Vec<(u64, Arc<OrderType<()>>)> =

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -1926,6 +1926,144 @@ mod tests {
         assert_eq!(deserialized.hidden_quantity(), 70);
         assert_eq!(deserialized.order_count(), 2);
     }
+
+    // ------------------------- PRICE-TIME PRIORITY (issue #39) -------------------------
+
+    #[test]
+    /// Regression for issue #39: a partial fill must keep the resting maker at
+    /// the FRONT of the queue. Rest A then B at the same price, partially fill
+    /// A, then send a second aggressor — it must consume A's remainder before
+    /// touching the later-arriving B.
+    fn test_match_partial_fill_keeps_maker_price_time_priority() {
+        let price_level = PriceLevel::new(10000);
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let trade_ids = UuidGenerator::new(namespace);
+
+        // A (id=1) arrives before B (id=2), both 100 @ 10000.
+        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level.add_order(create_standard_order(2, 10000, 100));
+
+        // First aggressor partially fills A (60 of 100). A's residual = 40.
+        let first = price_level.match_order(60, Id::from_u64(901), &trade_ids);
+        assert_eq!(first.trades().len(), 1);
+        assert_eq!(
+            first.trades().as_vec()[0].maker_order_id(),
+            Id::from_u64(1),
+            "first aggressor must hit A"
+        );
+        assert_eq!(first.trades().as_vec()[0].quantity(), Quantity::new(60));
+        // A(40) + B(100) still resting.
+        assert_eq!(price_level.visible_quantity(), 140);
+        assert_eq!(price_level.order_count(), 2);
+
+        // Second aggressor (50) must hit A's remainder (40) FIRST, then B (10).
+        let second = price_level.match_order(50, Id::from_u64(902), &trade_ids);
+        assert_eq!(second.trades().len(), 2);
+
+        let t0 = &second.trades().as_vec()[0];
+        assert_eq!(
+            t0.maker_order_id(),
+            Id::from_u64(1),
+            "price-time priority: A's residual must be consumed before B"
+        );
+        assert_eq!(t0.quantity(), Quantity::new(40));
+
+        let t1 = &second.trades().as_vec()[1];
+        assert_eq!(t1.maker_order_id(), Id::from_u64(2));
+        assert_eq!(t1.quantity(), Quantity::new(10));
+
+        // A fully consumed; B has 90 left. Conservation holds.
+        assert_eq!(second.filled_order_ids(), &[Id::from_u64(1)]);
+        assert_eq!(price_level.visible_quantity(), 90);
+        assert_eq!(price_level.order_count(), 1);
+    }
+
+    #[test]
+    /// Conservation: a partial fill never changes the total resting quantity at
+    /// the level beyond what was consumed.
+    fn test_match_partial_fill_conserves_quantity() {
+        let price_level = PriceLevel::new(10000);
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let trade_ids = UuidGenerator::new(namespace);
+
+        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level.add_order(create_standard_order(2, 10000, 100));
+        let total_before = match price_level.total_quantity() {
+            Ok(q) => q,
+            Err(e) => panic!("total_quantity failed: {e}"),
+        };
+        assert_eq!(total_before, 200);
+
+        let _ = price_level.match_order(60, Id::from_u64(901), &trade_ids);
+        let total_after = match price_level.total_quantity() {
+            Ok(q) => q,
+            Err(e) => panic!("total_quantity failed: {e}"),
+        };
+        assert_eq!(total_after, 140, "exactly the consumed 60 left the level");
+    }
+
+    #[test]
+    /// Iceberg/Reserve replenishment keeps its existing semantics: a refreshed
+    /// tranche LOSES time priority (goes to the tail), unlike a pure partial
+    /// fill. Confirms the `hidden_reduced` discriminator in `match_order`.
+    fn test_match_iceberg_replenish_loses_priority() {
+        let price_level = PriceLevel::new(10000);
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let trade_ids = UuidGenerator::new(namespace);
+
+        // Iceberg I (id=1) arrives first: visible 50, hidden 100.
+        price_level.add_order(create_iceberg_order(1, 10000, 50, 100));
+        // O (id=2) arrives later: a plain 50 (iceberg with no hidden).
+        price_level.add_order(create_iceberg_order(2, 10000, 50, 0));
+
+        // Aggressor consumes I's visible tip (50) → I refreshes from hidden and
+        // moves to the tail. remaining hits 0, so this call stops there.
+        let first = price_level.match_order(50, Id::from_u64(901), &trade_ids);
+        assert_eq!(first.trades().len(), 1);
+        assert_eq!(first.trades().as_vec()[0].maker_order_id(), Id::from_u64(1));
+
+        // Next aggressor must now hit O (id=2) FIRST, because the refreshed
+        // iceberg tranche lost its priority to the tail.
+        let second = price_level.match_order(50, Id::from_u64(902), &trade_ids);
+        assert_eq!(
+            second.trades().as_vec()[0].maker_order_id(),
+            Id::from_u64(2),
+            "refreshed iceberg tranche must lose time priority"
+        );
+    }
+
+    #[test]
+    /// A partial-fill residual at the front must survive a snapshot round-trip
+    /// with its priority intact.
+    fn test_snapshot_roundtrip_preserves_partial_fill_priority() {
+        let price_level = PriceLevel::new(10000);
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let trade_ids = UuidGenerator::new(namespace);
+
+        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level.add_order(create_standard_order(2, 10000, 100));
+        let _ = price_level.match_order(60, Id::from_u64(901), &trade_ids);
+
+        let json = match price_level.snapshot_to_json() {
+            Ok(j) => j,
+            Err(e) => panic!("snapshot_to_json failed: {e}"),
+        };
+        let restored = match PriceLevel::from_snapshot_json(&json) {
+            Ok(r) => r,
+            Err(e) => panic!("from_snapshot_json failed: {e}"),
+        };
+
+        // Match against the restored level: A's residual (40) must still come
+        // first, proving the snapshot preserved price-time priority.
+        let restored_trade_ids = UuidGenerator::new(namespace);
+        let result = restored.match_order(50, Id::from_u64(903), &restored_trade_ids);
+        assert_eq!(
+            result.trades().as_vec()[0].maker_order_id(),
+            Id::from_u64(1),
+            "restored level must keep A's residual ahead of B"
+        );
+        assert_eq!(result.trades().as_vec()[0].quantity(), Quantity::new(40));
+    }
 }
 
 #[cfg(test)]

--- a/src/price_level/tests/order_queue.rs
+++ b/src/price_level/tests/order_queue.rs
@@ -445,4 +445,94 @@ mod tests {
         assert!(order_ids.contains(&Id::from_u64(1)));
         assert!(order_ids.contains(&Id::from_u64(2)));
     }
+
+    #[test]
+    fn test_order_queue_reinsert_keeps_front_priority() {
+        // A arrives before B. Popping A (the head), then re-inserting it at its
+        // original sequence must keep A ahead of B — modelling a partial fill
+        // that preserves price-time priority.
+        let queue = OrderQueue::new();
+        queue.push(Arc::new(create_test_order(1, 1000u128, 10)));
+        queue.push(Arc::new(create_test_order(2, 1000u128, 20)));
+
+        let (seq_a, order_a) = match queue.pop_entry() {
+            Some(entry) => entry,
+            None => panic!("expected to pop order A"),
+        };
+        assert_eq!(order_a.id(), Id::from_u64(1));
+
+        // Re-insert A's residual at its original sequence.
+        queue.reinsert(seq_a, order_a);
+
+        // The very next pop must still be A, not the later-arriving B.
+        match queue.pop_entry() {
+            Some((_, order)) => assert_eq!(
+                order.id(),
+                Id::from_u64(1),
+                "re-inserted residual must keep front priority"
+            ),
+            None => panic!("expected to pop the re-inserted order A"),
+        }
+        match queue.pop() {
+            Some(order) => assert_eq!(order.id(), Id::from_u64(2)),
+            None => panic!("expected to pop order B"),
+        }
+        assert!(queue.pop().is_none());
+    }
+
+    #[test]
+    fn test_order_queue_push_assigns_tail_priority() {
+        // A re-pushed order (new sequence) lands behind everything else.
+        let queue = OrderQueue::new();
+        queue.push(Arc::new(create_test_order(1, 1000u128, 10)));
+        queue.push(Arc::new(create_test_order(2, 1000u128, 20)));
+
+        let order_a = match queue.pop() {
+            Some(order) => order,
+            None => panic!("expected to pop order A"),
+        };
+        assert_eq!(order_a.id(), Id::from_u64(1));
+
+        // Re-push A: it gets a fresh (highest) sequence and goes to the tail.
+        queue.push(order_a);
+
+        match queue.pop() {
+            Some(order) => assert_eq!(
+                order.id(),
+                Id::from_u64(2),
+                "B should now be ahead of re-pushed A"
+            ),
+            None => panic!("expected to pop order B"),
+        }
+        match queue.pop() {
+            Some(order) => assert_eq!(order.id(), Id::from_u64(1)),
+            None => panic!("expected to pop re-pushed order A"),
+        }
+        assert!(queue.pop().is_none());
+    }
+
+    #[test]
+    fn test_order_queue_remove_cleans_index() {
+        // Removing an order must drop it from both the map and the ordered
+        // index, so it never resurfaces from a later pop.
+        let queue = OrderQueue::new();
+        queue.push(Arc::new(create_test_order(1, 1000u128, 10)));
+        queue.push(Arc::new(create_test_order(2, 1000u128, 20)));
+
+        match queue.remove(Id::from_u64(1)) {
+            Some(order) => assert_eq!(order.id(), Id::from_u64(1)),
+            None => panic!("expected to remove order A"),
+        }
+        assert_eq!(queue.len(), 1);
+
+        match queue.pop() {
+            Some(order) => assert_eq!(
+                order.id(),
+                Id::from_u64(2),
+                "removed order must not resurface"
+            ),
+            None => panic!("expected to pop order B"),
+        }
+        assert!(queue.pop().is_none());
+    }
 }

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -3,3 +3,63 @@
    Email: jb@taunais.com
    Date: 28/3/25
 ******************************************************************************/
+
+//! Integration tests exercising the public `pricelevel` API across modules.
+
+use pricelevel::prelude::*;
+use uuid::Uuid;
+
+fn standard_buy(id: u64, price: u128, quantity: u64, timestamp: u64) -> OrderType<()> {
+    OrderType::Standard {
+        id: Id::from_u64(id),
+        price: Price::new(price),
+        quantity: Quantity::new(quantity),
+        side: Side::Buy,
+        user_id: Hash32::zero(),
+        timestamp: TimestampMs::new(timestamp),
+        time_in_force: TimeInForce::Gtc,
+        extra_fields: (),
+    }
+}
+
+/// End-to-end repro for issue #39 through the public surface: rest A then B at
+/// the same price, partially fill A, and confirm a second aggressor consumes
+/// A's remainder before B (strict price-time priority across `match_order`
+/// calls).
+#[test]
+fn partial_fill_keeps_price_time_priority_across_calls() {
+    let level = PriceLevel::new(10_000);
+    let namespace = match Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8") {
+        Ok(ns) => ns,
+        Err(e) => panic!("invalid namespace uuid: {e}"),
+    };
+    let trade_ids = UuidGenerator::new(namespace);
+
+    // A (id=1) rests before B (id=2); both 100 @ 10_000.
+    level.add_order(standard_buy(1, 10_000, 100, 1_000));
+    level.add_order(standard_buy(2, 10_000, 100, 1_001));
+
+    // Partially fill A.
+    let first = level.match_order(60, Id::from_u64(901), &trade_ids);
+    assert_eq!(first.trades().len(), 1);
+    assert_eq!(first.trades().as_vec()[0].maker_order_id(), Id::from_u64(1));
+
+    // Second aggressor must hit A's remainder (40) first, then B (10).
+    let second = level.match_order(50, Id::from_u64(902), &trade_ids);
+    assert_eq!(second.trades().len(), 2);
+    assert_eq!(
+        second.trades().as_vec()[0].maker_order_id(),
+        Id::from_u64(1),
+        "A's residual must be consumed before the later-arriving B"
+    );
+    assert_eq!(second.trades().as_vec()[0].quantity(), Quantity::new(40));
+    assert_eq!(
+        second.trades().as_vec()[1].maker_order_id(),
+        Id::from_u64(2)
+    );
+    assert_eq!(second.trades().as_vec()[1].quantity(), Quantity::new(10));
+
+    // Conservation: started 200, consumed 110, 90 remains on B.
+    assert_eq!(level.visible_quantity(), 90);
+    assert_eq!(level.order_count(), 1);
+}


### PR DESCRIPTION
## Summary

Fixes #39. A partial fill re-queued the resting maker's residual at the **tail** of its price level (`OrderQueue::push`), so the next aggressor at that price matched a **later** arrival instead of the older, partially-filled maker — a price-time (FIFO) priority violation observed downstream as a wrong `maker_order_id` (OrderBook-rs#88; failed the Matching-Engine-Benchmark report-stream hash on all 5 scenarios while the quantity audit passed 192/192).

## Approach

`OrderQueue` now keeps a monotonic insertion **sequence** and a lock-free `crossbeam-skiplist` ordered index (`SkipMap<seq, Id>`) in place of the tail-only `SegQueue`. The sequence travels with each order in the map, so `match_order`:

- on a **pure partial fill** (`hidden_reduced == 0`) re-inserts the residual at its **original** sequence (`reinsert`) → it stays at the front;
- on **iceberg/reserve replenishment** (`hidden_reduced > 0`) still `push`es the refreshed tranche to the tail → it loses time priority (unchanged, standard convention).

## Versioning — 0.8.0 (one breaking change)

The method surface of `OrderQueue` is unchanged (`pop`/`push`/`find`/`remove`/`len` signatures intact; `pop_entry`/`reinsert` are `pub(crate)`). But `cargo-semver-checks` correctly flags that, because the new skiplist index uses interior mutability, **`OrderQueue` and `PriceLevel` no longer implement `UnwindSafe` / `RefUnwindSafe`** (they remain `Send + Sync`). For a 0.x crate that is a breaking change, so this releases as **0.8.0**. Only callers wrapping these types in `std::panic::catch_unwind` are affected. Snapshot format/checksum is unchanged (the sequence is internal and not serialized).

Incidental: dropped the now-unused `crossbeam` umbrella dependency (replaced by `crossbeam-skiplist`); collapsed a pre-existing `collapsible_match` clippy warning in `match_order`.

## Testing
- `cargo test` — 330 lib + 1 integration + 9 doctests, **0 failed**.
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, `cargo build --release`, `cargo doc` — all clean.
- New coverage: queue-level priority/`remove`-cleanup units; `match_order` regression (rest A,B → partial-fill A → second aggressor hits A's remainder then B), conservation, iceberg-replenish-loses-priority, snapshot round-trip preserves residual priority; cross-call integration repro; `match_partial_fill_reinsert` / `_churn` Criterion benches guard the O(log n) index.

## Review notes
- **microstructure-critic** — *Ready for release*: the `hidden_reduced` discriminator is correct and complete across Standard / Iceberg / Reserve and the PostOnly/TrailingStop/Pegged/MarketToLimit catch-all; FIFO preserved and well covered.
- **concurrency-auditor** — flags that concurrent `match_order`+`cancel` (or `match_order`+`match_order`) on the **same** level have race windows (lost cancel; torn snapshot vs counters). These are **pre-existing** characteristics of the two-structure + separate-atomic-counters design (the original `SegQueue` queue had the same pop-then-reput shape), **not** introduced by this fix. Documented the single-logical-matcher-per-level contract on `match_order` and the snapshot timestamp-ordering note. The deeper atomicity hardening (CAS in-place value swap; consistent snapshot read) is tracked as follow-up.

## Downstream follow-up (separate)
Cut 0.8.0, bump `pricelevel` in OrderBook-rs, add a matching regression there.