### PR TITLE
Thread taker timestamp through match_order (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,28 @@ let restored = PriceLevel::from_snapshot_json(&json).unwrap();
 7. Update snapshot code to use [`PriceLevelSnapshotPackage`] for checksum validation.
 8. Address new `#[must_use]` warnings on query methods.
 
+### Migration Guide (deterministic `match_order` timestamp)
+
+[`PriceLevel::match_order`] now takes an explicit `timestamp: TimestampMs`
+argument, inserted **between** `taker_order_id` and the trade-id generator:
+
+| Before | After |
+|--------|-------|
+| `level.match_order(qty, taker_id, &gen)` | `level.match_order(qty, taker_id, ts, &gen)` |
+
+**Why.** The match path previously read the wall clock once per emitted
+[`Trade`] (`SystemTime::now()`) and once per fill inside the statistics
+update. That made the trade stream non-deterministic (each replay produced
+different `Trade::timestamp` values) and put two syscalls per fill on the
+hot path. The caller now threads a single taker timestamp in; it is stamped
+onto every [`Trade`] and used as the execution time for statistics. No clock
+is read on the match path, so matching the same input twice with the same
+`timestamp` yields a byte-identical trade stream — a prerequisite for
+snapshot/replay equivalence.
+
+Pass the taker's arrival timestamp (or any deterministic value for
+tests/replay), e.g. [`TimestampMs::new`].
+
 
  ## Setup Instructions
 

--- a/benches/concurrent/contention.rs
+++ b/benches/concurrent/contention.rs
@@ -107,7 +107,12 @@ fn measure_read_write_contention(
                         1 => {
                             // Match against existing orders
                             let taker_id = Id::from_u64(thread_id as u64 * 1_000_000 + i);
-                            thread_price_level.match_order(2, taker_id, &thread_transaction_id_gen);
+                            thread_price_level.match_order(
+                                2,
+                                taker_id,
+                                TimestampMs::new(1_716_000_000_000),
+                                &thread_transaction_id_gen,
+                            );
                         }
                         _ => {
                             // Cancel an order
@@ -217,7 +222,12 @@ fn measure_hot_spot_contention(
                     _ => {
                         // Match operations
                         let taker_id = Id::from_u64(thread_id as u64 * 1_000_000 + i);
-                        thread_price_level.match_order(1, taker_id, &thread_transaction_id_gen);
+                        thread_price_level.match_order(
+                            1,
+                            taker_id,
+                            TimestampMs::new(1_716_000_000_000),
+                            &thread_transaction_id_gen,
+                        );
                     }
                 }
             }

--- a/benches/concurrent/register.rs
+++ b/benches/concurrent/register.rs
@@ -72,7 +72,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
                             let transaction_id_generator = UuidGenerator::new(namespace);
                             // Use different taker order IDs for each thread/iteration
                             let taker_id = Id::from_u64(thread_id as u64 * 1_000_000 + iteration);
-                            price_level.match_order(5, taker_id, &transaction_id_generator);
+                            price_level.match_order(
+                                5,
+                                taker_id,
+                                TimestampMs::new(1_716_000_000_000),
+                                &transaction_id_generator,
+                            );
                         },
                     )
                 });
@@ -306,7 +311,12 @@ fn measure_concurrent_mixed_operations(thread_count: usize, iterations: u64) -> 
                     1 => {
                         // Match against existing orders
                         let taker_id = Id::from_u64(thread_id as u64 * 1_000_000 + i);
-                        thread_price_level.match_order(5, taker_id, &thread_transaction_id_gen);
+                        thread_price_level.match_order(
+                            5,
+                            taker_id,
+                            TimestampMs::new(1_716_000_000_000),
+                            &thread_transaction_id_gen,
+                        );
                     }
                     2 => {
                         // Cancel one of the initial orders

--- a/benches/price_level/checked_arithmetic.rs
+++ b/benches/price_level/checked_arithmetic.rs
@@ -24,7 +24,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
     // Benchmark executed_quantity on a MatchResult with many trades
     group.bench_function("executed_quantity_many_trades", |b| {
         let level = setup_standard_level(100);
-        let result = level.match_order(500, Id::from_u64(9999), &id_gen);
+        let result = level.match_order(
+            500,
+            Id::from_u64(9999),
+            TimestampMs::new(1_716_000_000_000),
+            &id_gen,
+        );
         b.iter(|| {
             black_box(result.executed_quantity().unwrap());
         })
@@ -33,7 +38,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
     // Benchmark executed_value on a MatchResult with many trades
     group.bench_function("executed_value_many_trades", |b| {
         let level = setup_standard_level(100);
-        let result = level.match_order(500, Id::from_u64(9999), &id_gen);
+        let result = level.match_order(
+            500,
+            Id::from_u64(9999),
+            TimestampMs::new(1_716_000_000_000),
+            &id_gen,
+        );
         b.iter(|| {
             black_box(result.executed_value().unwrap());
         })
@@ -42,7 +52,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
     // Benchmark average_price computation
     group.bench_function("average_price", |b| {
         let level = setup_standard_level(100);
-        let result = level.match_order(500, Id::from_u64(9999), &id_gen);
+        let result = level.match_order(
+            500,
+            Id::from_u64(9999),
+            TimestampMs::new(1_716_000_000_000),
+            &id_gen,
+        );
         b.iter(|| {
             black_box(result.average_price().unwrap());
         })
@@ -70,7 +85,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
     // Benchmark empty match result (zero trades) arithmetic
     group.bench_function("empty_match_arithmetic", |b| {
         let empty_level = PriceLevel::new(10000);
-        let result = empty_level.match_order(100, Id::from_u64(1), &id_gen);
+        let result = empty_level.match_order(
+            100,
+            Id::from_u64(1),
+            TimestampMs::new(1_716_000_000_000),
+            &id_gen,
+        );
         b.iter(|| {
             black_box(result.executed_quantity().unwrap());
             black_box(result.executed_value().unwrap());
@@ -83,7 +103,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
         let tc = *trade_count;
         group.bench_function(format!("executed_quantity_{tc}_trades"), |b| {
             let level = setup_standard_level(tc);
-            let result = level.match_order(tc * 10, Id::from_u64(9999), &id_gen);
+            let result = level.match_order(
+                tc * 10,
+                Id::from_u64(9999),
+                TimestampMs::new(1_716_000_000_000),
+                &id_gen,
+            );
             b.iter(|| {
                 black_box(result.executed_quantity().unwrap());
             })

--- a/benches/price_level/lifecycle.rs
+++ b/benches/price_level/lifecycle.rs
@@ -39,7 +39,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
             }
 
             // Phase 4: Match 500 units
-            let result = level.match_order(500, Id::from_u64(9999), &id_gen);
+            let result = level.match_order(
+                500,
+                Id::from_u64(9999),
+                TimestampMs::new(1_716_000_000_000),
+                &id_gen,
+            );
             let _ = black_box(result.executed_quantity());
 
             // Phase 5: Read stats
@@ -59,7 +64,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
             for i in 0..200_u64 {
                 if i % 5 == 0 {
                     // Match every 5th iteration
-                    black_box(level.match_order(10, Id::from_u64(10000 + i), &id_gen));
+                    black_box(level.match_order(
+                        10,
+                        Id::from_u64(10000 + i),
+                        TimestampMs::new(1_716_000_000_000),
+                        &id_gen,
+                    ));
                 } else {
                     // Add order
                     level.add_order(create_standard_order(i, 10000, 20));
@@ -102,7 +112,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
             }
 
             // Drain completely
-            let result = level.match_order(1000, Id::from_u64(9999), &id_gen);
+            let result = level.match_order(
+                1000,
+                Id::from_u64(9999),
+                TimestampMs::new(1_716_000_000_000),
+                &id_gen,
+            );
             black_box(result.is_complete());
             black_box(result.filled_order_ids().len());
         })
@@ -162,7 +177,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
             }
 
             // Match and query stats
-            let result = level.match_order(100, Id::from_u64(9999), &id_gen);
+            let result = level.match_order(
+                100,
+                Id::from_u64(9999),
+                TimestampMs::new(1_716_000_000_000),
+                &id_gen,
+            );
             let _ = black_box(result.executed_quantity());
 
             let stats = level.stats();

--- a/benches/price_level/match_orders.rs
+++ b/benches/price_level/match_orders.rs
@@ -17,7 +17,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
             let price_level = setup_standard_orders(100);
             let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
             let transaction_id_generator = UuidGenerator::new(namespace);
-            black_box(price_level.match_order(50, Id::from_u64(999), &transaction_id_generator));
+            black_box(price_level.match_order(
+                50,
+                Id::from_u64(999),
+                TimestampMs::new(1_716_000_000_000),
+                &transaction_id_generator,
+            ));
         })
     });
 
@@ -27,7 +32,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
             let price_level = setup_iceberg_orders(100);
             let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
             let transaction_id_generator = UuidGenerator::new(namespace);
-            black_box(price_level.match_order(75, Id::from_u64(999), &transaction_id_generator));
+            black_box(price_level.match_order(
+                75,
+                Id::from_u64(999),
+                TimestampMs::new(1_716_000_000_000),
+                &transaction_id_generator,
+            ));
         })
     });
 
@@ -37,7 +47,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
             let price_level = setup_reserve_orders(100);
             let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
             let transaction_id_generator = UuidGenerator::new(namespace);
-            black_box(price_level.match_order(60, Id::from_u64(999), &transaction_id_generator));
+            black_box(price_level.match_order(
+                60,
+                Id::from_u64(999),
+                TimestampMs::new(1_716_000_000_000),
+                &transaction_id_generator,
+            ));
         })
     });
 
