### PR TITLE
Use checked_mul in Trade::total_value (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,16 @@ checksum error). Re-take any persisted snapshots with this release. No code
 changes are required at the call sites: `snapshot_to_json()` /
 `from_snapshot_json()` keep the same signatures.
 
+### Migration Guide (`Trade::total_value` is now checked)
+
+[`Trade::total_value`](crate::execution::Trade::total_value) now returns
+`Result<u128, PriceLevelError>` instead of `u128`. It computes
+`price * quantity` with `checked_mul` and returns
+[`PriceLevelError::InvalidOperation`] on overflow, matching the checked
+arithmetic of [`MatchResult::executed_value`](crate::execution::MatchResult::executed_value),
+which previously used an unchecked `*` that could panic in debug or wrap in
+release. Callers must handle the `Result` (e.g. `trade.total_value()?`).
+
 
  ## Setup Instructions
 

--- a/src/execution/tests/transaction.rs
+++ b/src/execution/tests/transaction.rs
@@ -141,7 +141,7 @@ mod tests {
     #[test]
     fn test_total_value() {
         let transaction = create_test_trade();
-        assert_eq!(transaction.total_value(), 50000);
+        assert_eq!(transaction.total_value().unwrap(), 50000);
 
         // Test with larger values
         let uuid = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
@@ -154,7 +154,26 @@ mod tests {
             Side::Buy,
             TimestampMs::new(1616823000000),
         );
-        assert_eq!(large_trade.total_value(), 97406784);
+        assert_eq!(large_trade.total_value().unwrap(), 97406784);
+    }
+
+    #[test]
+    fn test_total_value_overflow_returns_invalid_operation() {
+        let uuid = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        // price * quantity overflows u128 -> checked_mul yields InvalidOperation.
+        let trade = Trade::with_timestamp(
+            Id::from_uuid(uuid),
+            Id::from_u64(1),
+            Id::from_u64(2),
+            Price::new(u128::MAX),
+            Quantity::new(2),
+            Side::Buy,
+            TimestampMs::new(1616823000000),
+        );
+        assert!(matches!(
+            trade.total_value(),
+            Err(crate::errors::PriceLevelError::InvalidOperation { .. })
+        ));
     }
 
     #[test]
@@ -447,7 +466,7 @@ mod transaction_serialization_tests {
     #[test]
     fn test_total_value_calculation() {
         let transaction = create_test_trade();
-        assert_eq!(transaction.total_value(), 50000);
+        assert_eq!(transaction.total_value().unwrap(), 50000);
 
         let uuid = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let large_trade = Trade::with_timestamp(
@@ -459,6 +478,6 @@ mod transaction_serialization_tests {
             Side::Buy,
             TimestampMs::new(1616823000000),
         );
-        assert_eq!(large_trade.total_value(), 827115);
+        assert_eq!(large_trade.total_value().unwrap(), 827115);
     }
 }

--- a/src/execution/trade.rs
+++ b/src/execution/trade.rs
@@ -136,10 +136,26 @@ impl Trade {
         }
     }
 
-    /// Returns the total value of this trade
-    #[must_use]
-    pub fn total_value(&self) -> u128 {
-        self.price.as_u128() * (self.quantity.as_u64() as u128)
+    /// Returns the total value of this trade (`price * quantity`), in
+    /// price-ticks × quantity units.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if `price * quantity`
+    /// overflows `u128`. This mirrors the checked-arithmetic discipline of
+    /// [`MatchResult::executed_value`](crate::execution::MatchResult::executed_value),
+    /// which computes the same product.
+    pub fn total_value(&self) -> Result<u128, PriceLevelError> {
+        self.price
+            .as_u128()
+            .checked_mul(u128::from(self.quantity.as_u64()))
+            .ok_or_else(|| PriceLevelError::InvalidOperation {
+                message: format!(
+                    "trade total value overflow: price {} * quantity {}",
+                    self.price.as_u128(),
+                    self.quantity.as_u64()
+                ),
+            })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,6 +371,16 @@
 //! changes are required at the call sites: `snapshot_to_json()` /
 //! `from_snapshot_json()` keep the same signatures.
 //!
+//! ## Migration Guide (`Trade::total_value` is now checked)
+//!
+//! [`Trade::total_value`](crate::execution::Trade::total_value) now returns
+//! `Result<u128, PriceLevelError>` instead of `u128`. It computes
+//! `price * quantity` with `checked_mul` and returns
+//! [`PriceLevelError::InvalidOperation`] on overflow, matching the checked
+//! arithmetic of [`MatchResult::executed_value`](crate::execution::MatchResult::executed_value),
+//! which previously used an unchecked `*` that could panic in debug or wrap in
+//! release. Callers must handle the `Result` (e.g. `trade.total_value()?`).
+//!
 
 mod orders;
 mod price_level;


### PR DESCRIPTION
## Summary

`Trade::total_value` computed `price * quantity` with an unchecked `*`, which can
panic in debug and wrap in release — inconsistent with
`MatchResult::executed_value` (two files over), which computes the same product
with `checked_mul`. This aligns it with the crate's checked-arithmetic discipline.

## Changes

- `Trade::total_value` now returns `Result<u128, PriceLevelError>`, using
  `checked_mul` and surfacing overflow as `PriceLevelError::InvalidOperation`
  with the offending price/quantity in the message.
- `# Errors` doc added; the redundant `#[must_use]` was dropped (a `Result` is
  already `#[must_use]`, and keeping it would trip `clippy::double_must_use`).

## Public API impact

Breaking: `total_value`'s return type changed from `u128` to
`Result<u128, PriceLevelError>`. Migration note added to the `src/lib.rs` guide;
`README.md` regenerated via `make readme`. Callers handle the `Result`
(`trade.total_value()?`).

## Testing

- [x] Existing `total_value` assertions updated to unwrap the `Result`
- [x] `test_total_value_overflow_returns_invalid_operation` — `price = u128::MAX`,
      `quantity = 2` → `Err(InvalidOperation)`
- [x] `make pre-push` clean

`cargo test`: all pass; `cargo clippy --all-targets --all-features -- -D
warnings`, `cargo fmt --all --check`, `cargo build --release`: all clean.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] Checked arithmetic on value math — no unchecked `*`, no `saturating_*` / `wrapping_*`
- [x] `# Errors` documented on the fallible accessor
- [x] No `.unwrap()` in production code (test fixtures aside)
- [x] No new production `unsafe`; no new dependencies
- [x] Module boundaries respected; `tracing` only
- [x] `src/lib.rs` migration guide + `README.md` (via `make readme`) updated

Closes #69
