### PR TITLE
Preserve price-time priority on update_order quantity change (#64)

### DIFF
--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -389,7 +389,34 @@ impl PriceLevel {
 }
 
 impl PriceLevel {
-    /// Apply an update to an existing order at this price level
+    /// Apply an update to an existing order at this price level.
+    ///
+    /// # Quantity-update priority policy
+    ///
+    /// For [`OrderUpdate::UpdateQuantity`] (and the same-price branch of
+    /// [`OrderUpdate::UpdatePriceAndQuantity`]) this method follows the
+    /// conventional exchange price-time-priority rules:
+    ///
+    /// - **Decrease or unchanged total quantity** keeps the maker's queue
+    ///   position. The stored order is updated *in place* at its existing
+    ///   insertion sequence, so it is consumed at the same point in FIFO order
+    ///   as before. Reducing size never forfeits time priority.
+    /// - **Increase in total quantity** demotes the order to the *back* of the
+    ///   queue (it is assigned a fresh insertion sequence). Sizing an order up
+    ///   loses time priority, matching standard exchange behaviour.
+    ///
+    /// Total quantity is `visible + hidden`; the branch is chosen by comparing
+    /// the order's total before and after the update. Order types that cannot
+    /// be resized fall back to an unchanged order and therefore take the
+    /// in-place (position-preserving) branch.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if an
+    /// [`OrderUpdate::UpdatePrice`] / [`OrderUpdate::Replace`] would not move
+    /// the order to a different price level, or if computing an order's total
+    /// quantity overflows `u64`.
+    #[must_use = "the updated order (or None when the order is absent) must be handled"]
     pub fn update_order(
         &self,
         update: OrderUpdate,
@@ -432,54 +459,100 @@ impl PriceLevel {
                 order_id,
                 new_quantity,
             } => {
-                // Find the order
-                if let Some(order) = self.orders.find(order_id) {
-                    // Get current quantities
-                    let old_visible = order.visible_quantity();
-                    let old_hidden = order.hidden_quantity();
+                // Find the order to read its current quantities.
+                let Some(order) = self.orders.find(order_id) else {
+                    return Ok(None); // Order not found
+                };
 
-                    // Remove the old order
-                    let old_order = match self.orders.remove(order_id) {
-                        Some(order) => order,
-                        None => return Ok(None), // Order not found, remove by other thread
-                    };
+                let old_visible = order.visible_quantity();
+                let old_hidden = order.hidden_quantity();
 
-                    // Create updated order with new quantity
-                    let new_order = old_order.with_reduced_quantity(new_quantity.as_u64());
+                // Build the updated order. `with_reduced_quantity` sets the
+                // (visible/main) quantity to exactly `new_quantity` for order
+                // types that support resizing; types it cannot resize fall
+                // back to an unchanged clone, so `new_total` simply equals
+                // `old_total` for them and we take the in-place branch.
+                let new_order = order.with_reduced_quantity(new_quantity.as_u64());
+                let new_visible = new_order.visible_quantity();
+                let new_hidden = new_order.hidden_quantity();
 
-                    // Calculate the new quantities
-                    let new_visible = new_order.visible_quantity();
-                    let new_hidden = new_order.hidden_quantity();
+                // Compare total quantity (visible + hidden) before/after to
+                // decide the priority policy. Use checked addition so a
+                // pathological overflow surfaces as an error rather than
+                // wrapping the comparison.
+                let old_total = old_visible.checked_add(old_hidden).ok_or_else(|| {
+                    PriceLevelError::InvalidOperation {
+                        message: "order total quantity overflow".to_string(),
+                    }
+                })?;
+                let new_total = new_visible.checked_add(new_hidden).ok_or_else(|| {
+                    PriceLevelError::InvalidOperation {
+                        message: "order total quantity overflow".to_string(),
+                    }
+                })?;
 
-                    // Update atomic counters
-                    if old_visible != new_visible {
-                        if new_visible > old_visible {
-                            self.visible_quantity
-                                .fetch_add(new_visible - old_visible, Ordering::AcqRel);
-                        } else {
-                            self.visible_quantity
-                                .fetch_sub(old_visible - new_visible, Ordering::AcqRel);
-                        }
+                let new_order_arc = Arc::new(new_order);
+
+                if new_total > old_total {
+                    // Quantity INCREASE: demote to the back of the queue
+                    // (mint a new sequence), losing time priority. This
+                    // retains the remove+push shape; its concurrency window is
+                    // the broader #81 work and is intentionally not addressed
+                    // here.
+                    if self.orders.remove(order_id).is_none() {
+                        return Ok(None); // Removed by another thread.
                     }
 
-                    if old_hidden != new_hidden {
-                        if new_hidden > old_hidden {
-                            self.hidden_quantity
-                                .fetch_add(new_hidden - old_hidden, Ordering::AcqRel);
-                        } else {
-                            self.hidden_quantity
-                                .fetch_sub(old_hidden - new_hidden, Ordering::AcqRel);
-                        }
+                    if new_visible >= old_visible {
+                        self.visible_quantity
+                            .fetch_add(new_visible - old_visible, Ordering::AcqRel);
+                    } else {
+                        self.visible_quantity
+                            .fetch_sub(old_visible - new_visible, Ordering::AcqRel);
+                    }
+                    if new_hidden >= old_hidden {
+                        self.hidden_quantity
+                            .fetch_add(new_hidden - old_hidden, Ordering::AcqRel);
+                    } else {
+                        self.hidden_quantity
+                            .fetch_sub(old_hidden - new_hidden, Ordering::AcqRel);
                     }
 
-                    // Add the updated order back to the queue
-                    let new_order_arc = Arc::new(new_order);
                     self.orders.push(new_order_arc.clone());
+                    Ok(Some(new_order_arc))
+                } else {
+                    // Quantity DECREASE or unchanged total: keep the maker's
+                    // queue position by swapping the stored order in place at
+                    // its existing insertion sequence. The swap is done under
+                    // the DashMap per-entry lock, so the counters are adjusted
+                    // only after we confirm the order is still present.
+                    if self
+                        .orders
+                        .update_in_place(order_id, new_order_arc.clone())
+                        .is_none()
+                    {
+                        return Ok(None); // Removed by another thread.
+                    }
 
-                    return Ok(Some(new_order_arc));
+                    // Totals can only shrink or stay equal here, so the
+                    // per-component deltas are non-negative subtractions.
+                    if old_visible > new_visible {
+                        self.visible_quantity
+                            .fetch_sub(old_visible - new_visible, Ordering::AcqRel);
+                    } else if new_visible > old_visible {
+                        self.visible_quantity
+                            .fetch_add(new_visible - old_visible, Ordering::AcqRel);
+                    }
+                    if old_hidden > new_hidden {
+                        self.hidden_quantity
+                            .fetch_sub(old_hidden - new_hidden, Ordering::AcqRel);
+                    } else if new_hidden > old_hidden {
+                        self.hidden_quantity
+                            .fetch_add(new_hidden - old_hidden, Ordering::AcqRel);
+                    }
+
+                    Ok(Some(new_order_arc))
                 }
-
-                Ok(None) // Order not found
             }
 
             OrderUpdate::UpdatePriceAndQuantity {

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -459,32 +459,30 @@ impl PriceLevel {
                 order_id,
                 new_quantity,
             } => {
-                // Find the order to read its current quantities.
+                // Read the current order to build the resized order and pick the
+                // priority policy. The counter deltas below are taken from the
+                // order actually removed/replaced under the queue's per-entry
+                // lock — not from this pre-read — so a concurrent update cannot
+                // drift `visible_quantity` / `hidden_quantity` from the queue.
                 let Some(order) = self.orders.find(order_id) else {
                     return Ok(None); // Order not found
                 };
 
-                let old_visible = order.visible_quantity();
-                let old_hidden = order.hidden_quantity();
+                let prev_total = order
+                    .visible_quantity()
+                    .checked_add(order.hidden_quantity())
+                    .ok_or_else(|| PriceLevelError::InvalidOperation {
+                        message: "order total quantity overflow".to_string(),
+                    })?;
 
                 // Build the updated order. `with_reduced_quantity` sets the
                 // (visible/main) quantity to exactly `new_quantity` for order
-                // types that support resizing; types it cannot resize fall
-                // back to an unchanged clone, so `new_total` simply equals
-                // `old_total` for them and we take the in-place branch.
+                // types that support resizing; types it cannot resize fall back
+                // to an unchanged clone, so `new_total` equals the old total for
+                // them and they take the position-preserving in-place branch.
                 let new_order = order.with_reduced_quantity(new_quantity.as_u64());
                 let new_visible = new_order.visible_quantity();
                 let new_hidden = new_order.hidden_quantity();
-
-                // Compare total quantity (visible + hidden) before/after to
-                // decide the priority policy. Use checked addition so a
-                // pathological overflow surfaces as an error rather than
-                // wrapping the comparison.
-                let old_total = old_visible.checked_add(old_hidden).ok_or_else(|| {
-                    PriceLevelError::InvalidOperation {
-                        message: "order total quantity overflow".to_string(),
-                    }
-                })?;
                 let new_total = new_visible.checked_add(new_hidden).ok_or_else(|| {
                     PriceLevelError::InvalidOperation {
                         message: "order total quantity overflow".to_string(),
@@ -493,66 +491,50 @@ impl PriceLevel {
 
                 let new_order_arc = Arc::new(new_order);
 
-                if new_total > old_total {
-                    // Quantity INCREASE: demote to the back of the queue
-                    // (mint a new sequence), losing time priority. This
-                    // retains the remove+push shape; its concurrency window is
-                    // the broader #81 work and is intentionally not addressed
-                    // here.
-                    if self.orders.remove(order_id).is_none() {
+                // Perform the queue mutation and capture the order it actually
+                // removed/replaced, so the counter deltas reflect the real
+                // transition rather than the possibly-stale pre-read above.
+                let old = if new_total > prev_total {
+                    // Quantity INCREASE: demote to the back of the queue (mint a
+                    // new sequence), losing time priority. Retains the
+                    // remove+push shape; its concurrency window is the broader
+                    // #81 work and is intentionally not addressed here.
+                    let Some(removed) = self.orders.remove(order_id) else {
                         return Ok(None); // Removed by another thread.
-                    }
-
-                    if new_visible >= old_visible {
-                        self.visible_quantity
-                            .fetch_add(new_visible - old_visible, Ordering::AcqRel);
-                    } else {
-                        self.visible_quantity
-                            .fetch_sub(old_visible - new_visible, Ordering::AcqRel);
-                    }
-                    if new_hidden >= old_hidden {
-                        self.hidden_quantity
-                            .fetch_add(new_hidden - old_hidden, Ordering::AcqRel);
-                    } else {
-                        self.hidden_quantity
-                            .fetch_sub(old_hidden - new_hidden, Ordering::AcqRel);
-                    }
-
+                    };
                     self.orders.push(new_order_arc.clone());
-                    Ok(Some(new_order_arc))
+                    removed
                 } else {
                     // Quantity DECREASE or unchanged total: keep the maker's
-                    // queue position by swapping the stored order in place at
-                    // its existing insertion sequence. The swap is done under
-                    // the DashMap per-entry lock, so the counters are adjusted
-                    // only after we confirm the order is still present.
-                    if self
-                        .orders
-                        .update_in_place(order_id, new_order_arc.clone())
-                        .is_none()
-                    {
+                    // queue position by swapping the stored order in place at its
+                    // existing insertion sequence, under the DashMap per-entry
+                    // lock.
+                    let Some(replaced) =
+                        self.orders.update_in_place(order_id, new_order_arc.clone())
+                    else {
                         return Ok(None); // Removed by another thread.
-                    }
+                    };
+                    replaced
+                };
 
-                    // Totals can only shrink or stay equal here, so the
-                    // per-component deltas are non-negative subtractions.
-                    if old_visible > new_visible {
-                        self.visible_quantity
-                            .fetch_sub(old_visible - new_visible, Ordering::AcqRel);
-                    } else if new_visible > old_visible {
-                        self.visible_quantity
-                            .fetch_add(new_visible - old_visible, Ordering::AcqRel);
+                // Apply the counter deltas from the actual replaced order. A
+                // single component (visible or hidden) can move in EITHER
+                // direction even when the total shrinks or is unchanged, because
+                // quantity can shift between the visible and hidden portions, so
+                // handle both signs.
+                let old_visible = old.visible_quantity();
+                let old_hidden = old.hidden_quantity();
+                let apply = |counter: &std::sync::atomic::AtomicU64, old: u64, new: u64| {
+                    if new >= old {
+                        counter.fetch_add(new - old, Ordering::AcqRel);
+                    } else {
+                        counter.fetch_sub(old - new, Ordering::AcqRel);
                     }
-                    if old_hidden > new_hidden {
-                        self.hidden_quantity
-                            .fetch_sub(old_hidden - new_hidden, Ordering::AcqRel);
-                    } else if new_hidden > old_hidden {
-                        self.hidden_quantity
-                            .fetch_add(new_hidden - old_hidden, Ordering::AcqRel);
-                    }
+                };
+                apply(&self.visible_quantity, old_visible, new_visible);
+                apply(&self.hidden_quantity, old_hidden, new_hidden);
 
-                    Ok(Some(new_order_arc))
-                }
+                Ok(Some(new_order_arc))
             }
 
             OrderUpdate::UpdatePriceAndQuantity {

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -97,6 +97,30 @@ impl OrderQueue {
         self.orders.get(&order_id).map(|o| o.value().1.clone())
     }
 
+    /// Replace the stored order for `order_id` in place, keeping its existing
+    /// insertion sequence (and therefore its price-time / FIFO position).
+    ///
+    /// Returns the previous order if `order_id` was present, or `None` if it
+    /// was not (e.g. concurrently removed). The `index` entry `seq -> id`
+    /// stays valid because the sequence is unchanged, so only the `DashMap`
+    /// value is swapped.
+    ///
+    /// The whole swap happens under the `DashMap` per-entry lock, so a
+    /// concurrent [`OrderQueue::remove`] of the same id either observes the
+    /// old value and removes it, or observes the new value and removes that —
+    /// it never sees the entry mid-update. This closes the
+    /// absent-from-`orders` window that a remove-then-push sequence would open.
+    #[must_use]
+    pub(crate) fn update_in_place(
+        &self,
+        order_id: Id,
+        new_order: Arc<OrderType<()>>,
+    ) -> Option<Arc<OrderType<()>>> {
+        let mut entry = self.orders.get_mut(&order_id)?;
+        let (_seq, slot) = entry.value_mut();
+        Some(std::mem::replace(slot, new_order))
+    }
+
     /// Remove an order with the given ID.
     /// Returns the removed order if found. Cleans both the map and the index.
     #[must_use]

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -116,6 +116,11 @@ impl OrderQueue {
         order_id: Id,
         new_order: Arc<OrderType<()>>,
     ) -> Option<Arc<OrderType<()>>> {
+        debug_assert_eq!(
+            new_order.id(),
+            order_id,
+            "update_in_place: new_order id must match the key it is stored under"
+        );
         let mut entry = self.orders.get_mut(&order_id)?;
         let (_seq, slot) = entry.value_mut();
         Some(std::mem::replace(slot, new_order))

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -1627,6 +1627,124 @@ mod tests {
     }
 
     #[test]
+    fn test_update_order_reduce_quantity_keeps_queue_position() {
+        let price_level = PriceLevel::new(10000);
+
+        // Add makers A (id 1) then B (id 2) at the same price. A is ahead in
+        // price-time priority.
+        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level.add_order(create_standard_order(2, 10000, 100));
+
+        // Reduce A's quantity (decrease). A must keep its front position.
+        let result = price_level.update_order(OrderUpdate::UpdateQuantity {
+            order_id: Id::from_u64(1),
+            new_quantity: Quantity::new(40),
+        });
+        assert!(result.is_ok());
+        let updated = result.unwrap();
+        assert!(updated.is_some());
+        assert_eq!(updated.unwrap().visible_quantity(), 40);
+
+        // Match a quantity that only consumes the first resting order. A (id 1)
+        // must be hit before B (id 2).
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let trade_id_generator = UuidGenerator::new(namespace);
+        let execution_ts = TimestampMs::new(1_716_000_000_000);
+        let match_result =
+            price_level.match_order(40, Id::from_u64(900), execution_ts, &trade_id_generator);
+
+        let trades = match_result.trades().as_vec();
+        assert_eq!(trades.len(), 1);
+        // The first (and only) trade must name A as the maker: A kept its
+        // position despite the reduction.
+        assert_eq!(trades[0].maker_order_id(), Id::from_u64(1));
+        assert_eq!(trades[0].quantity(), Quantity::new(40));
+    }
+
+    #[test]
+    fn test_update_order_increase_quantity_demotes_to_back() {
+        let price_level = PriceLevel::new(10000);
+
+        // Add makers A (id 1) then B (id 2) at the same price.
+        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level.add_order(create_standard_order(2, 10000, 100));
+
+        // Increase A's quantity (Standard orders support resizing). This must
+        // demote A to the back of the queue, behind B.
+        let result = price_level.update_order(OrderUpdate::UpdateQuantity {
+            order_id: Id::from_u64(1),
+            new_quantity: Quantity::new(150),
+        });
+        assert!(result.is_ok());
+        let updated = result.unwrap();
+        assert!(updated.is_some());
+        assert_eq!(updated.unwrap().visible_quantity(), 150);
+
+        // A subsequent match that only consumes the first resting order must
+        // now hit B (id 2) before the resized A (id 1).
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let trade_id_generator = UuidGenerator::new(namespace);
+        let execution_ts = TimestampMs::new(1_716_000_000_000);
+        let match_result =
+            price_level.match_order(100, Id::from_u64(900), execution_ts, &trade_id_generator);
+
+        let trades = match_result.trades().as_vec();
+        assert_eq!(trades.len(), 1);
+        // B is now at the front: it is matched before the resized A.
+        assert_eq!(trades[0].maker_order_id(), Id::from_u64(2));
+        assert_eq!(trades[0].quantity(), Quantity::new(100));
+    }
+
+    #[test]
+    fn test_update_order_quantity_counters_consistent() {
+        let price_level = PriceLevel::new(10000);
+
+        // Two standard makers plus an iceberg (so hidden_quantity is exercised).
+        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level.add_order(create_standard_order(2, 10000, 100));
+        price_level.add_order(create_iceberg_order(3, 10000, 50, 200));
+
+        // Decrease (in place) on a standard order.
+        let _ = price_level
+            .update_order(OrderUpdate::UpdateQuantity {
+                order_id: Id::from_u64(1),
+                new_quantity: Quantity::new(30),
+            })
+            .expect("decrease update should succeed");
+
+        // Increase (demote) on a standard order.
+        let _ = price_level
+            .update_order(OrderUpdate::UpdateQuantity {
+                order_id: Id::from_u64(2),
+                new_quantity: Quantity::new(180),
+            })
+            .expect("increase update should succeed");
+
+        // Reduce the iceberg's visible part in place (hidden unchanged).
+        let _ = price_level
+            .update_order(OrderUpdate::UpdateQuantity {
+                order_id: Id::from_u64(3),
+                new_quantity: Quantity::new(20),
+            })
+            .expect("iceberg decrease update should succeed");
+
+        // Atomic counters must equal the sum over the live queue contents.
+        let snapshot = price_level.snapshot_orders();
+        let expected_visible: u64 = snapshot.iter().map(|o| o.visible_quantity()).sum();
+        let expected_hidden: u64 = snapshot.iter().map(|o| o.hidden_quantity()).sum();
+
+        assert_eq!(price_level.order_count(), snapshot.len());
+        assert_eq!(price_level.visible_quantity(), expected_visible);
+        assert_eq!(price_level.hidden_quantity(), expected_hidden);
+
+        // Spot-check the expected values: A=30, B=180, iceberg visible=20.
+        assert_eq!(expected_visible, 30 + 180 + 20);
+        // Iceberg hidden remains 200.
+        assert_eq!(expected_hidden, 200);
+        assert_eq!(price_level.order_count(), 3);
+    }
+
+    #[test]
     fn test_update_order_update_price_and_quantity() {
         let price_level = PriceLevel::new(10000);
 


### PR DESCRIPTION
## Summary

`update_order`'s `UpdateQuantity` path removed the maker and re-pushed it with a
new insertion sequence, sending it to the **back** of the queue and forfeiting
its price-time priority — with a window where the order was absent from the queue
while counters were mid-adjust. Reducing an order's size should not cost it its
place in line.

## Changes

- `UpdateQuantity` now branches on total quantity (`visible + hidden`):
  - **decrease or unchanged** → update the order **in place** at its existing
    sequence (keeps queue position).
  - **increase** → demote to the back with a new sequence (the standard exchange
    rule that a size-up loses time priority). Policy documented in the
    `update_order` rustdoc.
- New `OrderQueue::update_in_place` swaps the `DashMap` value under the per-entry
  lock while keeping the sequence (the `index` entry stays valid), which also
  closes the absent-from-`orders` window for this path.

## Technical decisions

- Order types whose `with_reduced_quantity` can't change size (TrailingStop /
  Pegged / MarketToLimit / Reserve fall through to a clone) yield
  `new_total == old_total` and deterministically take the position-preserving
  in-place branch — correct, and documented in code.
- The increase/demote path keeps the remove+push shape; its concurrency window
  is the broader deferred #81 work and is intentionally not addressed here.

## Testing

- [x] `test_update_order_reduce_quantity_keeps_queue_position` — reduced maker
      still matches before a later maker
- [x] `test_update_order_increase_quantity_demotes_to_back`
- [x] `test_update_order_quantity_counters_consistent` — visible/hidden/count
      agree with the queue after decrease + increase + iceberg-visible-reduce
- [x] `make pre-push` clean

`cargo test`: 339 (lib) + 1 (integration) + 9 (doctests) = 349 passed, 0 failed.
`cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all
--check`, `cargo build --release`: all clean.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic; no `saturating_*` / `wrapping_*`
- [x] No new production `unsafe`; no new dependencies
- [x] Module boundaries respected; `tracing` only
- [x] FIFO/price-time determinism preserved; counter ↔ queue consistency held
- [x] Public API unchanged (no README/migration-guide change needed)

Closes #64