@@ -47,7 +62,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
             let price_level = setup_mixed_orders(100);
             let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
             let transaction_id_generator = UuidGenerator::new(namespace);
-            black_box(price_level.match_order(100, Id::from_u64(999), &transaction_id_generator));
+            black_box(price_level.match_order(
+                100,
+                Id::from_u64(999),
+                TimestampMs::new(1_716_000_000_000),
+                &transaction_id_generator,
+            ));
         })
     });
 
@@ -61,7 +81,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
             let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
             let transaction_id_generator = UuidGenerator::new(namespace);
             // 5 < head quantity (10): partial fill + front re-insert.
-            black_box(price_level.match_order(5, Id::from_u64(999), &transaction_id_generator));
+            black_box(price_level.match_order(
+                5,
+                Id::from_u64(999),
+                TimestampMs::new(1_716_000_000_000),
+                &transaction_id_generator,
+            ));
         })
     });
 
@@ -76,6 +101,7 @@ pub fn register_benchmarks(c: &mut Criterion) {
                 black_box(price_level.match_order(
                     3,
                     Id::from_u64(1000 + i),
+                    TimestampMs::new(1_716_000_000_000),
                     &transaction_id_generator,
                 ));
             }
@@ -96,6 +122,7 @@ pub fn register_benchmarks(c: &mut Criterion) {
                     black_box(price_level.match_order(
                         match_quantity,
                         Id::from_u64(999),
+                        TimestampMs::new(1_716_000_000_000),
                         &transaction_id_generator,
                     ));
                 })
@@ -117,6 +144,7 @@ pub fn register_benchmarks(c: &mut Criterion) {
                     black_box(price_level.match_order(
                         match_quantity,
                         Id::from_u64(999),
+                        TimestampMs::new(1_716_000_000_000),
                         &transaction_id_generator,
                     ));
                 })

--- a/benches/price_level/mixed_operations.rs
+++ b/benches/price_level/mixed_operations.rs
@@ -32,6 +32,7 @@ pub fn register_benchmarks(c: &mut Criterion) {
                 let _ = black_box(price_level.match_order(
                     50,
                     Id::from_u64(999),
+                    TimestampMs::new(1_716_000_000_000),
                     &transaction_id_generator,
                 ));
             }
@@ -65,6 +66,7 @@ pub fn register_benchmarks(c: &mut Criterion) {
                 black_box(price_level.match_order(
                     100,
                     Id::from_u64(1000),
+                    TimestampMs::new(1_716_000_000_000),
                     &transaction_id_generator,
                 ));
             }
@@ -90,6 +92,7 @@ pub fn register_benchmarks(c: &mut Criterion) {
                 black_box(price_level.match_order(
                     2,
                     Id::from_u64(1000 + i),
+                    TimestampMs::new(1_716_000_000_000),
                     &transaction_id_generator,
                 ));
 
@@ -121,9 +124,24 @@ pub fn register_benchmarks(c: &mut Criterion) {
             }
 
             // Execute a few large matches
-            black_box(price_level.match_order(300, Id::from_u64(1001), &transaction_id_generator));
-            black_box(price_level.match_order(400, Id::from_u64(1002), &transaction_id_generator));
-            black_box(price_level.match_order(300, Id::from_u64(1003), &transaction_id_generator));
+            black_box(price_level.match_order(
+                300,
+                Id::from_u64(1001),
+                TimestampMs::new(1_716_000_000_000),
+                &transaction_id_generator,
+            ));
+            black_box(price_level.match_order(
+                400,
+                Id::from_u64(1002),
+                TimestampMs::new(1_716_000_000_000),
+                &transaction_id_generator,
+            ));
+            black_box(price_level.match_order(
+                300,
+                Id::from_u64(1003),
+                TimestampMs::new(1_716_000_000_000),
+                &transaction_id_generator,
+            ));
         })
     });
 

--- a/benches/price_level/serialization.rs
+++ b/benches/price_level/serialization.rs
@@ -88,7 +88,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
     let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
     let id_gen = UuidGenerator::new(namespace);
     let level = setup_standard_level(50);
