### PR TITLE
Make PriceLevelStatistics atomic fields private (#66)

### DIFF
--- a/src/price_level/statistics.rs
+++ b/src/price_level/statistics.rs
@@ -7,32 +7,39 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Tracks performance statistics for a price level
+/// Tracks performance statistics for a price level.
+///
+/// All counters are private atomics so that no external consumer can
+/// `.store()` / `.fetch_add()` directly and desync them from the order queue
+/// or from the checked-arithmetic invariants enforced in
+/// [`record_execution`](Self::record_execution). Mutation happens only through
+/// the `record_*` / [`reset`](Self::reset) methods; reads happen only through
+/// the public accessors.
 #[derive(Debug)]
 pub struct PriceLevelStatistics {
     /// Number of orders added
-    pub orders_added: AtomicUsize,
+    orders_added: AtomicUsize,
 
     /// Number of orders removed
-    pub orders_removed: AtomicUsize,
+    orders_removed: AtomicUsize,
 
     /// Number of orders executed
-    pub orders_executed: AtomicUsize,
+    orders_executed: AtomicUsize,
 
     /// Total quantity executed
-    pub quantity_executed: AtomicU64,
+    quantity_executed: AtomicU64,
 
     /// Total value executed
-    pub value_executed: AtomicU64,
+    value_executed: AtomicU64,
 
     /// Last execution timestamp
-    pub last_execution_time: AtomicU64,
+    last_execution_time: AtomicU64,
 
     /// First order arrival timestamp
-    pub first_arrival_time: AtomicU64,
+    first_arrival_time: AtomicU64,
 
     /// Sum of waiting times for orders
-    pub sum_waiting_time: AtomicU64,
+    sum_waiting_time: AtomicU64,
 }
 
 impl PriceLevelStatistics {
@@ -197,6 +204,37 @@ impl PriceLevelStatistics {
     #[must_use]
     pub fn value_executed(&self) -> u64 {
         self.value_executed.load(Ordering::Relaxed)
+    }
+
+    /// Get the timestamp of the most recent execution, in milliseconds since
+    /// the Unix epoch.
+    ///
+    /// Returns `0` when no execution has been recorded yet.
+    #[must_use]
+    pub fn last_execution_time(&self) -> u64 {
+        self.last_execution_time.load(Ordering::Relaxed)
+    }
+
+    /// Get the timestamp of the first order arrival at this level, in
+    /// milliseconds since the Unix epoch.
+    ///
+    /// Seeded at construction (and on [`reset`](Self::reset)) with the current
+    /// wall-clock time, or `0` if the system clock could not be read.
+    #[must_use]
+    pub fn first_arrival_time(&self) -> u64 {
+        self.first_arrival_time.load(Ordering::Relaxed)
+    }
+
+    /// Get the accumulated waiting time across all executed orders, in
+    /// milliseconds.
+    ///
+    /// This is the sum of `execution_timestamp - order_timestamp` over every
+    /// recorded execution that carried a non-zero maker timestamp. Divide by
+    /// [`orders_executed`](Self::orders_executed) for the average; see
+    /// [`average_waiting_time`](Self::average_waiting_time).
+    #[must_use]
+    pub fn sum_waiting_time(&self) -> u64 {
+        self.sum_waiting_time.load(Ordering::Relaxed)
     }
 
     /// Get average execution price

--- a/src/price_level/statistics.rs
+++ b/src/price_level/statistics.rs
@@ -35,7 +35,8 @@ pub struct PriceLevelStatistics {
     /// Last execution timestamp
     last_execution_time: AtomicU64,
 
-    /// First order arrival timestamp
+    /// Statistics initialization timestamp (set at construction / reset).
+    /// Not updated on order arrival — see `first_arrival_time()`.
     first_arrival_time: AtomicU64,
 
     /// Sum of waiting times for orders
@@ -215,11 +216,13 @@ impl PriceLevelStatistics {
         self.last_execution_time.load(Ordering::Relaxed)
     }
 
-    /// Get the timestamp of the first order arrival at this level, in
-    /// milliseconds since the Unix epoch.
+    /// Get the statistics initialization timestamp, in milliseconds since the
+    /// Unix epoch.
     ///
-    /// Seeded at construction (and on [`reset`](Self::reset)) with the current
-    /// wall-clock time, or `0` if the system clock could not be read.
+    /// Set when the statistics are created and on [`reset`](Self::reset) with the
+    /// current wall-clock time (`0` if the system clock could not be read). It is
+    /// **not** updated on order arrival, so it marks when statistics tracking
+    /// began for this level, not the first order's actual arrival time.
     #[must_use]
     pub fn first_arrival_time(&self) -> u64 {
         self.first_arrival_time.load(Ordering::Relaxed)

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -157,17 +157,14 @@ mod tests {
         );
         // The raw timestamp / waiting-time aggregates round-trip exactly too.
         assert_eq!(
-            restored_stats.last_execution_time.load(Ordering::Relaxed),
-            stats.last_execution_time.load(Ordering::Relaxed)
+            restored_stats.last_execution_time(),
+            stats.last_execution_time()
         );
         assert_eq!(
-            restored_stats.first_arrival_time.load(Ordering::Relaxed),
-            stats.first_arrival_time.load(Ordering::Relaxed)
+            restored_stats.first_arrival_time(),
+            stats.first_arrival_time()
         );
-        assert_eq!(
-            restored_stats.sum_waiting_time.load(Ordering::Relaxed),
-            stats.sum_waiting_time.load(Ordering::Relaxed)
-        );
+        assert_eq!(restored_stats.sum_waiting_time(), stats.sum_waiting_time());
     }
 
     #[test]

--- a/src/price_level/tests/snapshot.rs
+++ b/src/price_level/tests/snapshot.rs
@@ -8,7 +8,6 @@ mod tests {
     use serde_json::Value;
     use std::str::FromStr;
     use std::sync::Arc;
-    use std::sync::atomic::Ordering;
 
     fn create_sample_orders() -> Vec<Arc<OrderType<()>>> {
         vec![
@@ -127,9 +126,9 @@ mod tests {
         let original_orders_executed = original.orders_executed();
         let original_quantity = original.quantity_executed();
         let original_value = original.value_executed();
-        let original_last = original.last_execution_time.load(Ordering::Relaxed);
-        let original_first = original.first_arrival_time.load(Ordering::Relaxed);
-        let original_waiting = original.sum_waiting_time.load(Ordering::Relaxed);
+        let original_last = original.last_execution_time();
+        let original_first = original.first_arrival_time();
+        let original_waiting = original.sum_waiting_time();
 
         let package = PriceLevelSnapshotPackage::new(snapshot).expect("Failed to create package");
         assert_eq!(package.version(), SNAPSHOT_FORMAT_VERSION);
@@ -147,18 +146,9 @@ mod tests {
         assert_eq!(restored_stats.orders_executed(), original_orders_executed);
         assert_eq!(restored_stats.quantity_executed(), original_quantity);
         assert_eq!(restored_stats.value_executed(), original_value);
-        assert_eq!(
-            restored_stats.last_execution_time.load(Ordering::Relaxed),
-            original_last
-        );
-        assert_eq!(
-            restored_stats.first_arrival_time.load(Ordering::Relaxed),
-            original_first
-        );
-        assert_eq!(
-            restored_stats.sum_waiting_time.load(Ordering::Relaxed),
-            original_waiting
-        );
+        assert_eq!(restored_stats.last_execution_time(), original_last);
+        assert_eq!(restored_stats.first_arrival_time(), original_first);
+        assert_eq!(restored_stats.sum_waiting_time(), original_waiting);
     }
 
     #[test]

--- a/src/price_level/tests/statistics.rs
+++ b/src/price_level/tests/statistics.rs
@@ -3,7 +3,6 @@ mod tests {
     use crate::price_level::PriceLevelStatistics;
     use std::str::FromStr;
     use std::sync::Arc;
-    use std::sync::atomic::Ordering;
     use std::thread;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -15,9 +14,9 @@ mod tests {
         assert_eq!(stats.orders_executed(), 0);
         assert_eq!(stats.quantity_executed(), 0);
         assert_eq!(stats.value_executed(), 0);
-        assert_eq!(stats.last_execution_time.load(Ordering::Relaxed), 0);
-        assert!(stats.first_arrival_time.load(Ordering::Relaxed) > 0);
-        assert_eq!(stats.sum_waiting_time.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.last_execution_time(), 0);
+        assert!(stats.first_arrival_time() > 0);
+        assert_eq!(stats.sum_waiting_time(), 0);
     }
 
     #[test]
@@ -69,7 +68,7 @@ mod tests {
         assert_eq!(stats.orders_executed(), 1);
         assert_eq!(stats.quantity_executed(), 10);
         assert_eq!(stats.value_executed(), 1000); // 10 * 100
-        assert!(stats.last_execution_time.load(Ordering::Relaxed) > 0);
+        assert!(stats.last_execution_time() > 0);
 
         // Test with a maker timestamp 1 second before the execution time.
         let timestamp = execution_time - 1000; // 1 second ago
@@ -82,7 +81,7 @@ mod tests {
         assert_eq!(stats.orders_executed(), 2);
         assert_eq!(stats.quantity_executed(), 15); // 10 + 5
         assert_eq!(stats.value_executed(), 2000); // 1000 + (5 * 200)
-        assert!(stats.sum_waiting_time.load(Ordering::Relaxed) >= 1000); // At least 1 second waiting time
+        assert!(stats.sum_waiting_time() >= 1000); // At least 1 second waiting time
     }
 
     #[test]
@@ -169,9 +168,9 @@ mod tests {
         assert_eq!(stats.orders_executed(), 0);
         assert_eq!(stats.quantity_executed(), 0);
         assert_eq!(stats.value_executed(), 0);
-        assert_eq!(stats.last_execution_time.load(Ordering::Relaxed), 0);
-        assert!(stats.first_arrival_time.load(Ordering::Relaxed) > 0);
-        assert_eq!(stats.sum_waiting_time.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.last_execution_time(), 0);
+        assert!(stats.first_arrival_time() > 0);
+        assert_eq!(stats.sum_waiting_time(), 0);
     }
 
     #[test]
@@ -213,15 +212,9 @@ mod tests {
         assert_eq!(stats.orders_executed(), 2);
         assert_eq!(stats.quantity_executed(), 15);
         assert_eq!(stats.value_executed(), 2000);
-        assert_eq!(
-            stats.last_execution_time.load(Ordering::Relaxed),
-            1616823000000
-        );
-        assert_eq!(
-            stats.first_arrival_time.load(Ordering::Relaxed),
-            1616823000001
-        );
-        assert_eq!(stats.sum_waiting_time.load(Ordering::Relaxed), 1000);
+        assert_eq!(stats.last_execution_time(), 1616823000000);
+        assert_eq!(stats.first_arrival_time(), 1616823000001);
+        assert_eq!(stats.sum_waiting_time(), 1000);
     }
 
     #[test]
@@ -280,27 +273,16 @@ mod tests {
 
     #[test]
     fn test_round_trip_display_parse() {
-        let stats = PriceLevelStatistics::new();
-
-        // Use precise timestamps to avoid timing issues
+        // Build a fully-populated statistics value through the public `FromStr`
+        // path (the counters are private and have no public mutator), with
+        // predictable, precise values in every field to avoid timing issues.
         let current_time: u64 = 1616823000000;
-        stats
-            .last_execution_time
-            .store(current_time, Ordering::Relaxed);
-        stats
-            .first_arrival_time
-            .store(current_time + 1, Ordering::Relaxed);
-
-        // Add some data
-        stats.record_order_added();
-        stats.record_order_added();
-        stats.record_order_removed();
-
-        // Manual record to have predictable values
-        stats.orders_executed.store(2, Ordering::Relaxed);
-        stats.quantity_executed.store(15, Ordering::Relaxed);
-        stats.value_executed.store(2000, Ordering::Relaxed);
-        stats.sum_waiting_time.store(1000, Ordering::Relaxed);
+        let input = format!(
+            "PriceLevelStatistics:orders_added=2;orders_removed=1;orders_executed=2;quantity_executed=15;value_executed=2000;last_execution_time={};first_arrival_time={};sum_waiting_time=1000",
+            current_time,
+            current_time + 1
+        );
+        let stats = PriceLevelStatistics::from_str(&input).unwrap();
 
         // Convert to string
         let string_representation = stats.to_string();
@@ -314,18 +296,9 @@ mod tests {
         assert_eq!(parsed.orders_executed(), stats.orders_executed());
         assert_eq!(parsed.quantity_executed(), stats.quantity_executed());
         assert_eq!(parsed.value_executed(), stats.value_executed());
-        assert_eq!(
-            parsed.last_execution_time.load(Ordering::Relaxed),
-            stats.last_execution_time.load(Ordering::Relaxed)
-        );
-        assert_eq!(
-            parsed.first_arrival_time.load(Ordering::Relaxed),
-            stats.first_arrival_time.load(Ordering::Relaxed)
-        );
-        assert_eq!(
-            parsed.sum_waiting_time.load(Ordering::Relaxed),
-            stats.sum_waiting_time.load(Ordering::Relaxed)
-        );
+        assert_eq!(parsed.last_execution_time(), stats.last_execution_time());
+        assert_eq!(parsed.first_arrival_time(), stats.first_arrival_time());
+        assert_eq!(parsed.sum_waiting_time(), stats.sum_waiting_time());
     }
 
     #[test]
@@ -391,24 +364,17 @@ mod tests {
         assert_eq!(stats.orders_executed(), 0);
         assert_eq!(stats.quantity_executed(), 0);
         assert_eq!(stats.value_executed(), 0);
-        assert_eq!(stats.last_execution_time.load(Ordering::Relaxed), 0);
-        assert!(stats.first_arrival_time.load(Ordering::Relaxed) > 0);
-        assert_eq!(stats.sum_waiting_time.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.last_execution_time(), 0);
+        assert!(stats.first_arrival_time() > 0);
+        assert_eq!(stats.sum_waiting_time(), 0);
     }
 
     #[test]
     fn test_statistics_serialize_deserialize_fields() {
-        let stats = PriceLevelStatistics::new();
-
-        // Set and verify each field
-        stats.orders_added.store(1, Ordering::Relaxed);
-        stats.orders_removed.store(2, Ordering::Relaxed);
-        stats.orders_executed.store(3, Ordering::Relaxed);
-        stats.quantity_executed.store(4, Ordering::Relaxed);
-        stats.value_executed.store(5, Ordering::Relaxed);
-        stats.last_execution_time.store(6, Ordering::Relaxed);
-        stats.first_arrival_time.store(7, Ordering::Relaxed);
-        stats.sum_waiting_time.store(8, Ordering::Relaxed);
+        // Populate every field with a distinct value through the public
+        // `FromStr` path (the counters are private and have no public mutator).
+        let input = "PriceLevelStatistics:orders_added=1;orders_removed=2;orders_executed=3;quantity_executed=4;value_executed=5;last_execution_time=6;first_arrival_time=7;sum_waiting_time=8";
+        let stats = PriceLevelStatistics::from_str(input).unwrap();
 
         // Serialize to JSON
         let serialized = serde_json::to_string(&stats).unwrap();
@@ -432,9 +398,9 @@ mod tests {
         assert_eq!(deserialized.orders_executed(), 3);
         assert_eq!(deserialized.quantity_executed(), 4);
         assert_eq!(deserialized.value_executed(), 5);
-        assert_eq!(deserialized.last_execution_time.load(Ordering::Relaxed), 6);
-        assert_eq!(deserialized.first_arrival_time.load(Ordering::Relaxed), 7);
-        assert_eq!(deserialized.sum_waiting_time.load(Ordering::Relaxed), 8);
+        assert_eq!(deserialized.last_execution_time(), 6);
+        assert_eq!(deserialized.first_arrival_time(), 7);
+        assert_eq!(deserialized.sum_waiting_time(), 8);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`PriceLevelStatistics` exposed all 8 atomic counters as `pub`. Because the type
is reachable via `PriceLevel::stats() -> Arc<PriceLevelStatistics>`, any consumer
could `.store()` / `.fetch_add()` directly and desync the counters from the queue
and from the checked-arithmetic invariants `record_execution` enforces — exactly
the invariant-violation class the v0.7 private-field migration targeted.

## Changes

- All 8 atomic fields are now **private**.
- Added the 3 missing read accessors (`#[must_use]`, documented with units):
  `last_execution_time()`, `first_arrival_time()`, `sum_waiting_time()`. Every
  counter now has a public read path; mutation stays behind `record_*` / `reset`.
- Test reads switched from raw `.load()` to the accessors; two stats round-trip
  tests that previously `.store()`-mutated the raw atomics now drive state through
  the public `FromStr` path (which is what they actually exercise).

## Technical decisions

- `PriceLevelStatistics` stays un-exported at the crate root (reachable via
  `PriceLevel::stats()`), so the public surface grows only by the 3 new accessor
  methods. The in-module hand-written `Serialize`/`Deserialize`, `FromStr`,
  `Display`, and `Clone` keep accessing fields by name (same module).

## Testing

- [x] `make pre-push` clean
- [x] Serde / `FromStr` / `Display` round-trip tests still pass

`cargo test`: 340 unit + 1 integration + 9 doctests = 350 passed, 0 failed.
`cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all
--check`, `cargo build --release`: all clean.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] No `pub` field that can violate invariants remains on `PriceLevelStatistics`
- [x] `#[must_use]` on the new pure accessors; `///` docs with units
- [x] No `.unwrap()`/`.expect()` in production; no new `unsafe`; no new deps
- [x] Module boundaries respected; `tracing` only
- [x] Public surface change limited to 3 accessor methods (no crate-root export added)

Closes #66
