### PR TITLE
Persist statistics through the snapshot round-trip (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,25 @@ snapshot/replay equivalence.
 Pass the taker's arrival timestamp (or any deterministic value for
 tests/replay), e.g. [`TimestampMs::new`].
 
+### Migration Guide (snapshot format v1 → v2)
+
+The checksum-protected snapshot format now persists per-level statistics
+(issue #63). [`PriceLevelSnapshot`] carries the eight `PriceLevelStatistics`
+counters — orders added / removed / executed, quantity and value executed,
+last-execution and first-arrival timestamps, and the waiting-time sum — and
+[`PriceLevel::from_snapshot_json`] / [`PriceLevel::from_snapshot`] restore
+them instead of resetting to a fresh, zeroed set. The new field is covered by
+the package SHA-256 checksum automatically.
+
+The snapshot format version (`SNAPSHOT_FORMAT_VERSION`) is bumped from `1` to
+`2`. Snapshot packages written by an earlier release carry `version: 1` and
+no statistics; they are **no longer accepted** —
+[`PriceLevelSnapshotPackage::validate`] rejects them up-front with a
+[`PriceLevelError::InvalidOperation`] version mismatch (not a confusing
+checksum error). Re-take any persisted snapshots with this release. No code
+changes are required at the call sites: `snapshot_to_json()` /
+`from_snapshot_json()` keep the same signatures.
+
 
  ## Setup Instructions
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,6 +352,25 @@
 //! Pass the taker's arrival timestamp (or any deterministic value for
 //! tests/replay), e.g. [`TimestampMs::new`].
 //!
+//! ## Migration Guide (snapshot format v1 → v2)
+//!
+//! The checksum-protected snapshot format now persists per-level statistics
+//! (issue #63). [`PriceLevelSnapshot`] carries the eight `PriceLevelStatistics`
+//! counters — orders added / removed / executed, quantity and value executed,
+//! last-execution and first-arrival timestamps, and the waiting-time sum — and
+//! [`PriceLevel::from_snapshot_json`] / [`PriceLevel::from_snapshot`] restore
+//! them instead of resetting to a fresh, zeroed set. The new field is covered by
+//! the package SHA-256 checksum automatically.
+//!
+//! The snapshot format version (`SNAPSHOT_FORMAT_VERSION`) is bumped from `1` to
+//! `2`. Snapshot packages written by an earlier release carry `version: 1` and
+//! no statistics; they are **no longer accepted** —
+//! [`PriceLevelSnapshotPackage::validate`] rejects them up-front with a
+//! [`PriceLevelError::InvalidOperation`] version mismatch (not a confusing
+//! checksum error). Re-take any persisted snapshots with this release. No code
+//! changes are required at the call sites: `snapshot_to_json()` /
+//! `from_snapshot_json()` keep the same signatures.
+//!
 
 mod orders;
 mod price_level;

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -38,6 +38,17 @@ pub struct PriceLevel {
 
 impl PriceLevel {
     /// Reconstructs a price level directly from a snapshot.
+    ///
+    /// The rebuilt level carries the per-level statistics persisted in the
+    /// snapshot (orders added / removed / executed, quantity / value executed,
+    /// waiting-time aggregates, and execution / arrival timestamps) rather than
+    /// a fresh, zeroed set — so a restored level resumes with its recorded
+    /// history.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if recomputing the snapshot
+    /// aggregates overflows `u64`.
     pub fn from_snapshot(mut snapshot: PriceLevelSnapshot) -> Result<Self, PriceLevelError> {
         snapshot.refresh_aggregates()?;
 
@@ -45,6 +56,8 @@ impl PriceLevel {
         let visible_quantity = snapshot.visible_quantity();
         let hidden_quantity = snapshot.hidden_quantity();
         let price = snapshot.price();
+        // Clone the persisted statistics before consuming the snapshot's orders.
+        let stats = (*snapshot.statistics()).clone();
         let queue = OrderQueue::from(snapshot.into_orders());
 
         Ok(Self {
@@ -53,7 +66,7 @@ impl PriceLevel {
             hidden_quantity: AtomicU64::new(hidden_quantity),
             order_count: AtomicUsize::new(order_count),
             orders: queue,
-            stats: Arc::new(PriceLevelStatistics::new()),
+            stats: Arc::new(stats),
         })
     }
 
@@ -349,12 +362,18 @@ impl PriceLevel {
             }
         }
 
-        PriceLevelSnapshot::from_raw_parts(
+        // Persist the per-level statistics alongside the aggregates so the
+        // snapshot round-trip reproduces the recorded execution history. The
+        // clone snapshots the eight atomic counters (best-effort, like every
+        // other read path); statistics are independent counters, not part of
+        // the queue / counter consistency invariant.
+        PriceLevelSnapshot::from_raw_parts_with_stats(
             self.price,
             visible_quantity,
             hidden_quantity,
             order_count,
             orders,
+            (*self.stats).clone(),
         )
     }
 
@@ -593,6 +612,8 @@ impl From<&PriceLevelSnapshot> for PriceLevel {
         let visible_quantity = snapshot.visible_quantity();
         let hidden_quantity = snapshot.hidden_quantity();
         let price = snapshot.price();
+        // Preserve the persisted statistics instead of resetting them.
+        let stats = (*snapshot.statistics()).clone();
         let queue = OrderQueue::from(snapshot.into_orders());
 
         Self {
@@ -601,7 +622,7 @@ impl From<&PriceLevelSnapshot> for PriceLevel {
             hidden_quantity: AtomicU64::new(hidden_quantity),
             order_count: AtomicUsize::new(order_count),
             orders: queue,
-            stats: Arc::new(PriceLevelStatistics::new()),
+            stats: Arc::new(stats),
         }
     }
 }

--- a/src/price_level/snapshot.rs
+++ b/src/price_level/snapshot.rs
@@ -482,10 +482,12 @@ impl<'de> Deserialize<'de> for PriceLevelSnapshot {
                 let order_count =
                     order_count.ok_or_else(|| de::Error::missing_field("order_count"))?;
                 let orders = orders.unwrap_or_default();
-                // `statistics` is optional so the DTO stays forward-compatible:
-                // a payload without it (e.g. a hand-built fixture) restores with
-                // empty statistics rather than failing. A genuine v1 *package*
-                // is still rejected up-front by `validate()`'s version check.
+                // `statistics` is optional on deserialize so a payload that omits
+                // it (e.g. a hand-built fixture) restores with empty statistics
+                // rather than failing — i.e. tolerant of a *missing* field, not
+                // forward-compatible with future *added* fields (this visitor
+                // still rejects unknown fields). A genuine v1 *package* is
+                // rejected up-front by `validate()`'s version check regardless.
                 let statistics = statistics.unwrap_or_default();
 
                 Ok(PriceLevelSnapshot {

--- a/src/price_level/snapshot.rs
+++ b/src/price_level/snapshot.rs
@@ -1,5 +1,6 @@
 use crate::errors::PriceLevelError;
 use crate::orders::OrderType;
+use crate::price_level::statistics::PriceLevelStatistics;
 use serde::de::{self, MapAccess, Visitor};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -9,8 +10,8 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 /// A snapshot of a price level in the order book. This struct provides a summary of the state of a specific price level
-/// at a given point in time, including the price, visible and hidden quantities, order count, and a vector of the orders
-/// at that level.
+/// at a given point in time, including the price, visible and hidden quantities, order count, the orders
+/// at that level, and the per-level execution statistics.
 #[derive(Debug, Default, Clone)]
 pub struct PriceLevelSnapshot {
     /// The price of this level.
@@ -23,6 +24,14 @@ pub struct PriceLevelSnapshot {
     order_count: usize,
     /// Orders at this level.
     orders: Vec<Arc<OrderType<()>>>,
+    /// Per-level execution statistics captured at snapshot time.
+    ///
+    /// Carries the eight counters (orders added / removed / executed, quantity
+    /// and value executed, last-execution and first-arrival timestamps, and the
+    /// waiting-time sum) so a restored level resumes with its recorded history
+    /// rather than a zeroed set. Persisted via [`PriceLevelStatistics`]'s own
+    /// serde shape and covered by the package SHA-256 checksum.
+    statistics: PriceLevelStatistics,
 }
 
 impl PriceLevelSnapshot {
@@ -35,13 +44,37 @@ impl PriceLevelSnapshot {
             hidden_quantity: 0,
             order_count: 0,
             orders: Vec::new(),
+            statistics: PriceLevelStatistics::new(),
         }
     }
 
     /// Creates a snapshot populated with orders, computing aggregates automatically.
+    ///
+    /// The statistics are initialized empty; use [`Self::with_orders_and_stats`]
+    /// to carry recorded execution statistics into the snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if summing the per-order
+    /// visible / hidden quantities overflows `u64`.
     pub fn with_orders(
         price: u128,
         orders: Vec<Arc<OrderType<()>>>,
+    ) -> Result<Self, PriceLevelError> {
+        Self::with_orders_and_stats(price, orders, PriceLevelStatistics::new())
+    }
+
+    /// Creates a snapshot populated with orders and statistics, computing
+    /// aggregates automatically.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if summing the per-order
+    /// visible / hidden quantities overflows `u64`.
+    pub fn with_orders_and_stats(
+        price: u128,
+        orders: Vec<Arc<OrderType<()>>>,
+        statistics: PriceLevelStatistics,
     ) -> Result<Self, PriceLevelError> {
         let mut snapshot = Self {
             price,
@@ -49,6 +82,7 @@ impl PriceLevelSnapshot {
             hidden_quantity: 0,
             order_count: 0,
             orders,
+            statistics,
         };
         snapshot.refresh_aggregates()?;
         Ok(snapshot)
@@ -78,6 +112,12 @@ impl PriceLevelSnapshot {
         self.order_count
     }
 
+    /// Returns a reference to the per-level statistics captured in this snapshot.
+    #[must_use]
+    pub fn statistics(&self) -> &PriceLevelStatistics {
+        &self.statistics
+    }
+
     /// Returns a reference to the orders in this snapshot.
     #[must_use]
     pub fn orders(&self) -> &[Arc<OrderType<()>>] {
@@ -90,10 +130,13 @@ impl PriceLevelSnapshot {
         self.orders
     }
 
-    /// Constructs a snapshot with pre-computed aggregates.
+    /// Constructs a snapshot with pre-computed aggregates and empty statistics.
     ///
     /// This is intended for internal crate use where the caller has already
-    /// computed the aggregate values (e.g., from atomic counters).
+    /// computed the aggregate values (e.g., from atomic counters) and does not
+    /// carry execution statistics. Use [`Self::from_raw_parts_with_stats`] to
+    /// persist recorded statistics alongside the aggregates.
+    #[cfg(test)]
     #[must_use]
     pub(crate) fn from_raw_parts(
         price: u128,
@@ -102,12 +145,37 @@ impl PriceLevelSnapshot {
         order_count: usize,
         orders: Vec<Arc<OrderType<()>>>,
     ) -> Self {
+        Self::from_raw_parts_with_stats(
+            price,
+            visible_quantity,
+            hidden_quantity,
+            order_count,
+            orders,
+            PriceLevelStatistics::new(),
+        )
+    }
+
+    /// Constructs a snapshot with pre-computed aggregates and recorded statistics.
+    ///
+    /// This is intended for internal crate use where the caller has already
+    /// computed the aggregate values (e.g., from atomic counters) and wants to
+    /// preserve the level's execution statistics through the snapshot.
+    #[must_use]
+    pub(crate) fn from_raw_parts_with_stats(
+        price: u128,
+        visible_quantity: u64,
+        hidden_quantity: u64,
+        order_count: usize,
+        orders: Vec<Arc<OrderType<()>>>,
+        statistics: PriceLevelStatistics,
+    ) -> Self {
         Self {
             price,
             visible_quantity,
             hidden_quantity,
             order_count,
             orders,
+            statistics,
         }
     }
 
@@ -154,7 +222,11 @@ impl PriceLevelSnapshot {
 }
 
 /// Format version for checksum-enabled price level snapshots.
-pub const SNAPSHOT_FORMAT_VERSION: u32 = 1;
+///
+/// Version 2 (issue #63) persists per-level [`PriceLevelStatistics`] inside the
+/// snapshot. Version 1 packages carried no statistics and are rejected by
+/// [`PriceLevelSnapshotPackage::validate`] with a version mismatch.
+pub const SNAPSHOT_FORMAT_VERSION: u32 = 2;
 
 /// Serialized representation of a price level snapshot including checksum validation metadata.
 ///
@@ -265,7 +337,7 @@ impl Serialize for PriceLevelSnapshot {
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("PriceLevelSnapshot", 5)?;
+        let mut state = serializer.serialize_struct("PriceLevelSnapshot", 6)?;
 
         state.serialize_field("price", &self.price)?;
         state.serialize_field("visible_quantity", &self.visible_quantity)?;
@@ -276,6 +348,7 @@ impl Serialize for PriceLevelSnapshot {
             self.orders.iter().map(|arc_order| **arc_order).collect();
 
         state.serialize_field("orders", &plain_orders)?;
+        state.serialize_field("statistics", &self.statistics)?;
 
         state.end()
     }
@@ -292,6 +365,7 @@ impl<'de> Deserialize<'de> for PriceLevelSnapshot {
             HiddenQuantity,
             OrderCount,
             Orders,
+            Statistics,
         }
 
         impl<'de> Deserialize<'de> for Field {
@@ -305,7 +379,7 @@ impl<'de> Deserialize<'de> for PriceLevelSnapshot {
                     type Value = Field;
 
                     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                        formatter.write_str("`price`, `visible_quantity`, `hidden_quantity`, `order_count`, or `orders`")
+                        formatter.write_str("`price`, `visible_quantity`, `hidden_quantity`, `order_count`, `orders`, or `statistics`")
                     }
 
                     fn visit_str<E>(self, value: &str) -> Result<Field, E>
@@ -318,6 +392,7 @@ impl<'de> Deserialize<'de> for PriceLevelSnapshot {
                             "hidden_quantity" => Ok(Field::HiddenQuantity),
                             "order_count" => Ok(Field::OrderCount),
                             "orders" => Ok(Field::Orders),
+                            "statistics" => Ok(Field::Statistics),
                             _ => Err(de::Error::unknown_field(
                                 value,
                                 &[
@@ -326,6 +401,7 @@ impl<'de> Deserialize<'de> for PriceLevelSnapshot {
                                     "hidden_quantity",
                                     "order_count",
                                     "orders",
+                                    "statistics",
                                 ],
                             )),
                         }
@@ -354,6 +430,7 @@ impl<'de> Deserialize<'de> for PriceLevelSnapshot {
                 let mut hidden_quantity = None;
                 let mut order_count = None;
                 let mut orders = None;
+                let mut statistics = None;
 
                 while let Some(key) = map.next_key()? {
                     match key {
@@ -388,6 +465,12 @@ impl<'de> Deserialize<'de> for PriceLevelSnapshot {
                             let plain_orders: Vec<OrderType<()>> = map.next_value()?;
                             orders = Some(plain_orders.into_iter().map(Arc::new).collect());
                         }
+                        Field::Statistics => {
+                            if statistics.is_some() {
+                                return Err(de::Error::duplicate_field("statistics"));
+                            }
+                            statistics = Some(map.next_value()?);
+                        }
                     }
                 }
 
@@ -399,6 +482,11 @@ impl<'de> Deserialize<'de> for PriceLevelSnapshot {
                 let order_count =
                     order_count.ok_or_else(|| de::Error::missing_field("order_count"))?;
                 let orders = orders.unwrap_or_default();
+                // `statistics` is optional so the DTO stays forward-compatible:
+                // a payload without it (e.g. a hand-built fixture) restores with
+                // empty statistics rather than failing. A genuine v1 *package*
+                // is still rejected up-front by `validate()`'s version check.
+                let statistics = statistics.unwrap_or_default();
 
                 Ok(PriceLevelSnapshot {
                     price,
@@ -406,6 +494,7 @@ impl<'de> Deserialize<'de> for PriceLevelSnapshot {
                     hidden_quantity,
                     order_count,
                     orders,
+                    statistics,
                 })
             }
         }
@@ -416,6 +505,7 @@ impl<'de> Deserialize<'de> for PriceLevelSnapshot {
             "hidden_quantity",
             "order_count",
             "orders",
+            "statistics",
         ];
         deserializer.deserialize_struct("PriceLevelSnapshot", FIELDS, PriceLevelSnapshotVisitor)
     }
@@ -497,13 +587,16 @@ impl FromStr for PriceLevelSnapshot {
         let order_count_str = get_field("order_count")?;
         let order_count = parse_usize("order_count", order_count_str)?;
 
-        // Create a new snapshot - note that orders cannot be serialized/deserialized in this simple format
+        // Create a new snapshot - note that orders and statistics cannot be
+        // serialized/deserialized in this simple, human-readable format. Use the
+        // JSON snapshot package for a lossless round-trip.
         Ok(PriceLevelSnapshot {
             price,
             visible_quantity,
             hidden_quantity,
             order_count,
             orders: Vec::new(),
+            statistics: PriceLevelStatistics::new(),
         })
     }
 }

--- a/src/price_level/statistics.rs
+++ b/src/price_level/statistics.rs
@@ -259,6 +259,30 @@ impl Default for PriceLevelStatistics {
     }
 }
 
+impl Clone for PriceLevelStatistics {
+    /// Clones the statistics by snapshotting each atomic counter.
+    ///
+    /// Each counter is read with [`Ordering::Relaxed`]: the clone is a
+    /// best-effort point-in-time copy of independent counters (the same
+    /// contract as the serde path and `snapshot()`), not a globally consistent
+    /// transactional read across all eight fields. This is the representation
+    /// persisted in [`PriceLevelSnapshot`](crate::price_level::PriceLevelSnapshot),
+    /// so a restored level carries the recorded statistics rather than a fresh,
+    /// zeroed set.
+    fn clone(&self) -> Self {
+        Self {
+            orders_added: AtomicUsize::new(self.orders_added.load(Ordering::Relaxed)),
+            orders_removed: AtomicUsize::new(self.orders_removed.load(Ordering::Relaxed)),
+            orders_executed: AtomicUsize::new(self.orders_executed.load(Ordering::Relaxed)),
+            quantity_executed: AtomicU64::new(self.quantity_executed.load(Ordering::Relaxed)),
+            value_executed: AtomicU64::new(self.value_executed.load(Ordering::Relaxed)),
+            last_execution_time: AtomicU64::new(self.last_execution_time.load(Ordering::Relaxed)),
+            first_arrival_time: AtomicU64::new(self.first_arrival_time.load(Ordering::Relaxed)),
+            sum_waiting_time: AtomicU64::new(self.sum_waiting_time.load(Ordering::Relaxed)),
+        }
+    }
+}
+
 impl fmt::Display for PriceLevelStatistics {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -100,6 +100,116 @@ mod tests {
     }
 
     #[test]
+    fn test_price_level_snapshot_roundtrip_preserves_statistics() {
+        let price_level = PriceLevel::new(10000);
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let trade_id_generator = UuidGenerator::new(namespace);
+
+        // Rest several makers so we accumulate non-trivial waiting-time and
+        // arrival aggregates, then partially match them to drive every counter.
+        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level.add_order(create_standard_order(2, 10000, 100));
+        price_level.add_order(create_standard_order(3, 10000, 100));
+
+        // Execution timestamp is comfortably after the order arrival timestamps
+        // (TIMESTAMP_COUNTER starts at 1_616_823_000_000), so waiting times are
+        // positive and deterministic.
+        let execution_ts = TimestampMs::new(1_716_000_000_000);
+
+        // First match: fully consumes maker 1 and partially maker 2.
+        let _ = price_level.match_order(150, Id::from_u64(900), execution_ts, &trade_id_generator);
+        // Second match: consumes the rest of maker 2 and part of maker 3.
+        let _ = price_level.match_order(60, Id::from_u64(901), execution_ts, &trade_id_generator);
+
+        let stats = price_level.stats();
+        // Sanity: stats are genuinely non-zero before we snapshot.
+        assert!(stats.orders_added() >= 3);
+        assert!(stats.orders_executed() > 0);
+        assert!(stats.quantity_executed() > 0);
+        assert!(stats.value_executed() > 0);
+        assert!(stats.average_waiting_time().is_some());
+
+        let json = price_level
+            .snapshot_to_json()
+            .expect("Failed to serialize snapshot to JSON");
+
+        let restored = PriceLevel::from_snapshot_json(&json)
+            .expect("Failed to restore price level from snapshot JSON");
+
+        let restored_stats = restored.stats();
+
+        // Every persisted statistic must survive the round-trip identically.
+        assert_eq!(restored_stats.orders_added(), stats.orders_added());
+        assert_eq!(restored_stats.orders_removed(), stats.orders_removed());
+        assert_eq!(restored_stats.orders_executed(), stats.orders_executed());
+        assert_eq!(
+            restored_stats.quantity_executed(),
+            stats.quantity_executed()
+        );
+        assert_eq!(restored_stats.value_executed(), stats.value_executed());
+        assert_eq!(
+            restored_stats.average_waiting_time(),
+            stats.average_waiting_time()
+        );
+        assert_eq!(
+            restored_stats.average_execution_price(),
+            stats.average_execution_price()
+        );
+        // The raw timestamp / waiting-time aggregates round-trip exactly too.
+        assert_eq!(
+            restored_stats.last_execution_time.load(Ordering::Relaxed),
+            stats.last_execution_time.load(Ordering::Relaxed)
+        );
+        assert_eq!(
+            restored_stats.first_arrival_time.load(Ordering::Relaxed),
+            stats.first_arrival_time.load(Ordering::Relaxed)
+        );
+        assert_eq!(
+            restored_stats.sum_waiting_time.load(Ordering::Relaxed),
+            stats.sum_waiting_time.load(Ordering::Relaxed)
+        );
+    }
+
+    #[test]
+    fn test_price_level_from_snapshot_json_v1_package_rejected() {
+        // Build a current (v2) package, then downgrade its `version` to 1 to
+        // emulate a snapshot written by a pre-#63 release. Restoration must fail
+        // with a clear version mismatch (InvalidOperation), not a checksum error
+        // and not a panic.
+        let price_level = PriceLevel::new(10000);
+        price_level.add_order(create_standard_order(1, 10000, 100));
+
+        let json = price_level
+            .snapshot_to_json()
+            .expect("Failed to serialize snapshot to JSON");
+
+        let mut value: serde_json::Value =
+            serde_json::from_str(&json).expect("JSON parsing failed");
+        if let Some(obj) = value.as_object_mut() {
+            obj.insert(
+                "version".to_string(),
+                serde_json::Value::Number(serde_json::Number::from(1u32)),
+            );
+        }
+        let downgraded_json = serde_json::to_string(&value).expect("JSON serialization failed");
+
+        let err = PriceLevel::from_snapshot_json(&downgraded_json)
+            .expect_err("Restoration should reject a v1 package");
+
+        match err {
+            PriceLevelError::InvalidOperation { message } => {
+                assert!(
+                    message.contains("Unsupported snapshot version"),
+                    "unexpected message: {message}"
+                );
+                assert!(message.contains('1'));
+                assert!(message.contains('2'));
+            }
+            other => panic!("expected InvalidOperation version mismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_price_level_from_snapshot_preserves_order_positions() {
         let price_level = PriceLevel::new(15000);
         price_level.add_order(create_standard_order(1, 15000, 100));

--- a/src/price_level/tests/snapshot.rs
+++ b/src/price_level/tests/snapshot.rs
@@ -8,6 +8,7 @@ mod tests {
     use serde_json::Value;
     use std::str::FromStr;
     use std::sync::Arc;
+    use std::sync::atomic::Ordering;
 
     fn create_sample_orders() -> Vec<Arc<OrderType<()>>> {
         vec![
@@ -96,6 +97,110 @@ mod tests {
             .validate()
             .expect_err("Checksum mismatch expected");
         assert!(matches!(err, PriceLevelError::ChecksumMismatch { .. }));
+    }
+
+    #[test]
+    fn test_snapshot_package_roundtrip_preserves_statistics() {
+        use crate::price_level::PriceLevelStatistics;
+
+        // Build statistics with distinct, non-zero values in every counter so a
+        // dropped or mis-mapped field fails the assertions below.
+        let stats = PriceLevelStatistics::new();
+        stats.record_order_added();
+        stats.record_order_added();
+        stats.record_order_removed();
+        // execution_timestamp (5_000) is after the maker arrival (1_000), so the
+        // recorded waiting time is positive and deterministic.
+        stats
+            .record_execution(7, 1000, 1000, 5000)
+            .expect("record_execution should succeed");
+        stats
+            .record_execution(3, 1000, 2000, 5000)
+            .expect("record_execution should succeed");
+
+        let snapshot = PriceLevelSnapshot::with_orders_and_stats(42, create_sample_orders(), stats)
+            .expect("Failed to create snapshot with stats");
+
+        let original = snapshot.statistics();
+        let original_orders_added = original.orders_added();
+        let original_orders_removed = original.orders_removed();
+        let original_orders_executed = original.orders_executed();
+        let original_quantity = original.quantity_executed();
+        let original_value = original.value_executed();
+        let original_last = original.last_execution_time.load(Ordering::Relaxed);
+        let original_first = original.first_arrival_time.load(Ordering::Relaxed);
+        let original_waiting = original.sum_waiting_time.load(Ordering::Relaxed);
+
+        let package = PriceLevelSnapshotPackage::new(snapshot).expect("Failed to create package");
+        assert_eq!(package.version(), SNAPSHOT_FORMAT_VERSION);
+
+        let json = package.to_json().expect("Failed to serialize package");
+        let restored_package =
+            PriceLevelSnapshotPackage::from_json(&json).expect("Failed to deserialize package");
+        let restored = restored_package
+            .into_snapshot()
+            .expect("Snapshot extraction failed (checksum should validate)");
+
+        let restored_stats = restored.statistics();
+        assert_eq!(restored_stats.orders_added(), original_orders_added);
+        assert_eq!(restored_stats.orders_removed(), original_orders_removed);
+        assert_eq!(restored_stats.orders_executed(), original_orders_executed);
+        assert_eq!(restored_stats.quantity_executed(), original_quantity);
+        assert_eq!(restored_stats.value_executed(), original_value);
+        assert_eq!(
+            restored_stats.last_execution_time.load(Ordering::Relaxed),
+            original_last
+        );
+        assert_eq!(
+            restored_stats.first_arrival_time.load(Ordering::Relaxed),
+            original_first
+        );
+        assert_eq!(
+            restored_stats.sum_waiting_time.load(Ordering::Relaxed),
+            original_waiting
+        );
+    }
+
+    #[test]
+    fn test_snapshot_package_v1_version_rejected() {
+        // A package carrying the previous format version must be rejected by
+        // `validate()` with a version mismatch (InvalidOperation) rather than a
+        // confusing checksum error, and never a panic.
+        let snapshot = PriceLevelSnapshot::with_orders(99, create_sample_orders())
+            .expect("Failed to create snapshot with orders");
+        let package = PriceLevelSnapshotPackage::new(snapshot).expect("Failed to create package");
+
+        let json = package.to_json().expect("Failed to serialize package");
+        let mut value: Value = serde_json::from_str(&json).expect("JSON parsing failed");
+        if let Some(obj) = value.as_object_mut() {
+            obj.insert("version".to_string(), Value::Number(1u32.into()));
+        }
+        let v1_json = serde_json::to_string(&value).expect("JSON serialization failed");
+
+        let v1_package = PriceLevelSnapshotPackage::from_json(&v1_json)
+            .expect("Deserialization should still succeed");
+        assert_eq!(v1_package.version(), 1);
+
+        let err = v1_package
+            .validate()
+            .expect_err("v1 package should be rejected");
+        match err {
+            PriceLevelError::InvalidOperation { message } => {
+                assert!(
+                    message.contains("Unsupported snapshot version"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected InvalidOperation version mismatch, got {other:?}"),
+        }
+
+        // `into_snapshot` (used by the restore path) must reject it too.
+        let v1_package_again = PriceLevelSnapshotPackage::from_json(&v1_json)
+            .expect("Deserialization should still succeed");
+        let err = v1_package_again
+            .into_snapshot()
+            .expect_err("v1 package should be rejected on restore");
+        assert!(matches!(err, PriceLevelError::InvalidOperation { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Snapshots silently dropped `PriceLevelStatistics`: `PriceLevelSnapshot` carried
none and `from_snapshot` reset them to a fresh zeroed set on restore. The rules
require the snapshot round-trip to reproduce stats. This persists them.

## Changes

- `PriceLevelSnapshot` gains a `statistics` field (the eight counters), reusing
  `PriceLevelStatistics`'s hand-written serde; the snapshot's hand-written
  `Serialize`/`Deserialize` visitor were updated to include it. The field is
  optional on deserialize (defaults) so the DTO stays forward-compatible; no
  `deny_unknown_fields` added.
- `snapshot()` populates the field from `self.stats()`; `from_snapshot` /
  `From<&PriceLevelSnapshot>` restore it instead of `PriceLevelStatistics::new()`.
- Added a `Clone` for `PriceLevelStatistics` (best-effort `Relaxed` snapshot of
  the independent counters — they are not part of the queue/counter consistency
  invariant).
- The new field flows through the package SHA-256 checksum automatically.

## Technical decisions

- **Snapshot format version bumped 1 → 2.** A `version: 1` package is rejected
  up-front by `validate()` (the version check runs before the checksum check)
  with a clean `PriceLevelError::InvalidOperation` version mismatch — never a
  confusing checksum error and never a panic. Re-take any persisted snapshots.
- `PriceLevelStatistics` and `SNAPSHOT_FORMAT_VERSION` are intentionally left
  un-exported at the crate root (reachable via `PriceLevel::stats()` /
  `package.version()`) to avoid an unrequested public-surface expansion.

## Public API impact

Snapshot wire format changed (v2). Migration note added to the `src/lib.rs`
guide and `README.md` regenerated via `make readme`. Public function signatures
(`snapshot_to_json` / `from_snapshot_json`) are unchanged.

## Testing

- [x] Round-trip preserves stats — `test_price_level_snapshot_roundtrip_preserves_statistics`
      (real `match_order` executions → snapshot → restore → every stat asserted)
- [x] Package-level SHA-256 round-trip — `test_snapshot_package_roundtrip_preserves_statistics`
- [x] v1 package rejected — `test_price_level_from_snapshot_json_v1_package_rejected`,
      `test_snapshot_package_v1_version_rejected`
- [x] Existing tampered-checksum tests still pass (`ChecksumMismatch`)
- [x] `make pre-push` clean

`cargo test`: 336 passed (lib) + 1 (integration) + 9 (doctests), 0 failed.
`cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all
--check`, `cargo build --release`: all clean.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic; no `saturating_*` / `wrapping_*`
- [x] No new production `unsafe`
- [x] Module boundaries respected
- [x] No new dependencies added
- [x] `tracing` only for logging
- [x] Snapshot round-trip covered via `PriceLevelSnapshotPackage` (SHA-256); preservation test for the new field
- [x] `src/lib.rs` migration guide + `README.md` (via `make readme`) updated

Closes #63