-    let match_result = level.match_order(200, Id::from_u64(9999), &id_gen);
+    let match_result = level.match_order(
+        200,
+        Id::from_u64(9999),
+        TimestampMs::new(1_716_000_000_000),
+        &id_gen,
+    );
 
     // MatchResult Display
     group.bench_function("match_result_display", |b| {

--- a/benches/price_level/special_orders.rs
+++ b/benches/price_level/special_orders.rs
@@ -17,7 +17,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
     group.bench_function("match_post_only", |b| {
         b.iter(|| {
             let level = setup_post_only_level(100);
-            black_box(level.match_order(50, Id::from_u64(9999), &id_gen));
+            black_box(level.match_order(
+                50,
+                Id::from_u64(9999),
+                TimestampMs::new(1_716_000_000_000),
+                &id_gen,
+            ));
         })
     });
 
@@ -25,7 +30,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
     group.bench_function("match_trailing_stop", |b| {
         b.iter(|| {
             let level = setup_trailing_stop_level(100);
-            black_box(level.match_order(50, Id::from_u64(9999), &id_gen));
+            black_box(level.match_order(
+                50,
+                Id::from_u64(9999),
+                TimestampMs::new(1_716_000_000_000),
+                &id_gen,
+            ));
         })
     });
 
@@ -33,7 +43,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
     group.bench_function("match_pegged", |b| {
         b.iter(|| {
             let level = setup_pegged_level(100);
-            black_box(level.match_order(50, Id::from_u64(9999), &id_gen));
+            black_box(level.match_order(
+                50,
+                Id::from_u64(9999),
+                TimestampMs::new(1_716_000_000_000),
+                &id_gen,
+            ));
         })
     });
 
@@ -41,7 +56,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
     group.bench_function("match_market_to_limit", |b| {
         b.iter(|| {
             let level = setup_market_to_limit_level(100);
-            black_box(level.match_order(50, Id::from_u64(9999), &id_gen));
+            black_box(level.match_order(
+                50,
+                Id::from_u64(9999),
+                TimestampMs::new(1_716_000_000_000),
+                &id_gen,
+            ));
         })
     });
 
@@ -49,7 +69,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
     group.bench_function("match_all_special_mixed", |b| {
         b.iter(|| {
             let level = setup_all_special_mixed(100);
-            black_box(level.match_order(100, Id::from_u64(9999), &id_gen));
+            black_box(level.match_order(
+                100,
+                Id::from_u64(9999),
+                TimestampMs::new(1_716_000_000_000),
+                &id_gen,
+            ));
         })
     });
 
@@ -61,7 +86,12 @@ pub fn register_benchmarks(c: &mut Criterion) {
             |b, &order_count| {
                 b.iter(|| {
                     let level = setup_all_special_mixed(order_count);
-                    black_box(level.match_order(order_count / 2, Id::from_u64(9999), &id_gen));
+                    black_box(level.match_order(
+                        order_count / 2,
+                        Id::from_u64(9999),
+                        TimestampMs::new(1_716_000_000_000),
+                        &id_gen,
+                    ));
                 })
             },
         );

--- a/examples/src/bin/contention_test.rs
+++ b/examples/src/bin/contention_test.rs
@@ -112,6 +112,7 @@ fn test_read_write_ratio() {
                                 thread_price_level.match_order(
                                     5, // Match 5 units
                                     taker_id,
+                                    TimestampMs::new(1_716_000_000_000),
                                     &thread_tx_id_gen,
                                 );
                             }

--- a/examples/src/bin/hft_simulation.rs
+++ b/examples/src/bin/hft_simulation.rs
@@ -137,7 +137,12 @@ fn main() {
 
                 // Match varying quantities
                 let quantity = (local_counter % 5) + 1; // Match 1-5 units
-                let result = thread_price_level.match_order(quantity, taker_id, &thread_tx_id_gen);
+                let result = thread_price_level.match_order(
+                    quantity,
+                    taker_id,
+                    TimestampMs::new(1_716_000_000_000),
+                    &thread_tx_id_gen,
+                );
 
                 // Count successful matches
                 if result.executed_quantity().unwrap_or(0) > 0 {

--- a/examples/src/bin/integration_basic_lifecycle.rs
+++ b/examples/src/bin/integration_basic_lifecycle.rs
@@ -21,7 +21,7 @@ fn main() {
 
     // --- Phase 1: Add orders ---
     println!("[Phase 1] Adding orders...");
-    let mut ts = 1_616_823_000_000_u64;
+    let base_ts = 1_616_823_000_000_u64;
 
     for i in 1..=10_u64 {
         let order = OrderType::Standard {
@@ -30,12 +30,11 @@ fn main() {
             quantity: Quantity::new(100),
             side: Side::Buy,
             user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(ts),
+            timestamp: TimestampMs::new(base_ts + (i - 1)),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
         price_level.add_order(order);
-        ts += 1;
     }
 
     assert_eq_or_exit(price_level.order_count(), 10, "order_count after add");
@@ -125,7 +124,12 @@ fn main() {
     // --- Phase 5: Match orders ---
     println!("[Phase 5] Matching orders...");
     let taker_id = Id::from_u64(1000);
-    let match_result: MatchResult = price_level.match_order(200, taker_id, &trade_id_gen);
+    let match_result: MatchResult = price_level.match_order(
+        200,
+        taker_id,
+        TimestampMs::new(1_716_000_000_000),
+        &trade_id_gen,
+    );
 
     let executed_qty = match_result
         .executed_quantity()
@@ -150,7 +154,12 @@ fn main() {
     println!("[Phase 6] Partial match (exceeds available)...");
     let taker_id2 = Id::from_u64(1001);
     let remaining_visible = price_level.visible_quantity();
-    let partial = price_level.match_order(remaining_visible + 500, taker_id2, &trade_id_gen);
+    let partial = price_level.match_order(
+        remaining_visible + 500,
+        taker_id2,
+        TimestampMs::new(1_716_000_000_000),
+        &trade_id_gen,
+    );
 
     assert_or_exit(
         !partial.is_complete(),

--- a/examples/src/bin/integration_checked_arithmetic.rs
+++ b/examples/src/bin/integration_checked_arithmetic.rs
@@ -85,7 +85,12 @@ fn test_executed_quantity_and_value(id_gen: &UuidGenerator) {
         });
     }
 
-    let result = level.match_order(250, Id::from_u64(999), id_gen);
+    let result = level.match_order(
+        250,
+        Id::from_u64(999),
+        TimestampMs::new(1_716_000_000_000),
+        id_gen,
+    );
 
     let executed_qty = result
         .executed_quantity()
@@ -130,7 +135,12 @@ fn test_average_price(id_gen: &UuidGenerator) {
         extra_fields: (),
     });
 
-    let result = level.match_order(100, Id::from_u64(800), id_gen);
+    let result = level.match_order(
+        100,
+        Id::from_u64(800),
+        TimestampMs::new(1_716_000_000_000),
+        id_gen,
+    );
     let avg = result
         .average_price()
         .unwrap_or_else(|e| exit_err(&format!("average_price: {e}")));
@@ -150,7 +160,12 @@ fn test_empty_match_result(id_gen: &UuidGenerator) {
 
     // Match on empty level
     let empty_level = PriceLevel::new(10_000);
-    let result = empty_level.match_order(100, Id::from_u64(900), id_gen);
+    let result = empty_level.match_order(
+        100,
+        Id::from_u64(900),
+        TimestampMs::new(1_716_000_000_000),
+        id_gen,
+    );
 
     let executed = result
         .executed_quantity()
@@ -228,7 +243,12 @@ fn test_match_result_display_fromstr(id_gen: &UuidGenerator) {
         extra_fields: (),
     });
 
-    let result = level.match_order(30, Id::from_u64(888), id_gen);
+    let result = level.match_order(
+        30,
+        Id::from_u64(888),
+        TimestampMs::new(1_716_000_000_000),
+        id_gen,
+    );
     let display = result.to_string();
 
     // Verify the display contains expected fields

--- a/examples/src/bin/integration_special_orders.rs
+++ b/examples/src/bin/integration_special_orders.rs
@@ -50,7 +50,12 @@ fn test_iceberg_order(id_gen: &UuidGenerator) {
     assert_eq_or_exit(level.order_count(), 1, "iceberg order_count");
 
     // Match against visible portion
-    let result = level.match_order(10, Id::from_u64(100), id_gen);
+    let result = level.match_order(
+        10,
+        Id::from_u64(100),
+        TimestampMs::new(1_716_000_000_000),
+        id_gen,
+    );
     let executed = result.executed_quantity().unwrap_or(0);
     assert_eq_or_exit(executed, 10, "iceberg match executed");
     assert_or_exit(result.is_complete(), "taker should be fully filled");
@@ -89,7 +94,12 @@ fn test_reserve_order(id_gen: &UuidGenerator) {
     assert_eq_or_exit(level.hidden_quantity(), 50, "reserve hidden_qty");
 
     // Match some visible quantity
-    let result = level.match_order(8, Id::from_u64(200), id_gen);
+    let result = level.match_order(
+        8,
+        Id::from_u64(200),
+        TimestampMs::new(1_716_000_000_000),
+        id_gen,
+    );
     let executed = result.executed_quantity().unwrap_or(0);
     assert_eq_or_exit(executed, 8, "reserve match executed");
 
@@ -127,7 +137,12 @@ fn test_post_only_order(id_gen: &UuidGenerator) {
     assert_eq_or_exit(level.order_count(), 1, "postonly order_count");
 
     // Match against post-only order
-    let result = level.match_order(50, Id::from_u64(300), id_gen);
+    let result = level.match_order(
+        50,
+        Id::from_u64(300),
+        TimestampMs::new(1_716_000_000_000),
+        id_gen,
+    );
     assert_eq_or_exit(
         result.executed_quantity().unwrap_or(0),
         50,
@@ -164,7 +179,12 @@ fn test_trailing_stop_order(id_gen: &UuidGenerator) {
 
     assert_eq_or_exit(level.visible_quantity(), 30, "trailing visible_qty");
 
-    let result = level.match_order(30, Id::from_u64(400), id_gen);
+    let result = level.match_order(
+        30,
+        Id::from_u64(400),
+        TimestampMs::new(1_716_000_000_000),
+        id_gen,
+    );
     assert_eq_or_exit(
         result.executed_quantity().unwrap_or(0),
         30,
@@ -194,7 +214,12 @@ fn test_pegged_order(id_gen: &UuidGenerator) {
 
     assert_eq_or_exit(level.visible_quantity(), 25, "pegged visible_qty");
 
-    let result = level.match_order(25, Id::from_u64(500), id_gen);
+    let result = level.match_order(
+        25,
+        Id::from_u64(500),
+        TimestampMs::new(1_716_000_000_000),
+        id_gen,
+    );
     assert_eq_or_exit(
         result.executed_quantity().unwrap_or(0),
         25,
@@ -223,7 +248,12 @@ fn test_market_to_limit_order(id_gen: &UuidGenerator) {
     assert_eq_or_exit(level.visible_quantity(), 40, "m2l visible_qty");
 
     // Partial match
-    let result = level.match_order(15, Id::from_u64(600), id_gen);
+    let result = level.match_order(
+        15,
+        Id::from_u64(600),
+        TimestampMs::new(1_716_000_000_000),
+        id_gen,
+    );
     assert_eq_or_exit(
         result.executed_quantity().unwrap_or(0),
         15,

--- a/examples/src/bin/integration_trade_roundtrip.rs
+++ b/examples/src/bin/integration_trade_roundtrip.rs
@@ -134,7 +134,12 @@ fn main() {
     let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
         .unwrap_or_else(|e| exit_err(&format!("uuid: {e}")));
     let id_gen = UuidGenerator::new(namespace);
-    let result: MatchResult = price_level.match_order(50, Id::from_u64(999), &id_gen);
+    let result: MatchResult = price_level.match_order(
+        50,
+        Id::from_u64(999),
+        TimestampMs::new(1_716_000_000_000),
+        &id_gen,
+    );
 
     assert_eq_or_exit(
         result.executed_quantity().unwrap_or(0),

--- a/examples/src/bin/simple.rs
+++ b/examples/src/bin/simple.rs
@@ -70,6 +70,7 @@ fn main() {
                         let match_result = thread_price_level.match_order(
                             5, // Match 5 units each time
                             taker_id,
+                            TimestampMs::new(1_716_000_000_000),
                             &thread_tx_id_gen,
                         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,6 +330,28 @@
 //! 7. Update snapshot code to use [`PriceLevelSnapshotPackage`] for checksum validation.
 //! 8. Address new `#[must_use]` warnings on query methods.
 //!
+//! ## Migration Guide (deterministic `match_order` timestamp)
+//!
+//! [`PriceLevel::match_order`] now takes an explicit `timestamp: TimestampMs`
+//! argument, inserted **between** `taker_order_id` and the trade-id generator:
+//!
+//! | Before | After |
+//! |--------|-------|
+//! | `level.match_order(qty, taker_id, &gen)` | `level.match_order(qty, taker_id, ts, &gen)` |
+//!
+//! **Why.** The match path previously read the wall clock once per emitted
+//! [`Trade`] (`SystemTime::now()`) and once per fill inside the statistics
+//! update. That made the trade stream non-deterministic (each replay produced
+//! different `Trade::timestamp` values) and put two syscalls per fill on the
+//! hot path. The caller now threads a single taker timestamp in; it is stamped
+//! onto every [`Trade`] and used as the execution time for statistics. No clock
+//! is read on the match path, so matching the same input twice with the same
+//! `timestamp` yields a byte-identical trade stream — a prerequisite for
+//! snapshot/replay equivalence.
+//!
+//! Pass the taker's arrival timestamp (or any deterministic value for
+//! tests/replay), e.g. [`TimestampMs::new`].
+//!
 
 mod orders;
 mod price_level;

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -6,7 +6,7 @@ use crate::execution::{MatchResult, Trade};
 use crate::orders::{Id, OrderType, OrderUpdate};
 use crate::price_level::order_queue::OrderQueue;
 use crate::price_level::{PriceLevelSnapshot, PriceLevelSnapshotPackage, PriceLevelStatistics};
-use crate::utils::{Price, Quantity};
+use crate::utils::{Price, Quantity, TimestampMs};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::FromStr;
@@ -173,7 +173,14 @@ impl PriceLevel {
     ///
     /// * `incoming_quantity`: The quantity of the incoming order to be matched.
     /// * `taker_order_id`: The ID of the incoming order (the "taker" order).
+    /// * `timestamp`: The taker timestamp (milliseconds since epoch) stamped
+    ///   onto every emitted [`Trade`] and used as the execution time for
+    ///   statistics. It is threaded in from the caller so the match path never
+    ///   reads the wall clock — guaranteeing a deterministic, replayable trade
+    ///   stream for a fixed input.
     /// * `trade_id_generator`: An atomic counter used to generate unique trade IDs.
+    ///
+    /// [`Trade`]: crate::execution::Trade
     ///
     /// # Returns
     ///
@@ -196,6 +203,7 @@ impl PriceLevel {
         &self,
         incoming_quantity: u64,
         taker_order_id: Id,
+        timestamp: TimestampMs,
         trade_id_generator: &UuidGenerator,
     ) -> MatchResult {
         let mut result = MatchResult::new(taker_order_id, incoming_quantity);
@@ -213,13 +221,14 @@ impl PriceLevel {
                     // Use UUID generator directly
                     let trade_id = Id::from_uuid(trade_id_generator.next());
 
-                    let trade = Trade::new(
+                    let trade = Trade::with_timestamp(
                         trade_id,
                         taker_order_id,
                         order_arc.id(),
                         Price::new(self.price),
                         Quantity::new(consumed),
                         order_arc.side().opposite(),
+                        timestamp,
                     );
 
                     if result.add_trade(trade).is_err() {
@@ -240,6 +249,7 @@ impl PriceLevel {
                     consumed,
                     order_arc.price().as_u128(),
                     order_arc.timestamp(),
+                    timestamp.as_u64(),
                 );
 
                 if let Some(updated) = updated_order {

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -240,17 +240,20 @@ impl PriceLevel {
                     if updated_order.is_none() {
                         result.add_filled_order_id(order_arc.id());
                     }
+
+                    // Update statistics only for real executions. A popped maker
+                    // can yield `consumed == 0` (e.g. a zero-quantity resting
+                    // order from `update_order`); recording it would inflate
+                    // `orders_executed` / `last_execution_time` without a trade.
+                    let _ = self.stats.record_execution(
+                        consumed,
+                        order_arc.price().as_u128(),
+                        order_arc.timestamp(),
+                        timestamp.as_u64(),
+                    );
                 }
 
                 remaining = new_remaining;
-
-                // update statistics
-                let _ = self.stats.record_execution(
-                    consumed,
-                    order_arc.price().as_u128(),
-                    order_arc.timestamp(),
-                    timestamp.as_u64(),
-                );
 
                 if let Some(updated) = updated_order {
                     if hidden_reduced > 0 {

--- a/src/price_level/statistics.rs
+++ b/src/price_level/statistics.rs
@@ -126,8 +126,22 @@ impl PriceLevelStatistics {
     ) -> Result<(), PriceLevelError> {
         let current_time = execution_timestamp;
 
-        self.orders_executed.fetch_add(1, Ordering::Relaxed);
-        Self::checked_fetch_add_u64(&self.quantity_executed, quantity, "quantity_executed")?;
+        // Validate everything that can fail BEFORE mutating any counter, so a
+        // rejected record leaves the statistics untouched. `match_order` ignores
+        // the returned `Result`, so any partial side effect would silently
+        // corrupt the stats.
+        let waiting_time = if order_timestamp > 0 {
+            Some(current_time.checked_sub(order_timestamp).ok_or_else(|| {
+                PriceLevelError::InvalidOperation {
+                    message: format!(
+                        "order timestamp {} is in the future of current time {}",
+                        order_timestamp, current_time
+                    ),
+                }
+            })?)
+        } else {
+            None
+        };
 
         let value_u128 = u128::from(quantity).checked_mul(price).ok_or_else(|| {
             PriceLevelError::InvalidOperation {
@@ -140,21 +154,15 @@ impl PriceLevelStatistics {
                 message: "value_executed exceeds u64 storage".to_string(),
             })?;
 
+        // All fallible validation passed — now apply the mutations. (The only
+        // residual failure mode is a counter nearing `u64::MAX`, inherent to
+        // independent lock-free atomics.)
+        self.orders_executed.fetch_add(1, Ordering::Relaxed);
+        Self::checked_fetch_add_u64(&self.quantity_executed, quantity, "quantity_executed")?;
         Self::checked_fetch_add_u64(&self.value_executed, value_u64, "value_executed")?;
         self.last_execution_time
             .store(current_time, Ordering::Relaxed);
-
-        // Calculate waiting time for this order
-        if order_timestamp > 0 {
-            let waiting_time = current_time.checked_sub(order_timestamp).ok_or_else(|| {
-                PriceLevelError::InvalidOperation {
-                    message: format!(
-                        "order timestamp {} is in the future of current time {}",
-                        order_timestamp, current_time
-                    ),
-                }
-            })?;
-
+        if let Some(waiting_time) = waiting_time {
             Self::checked_fetch_add_u64(&self.sum_waiting_time, waiting_time, "sum_waiting_time")?;
         }
 

--- a/src/price_level/statistics.rs
+++ b/src/price_level/statistics.rs
@@ -101,14 +101,30 @@ impl PriceLevelStatistics {
         self.orders_removed.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Record an order execution
+    /// Record an order execution.
+    ///
+    /// The `execution_timestamp` is the taker timestamp threaded in from the
+    /// caller (the same value stamped onto the emitted [`Trade`]s). It is used
+    /// both as the level's `last_execution_time` and as the reference time for
+    /// the per-maker waiting-time accumulation. This keeps the match path
+    /// clock-free and deterministic: no wall-clock read happens during a match.
+    ///
+    /// [`Trade`]: crate::execution::Trade
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if any of the counter
+    /// accumulations overflow, if the value (`quantity * price`) overflows
+    /// `u128`/`u64`, or if `order_timestamp` is strictly greater than
+    /// `execution_timestamp` (a maker arriving in the future of execution).
     pub fn record_execution(
         &self,
         quantity: u64,
         price: u128,
         order_timestamp: u64,
+        execution_timestamp: u64,
     ) -> Result<(), PriceLevelError> {
-        let current_time = Self::current_timestamp_milliseconds()?;
+        let current_time = execution_timestamp;
 
         self.orders_executed.fetch_add(1, Ordering::Relaxed);
         Self::checked_fetch_add_u64(&self.quantity_executed, quantity, "quantity_executed")?;

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -496,13 +496,27 @@ mod tests {
         let taker_id = Id::from_u64(999);
         let timestamp = TimestampMs::new(1_716_000_000_000);
 
+        // Build makers with FIXED timestamps so both runs use truly identical
+        // input. `create_standard_order` draws from a global counter that
+        // advances on every call, which would differ between the two runs.
+        let mk = |id: u64, qty: u64| OrderType::Standard {
+            id: Id::from_u64(id),
+            price: Price::new(10000),
+            quantity: Quantity::new(qty),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_700_000_000_000 + id),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        };
+
         // Run a scenario that crosses several resting makers (partial fill of
         // the last maker) so the trade stream has multiple entries.
         let run = || {
             let price_level = PriceLevel::new(10000);
-            price_level.add_order(create_standard_order(1, 10000, 40));
-            price_level.add_order(create_standard_order(2, 10000, 30));
-            price_level.add_order(create_standard_order(3, 10000, 50));
+            price_level.add_order(mk(1, 40));
+            price_level.add_order(mk(2, 30));
+            price_level.add_order(mk(3, 50));
 
             let trade_id_generator = UuidGenerator::new(namespace);
             price_level.match_order(90, taker_id, timestamp, &trade_id_generator)

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -456,7 +456,12 @@ mod tests {
 
         // Match the entire order
         let taker_id = Id::from_u64(999); // market order ID
-        let match_result = price_level.match_order(100, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            100,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.order_id(), taker_id);
         assert_eq!(match_result.remaining_quantity(), 0);
@@ -482,6 +487,49 @@ mod tests {
     }
 
     #[test]
+    fn test_match_order_multi_maker_deterministic_timestamps() {
+        // Matching the same input twice with the same threaded timestamp must
+        // yield byte-identical trade streams — including each trade's timestamp,
+        // trade_id, and quantity. This guarantees a replayable trade stream and
+        // proves the match path never reads the wall clock.
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let taker_id = Id::from_u64(999);
+        let timestamp = TimestampMs::new(1_716_000_000_000);
+
+        // Run a scenario that crosses several resting makers (partial fill of
+        // the last maker) so the trade stream has multiple entries.
+        let run = || {
+            let price_level = PriceLevel::new(10000);
+            price_level.add_order(create_standard_order(1, 10000, 40));
+            price_level.add_order(create_standard_order(2, 10000, 30));
+            price_level.add_order(create_standard_order(3, 10000, 50));
+
+            let trade_id_generator = UuidGenerator::new(namespace);
+            price_level.match_order(90, taker_id, timestamp, &trade_id_generator)
+        };
+
+        let first = run();
+        let second = run();
+
+        let first_trades = first.trades().as_vec();
+        let second_trades = second.trades().as_vec();
+
+        // Crossed two full makers (40 + 30) and partially filled the third (20).
+        assert_eq!(first_trades.len(), 3);
+        assert_eq!(first.executed_quantity().unwrap_or_default(), 90);
+        assert_eq!(second.executed_quantity().unwrap_or_default(), 90);
+
+        // Byte-identical trade streams (Trade derives PartialEq over every
+        // field, including the timestamp).
+        assert_eq!(first_trades, second_trades);
+
+        // Explicitly assert each trade's timestamp is exactly the threaded one.
+        for trade in first_trades {
+            assert_eq!(trade.timestamp(), timestamp);
+        }
+    }
+
+    #[test]
     fn test_match_standard_order_partial() {
         let price_level = PriceLevel::new(10000);
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
@@ -491,7 +539,12 @@ mod tests {
 
         // Match part of the order
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(60, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            60,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         // Verificar el resultado de matching
         assert_eq!(match_result.order_id(), taker_id);
@@ -527,7 +580,12 @@ mod tests {
 
         // Match with quantity exceeding available
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(150, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            150,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.order_id(), taker_id);
         assert_eq!(match_result.remaining_quantity(), 50); // 150 - 100 = 50 remaining
@@ -563,7 +621,12 @@ mod tests {
 
         // Match the visible portion of the iceberg order.
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            50,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         // Assertions to validate the match result.
         assert_eq!(match_result.order_id(), taker_id);
@@ -585,7 +648,12 @@ mod tests {
 
         // Match another 50 units, which should deplete the visible portion and reveal more.
         let taker_id = Id::from_u64(1000);
-        let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            50,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 50); // Visible quantity replenished
@@ -602,7 +670,12 @@ mod tests {
 
         // Match the remaining 50 units (50 visible + 0 hidden).
         let taker_id = Id::from_u64(1001);
-        let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            50,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
@@ -623,7 +696,12 @@ mod tests {
 
         // Match the visible portion of the iceberg order.
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            50,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         // Assertions to validate the match result.
         assert_eq!(match_result.order_id(), taker_id);
@@ -645,7 +723,12 @@ mod tests {
 
         // Match another 50 units, which should deplete the visible portion and reveal more.
         let taker_id = Id::from_u64(1000);
-        let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            50,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 50); // Visible quantity replenished
@@ -664,7 +747,12 @@ mod tests {
         let taker_id = Id::from_u64(1001);
 
         // This should match the remaining visible quantity and deplete the hidden quantity.
-        let match_result = price_level.match_order(150, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            150,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
         assert_eq!(match_result.remaining_quantity(), 50);
         assert!(!match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
@@ -684,7 +772,12 @@ mod tests {
 
         // Match part of the visible portion
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(30, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            30,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -709,7 +802,12 @@ mod tests {
 
         // Match the entire visible portion
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            50,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -733,7 +831,12 @@ mod tests {
 
         // Match the entire visible portion
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            50,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -763,7 +866,12 @@ mod tests {
 
         // Match partially, but still above threshold
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(25, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            25,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -772,7 +880,12 @@ mod tests {
 
         // Match more to go below threshold
         let taker_id = Id::from_u64(1000);
-        let match_result = price_level.match_order(10, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            10,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -804,7 +917,12 @@ mod tests {
 
         // Match the entire visible portion
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            50,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -828,7 +946,12 @@ mod tests {
 
         // Match partially
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(49, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            49,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -851,7 +974,12 @@ mod tests {
 
         // Match the entire visible portion
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            50,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -874,7 +1002,12 @@ mod tests {
 
         // Match the entire visible portion
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            50,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -897,7 +1030,12 @@ mod tests {
 
         // Match part of the visible portion, but still above threshold
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(25, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            25,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -906,7 +1044,12 @@ mod tests {
 
         // Match more to go below threshold
         let taker_id = Id::from_u64(1000);
-        let match_result = price_level.match_order(10, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            10,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -932,7 +1075,12 @@ mod tests {
 
         // Match 80 units, which is above the replenish threshold
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(80, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            80,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         // Validate the match result
         assert_eq!(match_result.order_id(), taker_id);
@@ -954,7 +1102,12 @@ mod tests {
 
         // Match 10 more units, which will take us below the replenish threshold
         let taker_id = Id::from_u64(1000);
-        let match_result = price_level.match_order(10, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            10,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -972,7 +1125,12 @@ mod tests {
 
         // Match with a larger amount than what's available
         let taker_id = Id::from_u64(1001);
-        let match_result = price_level.match_order(150, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            150,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 40); // 150 - 90 - 20 = 40
         assert!(!match_result.is_complete());
@@ -1012,7 +1170,12 @@ mod tests {
 
         // Post-only orders behave like standard orders for matching
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(60, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            60,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -1030,7 +1193,12 @@ mod tests {
 
         // Trailing stop orders behave like standard orders for matching
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(100, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            100,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -1048,7 +1216,12 @@ mod tests {
 
         // Pegged orders behave like standard orders for matching
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            50,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -1066,7 +1239,12 @@ mod tests {
 
         // Market-to-limit orders behave like standard orders for matching
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(100, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            100,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -1084,7 +1262,12 @@ mod tests {
 
         // For the price level, FOK behaves like standard orders
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(100, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            100,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -1102,7 +1285,12 @@ mod tests {
 
         // For the price level, IOC behaves like standard orders
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(50, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            50,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -1120,7 +1308,12 @@ mod tests {
 
         // GTD orders behave like standard orders for matching
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(100, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            100,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -1140,7 +1333,12 @@ mod tests {
 
         // Match first two orders completely and third partially
         let taker_id = Id::from_u64(999);
-        let match_result = price_level.match_order(140, taker_id, &transaction_id_generator);
+        let match_result = price_level.match_order(
+            140,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         // Verificar el resultado de matching
         assert_eq!(match_result.order_id(), taker_id);
@@ -1564,8 +1762,12 @@ mod tests {
         price_level.add_order(create_standard_order(1, 10000, 200));
 
         // Match only part of what's available
-        let match_result =
-            price_level.match_order(100, Id::from_u64(999), &transaction_id_generator);
+        let match_result = price_level.match_order(
+            100,
+            Id::from_u64(999),
+            TimestampMs::new(1_716_000_000_000),
+            &transaction_id_generator,
+        );
 
         assert_eq!(match_result.remaining_quantity(), 0);
         assert!(match_result.is_complete());
@@ -1944,7 +2146,12 @@ mod tests {
         price_level.add_order(create_standard_order(2, 10000, 100));
 
         // First aggressor partially fills A (60 of 100). A's residual = 40.
-        let first = price_level.match_order(60, Id::from_u64(901), &trade_ids);
+        let first = price_level.match_order(
+            60,
+            Id::from_u64(901),
+            TimestampMs::new(1_716_000_000_000),
+            &trade_ids,
+        );
         assert_eq!(first.trades().len(), 1);
         assert_eq!(
             first.trades().as_vec()[0].maker_order_id(),
@@ -1957,7 +2164,12 @@ mod tests {
         assert_eq!(price_level.order_count(), 2);
 
         // Second aggressor (50) must hit A's remainder (40) FIRST, then B (10).
-        let second = price_level.match_order(50, Id::from_u64(902), &trade_ids);
+        let second = price_level.match_order(
+            50,
+            Id::from_u64(902),
+            TimestampMs::new(1_716_000_000_000),
+            &trade_ids,
+        );
         assert_eq!(second.trades().len(), 2);
 
         let t0 = &second.trades().as_vec()[0];
@@ -1994,7 +2206,12 @@ mod tests {
         };
         assert_eq!(total_before, 200);
 
-        let _ = price_level.match_order(60, Id::from_u64(901), &trade_ids);
+        let _ = price_level.match_order(
+            60,
+            Id::from_u64(901),
+            TimestampMs::new(1_716_000_000_000),
+            &trade_ids,
+        );
         let total_after = match price_level.total_quantity() {
             Ok(q) => q,
             Err(e) => panic!("total_quantity failed: {e}"),
@@ -2018,13 +2235,23 @@ mod tests {
 
         // Aggressor consumes I's visible tip (50) → I refreshes from hidden and
         // moves to the tail. remaining hits 0, so this call stops there.
-        let first = price_level.match_order(50, Id::from_u64(901), &trade_ids);
+        let first = price_level.match_order(
+            50,
+            Id::from_u64(901),
+            TimestampMs::new(1_716_000_000_000),
+            &trade_ids,
+        );
         assert_eq!(first.trades().len(), 1);
         assert_eq!(first.trades().as_vec()[0].maker_order_id(), Id::from_u64(1));
 
         // Next aggressor must now hit O (id=2) FIRST, because the refreshed
         // iceberg tranche lost its priority to the tail.
-        let second = price_level.match_order(50, Id::from_u64(902), &trade_ids);
+        let second = price_level.match_order(
+            50,
+            Id::from_u64(902),
+            TimestampMs::new(1_716_000_000_000),
+            &trade_ids,
+        );
         assert_eq!(
             second.trades().as_vec()[0].maker_order_id(),
             Id::from_u64(2),
@@ -2042,7 +2269,12 @@ mod tests {
 
         price_level.add_order(create_standard_order(1, 10000, 100));
         price_level.add_order(create_standard_order(2, 10000, 100));
-        let _ = price_level.match_order(60, Id::from_u64(901), &trade_ids);
+        let _ = price_level.match_order(
+            60,
+            Id::from_u64(901),
+            TimestampMs::new(1_716_000_000_000),
+            &trade_ids,
+        );
 
         let json = match price_level.snapshot_to_json() {
             Ok(j) => j,
@@ -2056,7 +2288,12 @@ mod tests {
         // Match against the restored level: A's residual (40) must still come
         // first, proving the snapshot preserved price-time priority.
         let restored_trade_ids = UuidGenerator::new(namespace);
-        let result = restored.match_order(50, Id::from_u64(903), &restored_trade_ids);
+        let result = restored.match_order(
+            50,
+            Id::from_u64(903),
+            TimestampMs::new(1_716_000_000_000),
+            &restored_trade_ids,
+        );
         assert_eq!(
             result.trades().as_vec()[0].maker_order_id(),
             Id::from_u64(1),

--- a/src/price_level/tests/statistics.rs
+++ b/src/price_level/tests/statistics.rs
@@ -5,7 +5,7 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::Ordering;
     use std::thread;
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn test_new() {
@@ -29,11 +29,12 @@ mod tests {
             .unwrap()
             .as_millis() as u64;
 
-        // Future timestamps should return an explicit error.
-        assert!(stats.record_execution(1, 100, now + 1_000).is_err());
+        // Future timestamps (maker arrived after execution) should return an
+        // explicit error.
+        assert!(stats.record_execution(1, 100, now + 1_000, now).is_err());
 
         // Multiplication overflow should return an explicit error.
-        assert!(stats.record_execution(u64::MAX, u128::MAX, 0).is_err());
+        assert!(stats.record_execution(u64::MAX, u128::MAX, 0, now).is_err());
     }
 
     #[test]
@@ -60,24 +61,24 @@ mod tests {
         }
         assert_eq!(stats.orders_removed(), 3);
 
+        // Deterministic execution timestamp threaded in by the caller.
+        let execution_time: u64 = 1_716_000_000_000;
+
         // Test recording executed orders
-        assert!(stats.record_execution(10, 100, 0).is_ok()); // qty=10, price=100, no timestamp
+        assert!(stats.record_execution(10, 100, 0, execution_time).is_ok()); // qty=10, price=100, no timestamp
         assert_eq!(stats.orders_executed(), 1);
         assert_eq!(stats.quantity_executed(), 10);
         assert_eq!(stats.value_executed(), 1000); // 10 * 100
         assert!(stats.last_execution_time.load(Ordering::Relaxed) > 0);
 
-        // Test with timestamp
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64
-            - 1000; // 1 second ago
+        // Test with a maker timestamp 1 second before the execution time.
+        let timestamp = execution_time - 1000; // 1 second ago
 
-        // Sleep to ensure waiting time is measurable
-        thread::sleep(Duration::from_millis(10));
-
-        assert!(stats.record_execution(5, 200, timestamp).is_ok());
+        assert!(
+            stats
+                .record_execution(5, 200, timestamp, execution_time)
+                .is_ok()
+        );
         assert_eq!(stats.orders_executed(), 2);
         assert_eq!(stats.quantity_executed(), 15); // 10 + 5
         assert_eq!(stats.value_executed(), 2000); // 1000 + (5 * 200)
@@ -92,8 +93,9 @@ mod tests {
         assert_eq!(stats.average_execution_price(), None);
 
         // Test with executions
-        assert!(stats.record_execution(10, 100, 0).is_ok()); // Total value: 1000
-        assert!(stats.record_execution(20, 150, 0).is_ok()); // Total value: 3000 + 1000 = 4000
+        let execution_time: u64 = 1_716_000_000_000;
+        assert!(stats.record_execution(10, 100, 0, execution_time).is_ok()); // Total value: 1000
+        assert!(stats.record_execution(20, 150, 0, execution_time).is_ok()); // Total value: 3000 + 1000 = 4000
 
         // Average price should be 4000 / 30 = 133.33...
         let avg_price = stats.average_execution_price().unwrap();
@@ -107,14 +109,11 @@ mod tests {
         // Test with no executions
         assert_eq!(stats.average_waiting_time(), None);
 
-        // Test with executions
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64;
+        // Test with executions against a fixed execution time.
+        let now: u64 = 1_716_000_000_000;
 
-        assert!(stats.record_execution(10, 100, now - 1000).is_ok()); // 1 second ago
-        assert!(stats.record_execution(20, 150, now - 3000).is_ok()); // 3 seconds ago
+        assert!(stats.record_execution(10, 100, now - 1000, now).is_ok()); // 1 second ago
+        assert!(stats.record_execution(20, 150, now - 3000, now).is_ok()); // 3 seconds ago
 
         // Total waiting time: 1000 + 3000 = 4000ms, average = 2000ms
         let avg_wait = stats.average_waiting_time().unwrap();
@@ -128,11 +127,15 @@ mod tests {
         // Test with no executions
         assert_eq!(stats.time_since_last_execution(), None);
 
-        // Record an execution
-        assert!(stats.record_execution(10, 100, 0).is_ok());
-
-        // Sleep a bit to ensure time passes
-        thread::sleep(Duration::from_millis(10));
+        // Record an execution with an explicit execution time in the past so
+        // the wall-clock-based `time_since_last_execution` reports a positive
+        // delta deterministically (no sleep needed).
+        let past = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64
+            - 1000;
+        assert!(stats.record_execution(10, 100, 0, past).is_ok());
 
         // Should return some non-zero value
         let time_since = stats.time_since_last_execution().unwrap();
@@ -146,7 +149,11 @@ mod tests {
         // Add some data
         stats.record_order_added();
         stats.record_order_removed();
-        assert!(stats.record_execution(10, 100, 0).is_ok());
+        assert!(
+            stats
+                .record_execution(10, 100, 0, 1_716_000_000_000)
+                .is_ok()
+        );
 
         // Verify data was recorded
         assert_eq!(stats.orders_added(), 1);
@@ -174,7 +181,11 @@ mod tests {
         // Add some data
         stats.record_order_added();
         stats.record_order_removed();
-        assert!(stats.record_execution(10, 100, 0).is_ok());
+        assert!(
+            stats
+                .record_execution(10, 100, 0, 1_716_000_000_000)
+                .is_ok()
+        );
 
         // Get display string
         let display_str = stats.to_string();
@@ -240,7 +251,11 @@ mod tests {
         // Add some data
         stats.record_order_added();
         stats.record_order_removed();
-        assert!(stats.record_execution(10, 100, 0).is_ok());
+        assert!(
+            stats
+                .record_execution(10, 100, 0, 1_716_000_000_000)
+                .is_ok()
+        );
 
         // Serialize to JSON
         let json = serde_json::to_string(&stats).unwrap();
@@ -327,7 +342,7 @@ mod tests {
                 for _ in 0..100 {
                     stats_clone.record_order_added();
                     stats_clone.record_order_removed();
-                    if let Err(error) = stats_clone.record_execution(1, 100, 0) {
+                    if let Err(error) = stats_clone.record_execution(1, 100, 0, 1_716_000_000_000) {
                         panic!("record_execution failed in thread: {error}");
                     }
                 }
@@ -356,7 +371,11 @@ mod tests {
         stats.record_order_added();
         stats.record_order_added();
         stats.record_order_removed();
-        assert!(stats.record_execution(10, 100, 0).is_ok());
+        assert!(
+            stats
+                .record_execution(10, 100, 0, 1_716_000_000_000)
+                .is_ok()
+        );
 
         // Verify stats were recorded
         assert_eq!(stats.orders_added(), 2);

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -40,12 +40,22 @@ fn partial_fill_keeps_price_time_priority_across_calls() {
     level.add_order(standard_buy(2, 10_000, 100, 1_001));
 
     // Partially fill A.
-    let first = level.match_order(60, Id::from_u64(901), &trade_ids);
+    let first = level.match_order(
+        60,
+        Id::from_u64(901),
+        TimestampMs::new(1_716_000_000_000),
+        &trade_ids,
+    );
     assert_eq!(first.trades().len(), 1);
     assert_eq!(first.trades().as_vec()[0].maker_order_id(), Id::from_u64(1));
 
     // Second aggressor must hit A's remainder (40) first, then B (10).
-    let second = level.match_order(50, Id::from_u64(902), &trade_ids);
+    let second = level.match_order(
+        50,
+        Id::from_u64(902),
+        TimestampMs::new(1_716_000_000_000),
+        &trade_ids,
+    );
     assert_eq!(second.trades().len(), 2);
     assert_eq!(
         second.trades().as_vec()[0].maker_order_id(),


### PR DESCRIPTION
## Summary

The match path read the wall clock inside the inner fill loop — `Trade::new`
called `SystemTime::now()` for every emitted trade and the statistics update read
the clock once per fill — which made the trade stream non-deterministic and put
~2 syscalls per fill on the hot path. `match_order` now takes the taker timestamp
explicitly and threads it through, so no clock is read on the match path.

## Changes

- `PriceLevel::match_order` gains a `timestamp: TimestampMs` parameter (inserted
  between `taker_order_id` and the trade-id generator).
- Trades are built via `Trade::with_timestamp(...)` using the threaded value; no
  `Trade::new`/`SystemTime::now()` on the match path.
- `PriceLevelStatistics::record_execution` takes the execution timestamp instead
  of reading the clock internally; the off-path clock helpers (`new`, `reset`,
  `time_since_last_execution`, deserialize) are unchanged.
- All call sites updated (tests, integration, examples, benches) with a
  deterministic timestamp.

## Technical decisions

- Threading the timestamp from the caller (rather than reading it once at
  `match_order` entry) is what gives full snapshot/replay determinism: matching
  the same input twice with the same `timestamp` yields a byte-identical trade
  stream. The order book that composes levels passes the taker's arrival
  timestamp.
- FIFO/price-time determinism, `MatchResult` field agreement
  (`is_complete` ⇔ `remaining_quantity == 0`, `executed_quantity` == trade sum),
  all `Trade` fields, and snapshot round-trip are unchanged.

## Public API impact

Breaking: `match_order`'s signature changed. A migration note was added to the
guide in `src/lib.rs` and `README.md` was regenerated via `make readme`. No crate
version bump in this PR (releases are handled separately).

| Before | After |
|--------|-------|
| `level.match_order(qty, taker_id, &gen)` | `level.match_order(qty, taker_id, ts, &gen)` |

## Testing

- [x] Unit tests added or updated (co-located under `src/<module>/tests/`)
- [x] Determinism test: `test_match_order_multi_maker_deterministic_timestamps`
      (same input + same `timestamp` ⇒ byte-identical trade stream incl. each
      `Trade.timestamp`)
- [x] Integration tests under `tests/unit/` updated
- [x] `make pre-push` run locally and clean

`cargo test`: 331 passed (lib) + 1 (integration) + 9 (doctests), 0 failed.
`cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all
--check`, `cargo build --release`: all clean.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic on quantity / value / counters — no `saturating_*` / `wrapping_*`
- [x] No new production `unsafe` introduced
- [x] Module boundaries respected
- [x] No new dependencies added
- [x] `tracing` only for logging
- [x] `src/lib.rs` docs + `README.md` (via `make readme`) updated for the signature change

Closes #61
