### PR TITLE
Justify atomic orderings; downgrade advisory counters to Relaxed (#67)

### DIFF
--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -120,7 +120,13 @@ impl PriceLevel {
     /// from it.
     #[must_use]
     pub fn visible_quantity(&self) -> u64 {
-        self.visible_quantity.load(Ordering::Acquire)
+        // `Relaxed`: this counter is advisory / eventually-consistent (see the
+        // doc above and issue #68). It carries NO happens-before relationship —
+        // the lock-free `SkipMap` / `DashMap` in `OrderQueue` carry the real
+        // ordering between producers and consumers, and `snapshot()` is the
+        // mutually-consistent view. Nothing is published or synchronized through
+        // this load, so `Acquire` would buy nothing.
+        self.visible_quantity.load(Ordering::Relaxed)
     }
 
     /// Get the hidden quantity, in quantity units.
@@ -129,7 +135,9 @@ impl PriceLevel {
     /// [`Self::visible_quantity`]; use [`Self::snapshot`] for a consistent view.
     #[must_use]
     pub fn hidden_quantity(&self) -> u64 {
-        self.hidden_quantity.load(Ordering::Acquire)
+        // `Relaxed`: advisory counter, no happens-before rides on it — see
+        // `visible_quantity` for the full rationale.
+        self.hidden_quantity.load(Ordering::Relaxed)
     }
 
     /// Get the total quantity (visible + hidden), in quantity units.
@@ -151,7 +159,9 @@ impl PriceLevel {
     /// [`Self::visible_quantity`]; use [`Self::snapshot`] for a consistent view.
     #[must_use]
     pub fn order_count(&self) -> usize {
-        self.order_count.load(Ordering::Acquire)
+        // `Relaxed`: advisory counter, no happens-before rides on it — see
+        // `visible_quantity` for the full rationale.
+        self.order_count.load(Ordering::Relaxed)
     }
 
     /// Get the statistics for this price level
@@ -176,11 +186,17 @@ impl PriceLevel {
         let order_arc = Arc::new(order);
         self.orders.push(order_arc.clone());
 
-        // Update atomic counters
+        // Update atomic counters. `Relaxed` on all three: these are the
+        // advisory counters (issue #68). The queue publication above (the
+        // `push` into `OrderQueue`'s `SkipMap` / `DashMap`) carries the actual
+        // happens-before for a concurrent reader; the counters are not a
+        // synchronization channel, so a release here would publish nothing a
+        // reader relies on. The RMWs only need to be atomic, not ordered.
         self.visible_quantity
-            .fetch_add(visible_qty, Ordering::AcqRel);
-        self.hidden_quantity.fetch_add(hidden_qty, Ordering::AcqRel);
-        self.order_count.fetch_add(1, Ordering::AcqRel);
+            .fetch_add(visible_qty, Ordering::Relaxed);
+        self.hidden_quantity
+            .fetch_add(hidden_qty, Ordering::Relaxed);
+        self.order_count.fetch_add(1, Ordering::Relaxed);
 
         // Update statistics
         self.stats.record_order_added();
@@ -256,8 +272,10 @@ impl PriceLevel {
                     order_arc.match_against(remaining);
 
                 if consumed > 0 {
-                    // Update visible quantity counter
-                    self.visible_quantity.fetch_sub(consumed, Ordering::AcqRel);
+                    // Update visible quantity counter. `Relaxed`: advisory
+                    // counter (issue #68); the queue mutation (`pop_entry`
+                    // above) carries the real happens-before, not this RMW.
+                    self.visible_quantity.fetch_sub(consumed, Ordering::Relaxed);
 
                     // Use UUID generator directly
                     let trade_id = Id::from_uuid(trade_id_generator.next());
@@ -302,10 +320,13 @@ impl PriceLevel {
                         // drawn from hidden into visible. By convention the
                         // refreshed tranche loses time priority, so it is
                         // appended to the tail via `push` (new sequence).
+                        // `Relaxed` on both counter RMWs: advisory counters
+                        // (issue #68); the `push` below carries the real
+                        // happens-before for the refreshed tranche.
                         self.hidden_quantity
-                            .fetch_sub(hidden_reduced, Ordering::AcqRel);
+                            .fetch_sub(hidden_reduced, Ordering::Relaxed);
                         self.visible_quantity
-                            .fetch_add(hidden_reduced, Ordering::AcqRel);
+                            .fetch_add(hidden_reduced, Ordering::Relaxed);
                         self.orders.push(Arc::new(updated));
                     } else {
                         // Pure partial fill: the maker keeps its place in the
@@ -315,7 +336,11 @@ impl PriceLevel {
                         self.orders.reinsert(order_seq, Arc::new(updated));
                     }
                 } else {
-                    self.order_count.fetch_sub(1, Ordering::AcqRel);
+                    // Maker fully consumed and removed from the queue (the
+                    // `pop_entry` above already removed it). `Relaxed` on both
+                    // counter RMWs: advisory counters (issue #68); the queue
+                    // removal carries the happens-before, not these counters.
+                    self.order_count.fetch_sub(1, Ordering::Relaxed);
                     match &*order_arc {
                         OrderType::IcebergOrder {
                             hidden_quantity, ..
@@ -324,7 +349,7 @@ impl PriceLevel {
                             hidden_quantity, ..
                         } if hidden_quantity.as_u64() > 0 && hidden_reduced == 0 => {
                             self.hidden_quantity
-                                .fetch_sub(hidden_quantity.as_u64(), Ordering::AcqRel);
+                                .fetch_sub(hidden_quantity.as_u64(), Ordering::Relaxed);
                         }
                         _ => {}
                     }
@@ -460,14 +485,18 @@ impl PriceLevel {
                     let order = self.orders.remove(order_id);
 
                     if let Some(ref order_arc) = order {
-                        // Update atomic counters
+                        // Update atomic counters from the order actually removed
+                        // from the queue above. `Relaxed` on all three: advisory
+                        // counters (issue #68); the `OrderQueue::remove` carries
+                        // the happens-before, not these counters.
                         let visible_qty = order_arc.visible_quantity();
                         let hidden_qty = order_arc.hidden_quantity();
 
                         self.visible_quantity
-                            .fetch_sub(visible_qty, Ordering::AcqRel);
-                        self.hidden_quantity.fetch_sub(hidden_qty, Ordering::AcqRel);
-                        self.order_count.fetch_sub(1, Ordering::AcqRel);
+                            .fetch_sub(visible_qty, Ordering::Relaxed);
+                        self.hidden_quantity
+                            .fetch_sub(hidden_qty, Ordering::Relaxed);
+                        self.order_count.fetch_sub(1, Ordering::Relaxed);
 
                         // Update statistics
                         self.stats.record_order_removed();
@@ -552,11 +581,14 @@ impl PriceLevel {
                 // handle both signs.
                 let old_visible = old.visible_quantity();
                 let old_hidden = old.hidden_quantity();
+                // `Relaxed` on both branches: advisory counters (issue #68); the
+                // queue mutation above (`update_in_place` / `remove` + `push`)
+                // carries the happens-before, not these counter RMWs.
                 let apply = |counter: &std::sync::atomic::AtomicU64, old: u64, new: u64| {
                     if new >= old {
-                        counter.fetch_add(new - old, Ordering::AcqRel);
+                        counter.fetch_add(new - old, Ordering::Relaxed);
                     } else {
-                        counter.fetch_sub(old - new, Ordering::AcqRel);
+                        counter.fetch_sub(old - new, Ordering::Relaxed);
                     }
                 };
                 apply(&self.visible_quantity, old_visible, new_visible);
@@ -575,14 +607,18 @@ impl PriceLevel {
                     let order = self.orders.remove(order_id);
 
                     if let Some(ref order_arc) = order {
-                        // Update atomic counters
+                        // Update atomic counters from the order actually removed
+                        // from the queue above. `Relaxed` on all three: advisory
+                        // counters (issue #68); the `OrderQueue::remove` carries
+                        // the happens-before, not these counters.
                         let visible_qty = order_arc.visible_quantity();
                         let hidden_qty = order_arc.hidden_quantity();
 
                         self.visible_quantity
-                            .fetch_sub(visible_qty, Ordering::AcqRel);
-                        self.hidden_quantity.fetch_sub(hidden_qty, Ordering::AcqRel);
-                        self.order_count.fetch_sub(1, Ordering::AcqRel);
+                            .fetch_sub(visible_qty, Ordering::Relaxed);
+                        self.hidden_quantity
+                            .fetch_sub(hidden_qty, Ordering::Relaxed);
+                        self.order_count.fetch_sub(1, Ordering::Relaxed);
 
                         // Update statistics
                         self.stats.record_order_removed();
@@ -602,14 +638,18 @@ impl PriceLevel {
                 let order = self.orders.remove(order_id);
 
                 if let Some(ref order_arc) = order {
-                    // Update atomic counters
+                    // Update atomic counters from the order actually removed from
+                    // the queue above. `Relaxed` on all three: advisory counters
+                    // (issue #68); the `OrderQueue::remove` carries the
+                    // happens-before, not these counters.
                     let visible_qty = order_arc.visible_quantity();
                     let hidden_qty = order_arc.hidden_quantity();
 
                     self.visible_quantity
-                        .fetch_sub(visible_qty, Ordering::AcqRel);
-                    self.hidden_quantity.fetch_sub(hidden_qty, Ordering::AcqRel);
-                    self.order_count.fetch_sub(1, Ordering::AcqRel);
+                        .fetch_sub(visible_qty, Ordering::Relaxed);
+                    self.hidden_quantity
+                        .fetch_sub(hidden_qty, Ordering::Relaxed);
+                    self.order_count.fetch_sub(1, Ordering::Relaxed);
 
                     // Update statistics
                     self.stats.record_order_removed();
@@ -630,14 +670,18 @@ impl PriceLevel {
                     let order = self.orders.remove(order_id);
 
                     if let Some(ref order_arc) = order {
-                        // Update atomic counters
+                        // Update atomic counters from the order actually removed
+                        // from the queue above. `Relaxed` on all three: advisory
+                        // counters (issue #68); the `OrderQueue::remove` carries
+                        // the happens-before, not these counters.
                         let visible_qty = order_arc.visible_quantity();
                         let hidden_qty = order_arc.hidden_quantity();
 
                         self.visible_quantity
-                            .fetch_sub(visible_qty, Ordering::AcqRel);
-                        self.hidden_quantity.fetch_sub(hidden_qty, Ordering::AcqRel);
-                        self.order_count.fetch_sub(1, Ordering::AcqRel);
+                            .fetch_sub(visible_qty, Ordering::Relaxed);
+                        self.hidden_quantity
+                            .fetch_sub(hidden_qty, Ordering::Relaxed);
+                        self.order_count.fetch_sub(1, Ordering::Relaxed);
 
                         // Update statistics
                         self.stats.record_order_removed();

--- a/src/price_level/statistics.rs
+++ b/src/price_level/statistics.rs
@@ -15,6 +15,22 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// [`record_execution`](Self::record_execution). Mutation happens only through
 /// the `record_*` / [`reset`](Self::reset) methods; reads happen only through
 /// the public accessors.
+///
+/// # Atomic ordering
+///
+/// **Every atomic access in this type uses [`Ordering::Relaxed`], deliberately.**
+/// These are pure observability counters: nothing in the engine reads a
+/// statistic to gate a queue mutation, and no other field's visibility is
+/// published through them. They carry no happens-before relationship — each
+/// counter is independent and may be read mid-update, so a multi-field read
+/// (serde, [`Display`](std::fmt::Display), [`Clone`]) is an explicitly
+/// best-effort, non-transactional point-in-time view (the same contract as
+/// `PriceLevel::snapshot`). `Relaxed` is therefore both correct and the
+/// cheapest valid choice; a stronger ordering would only add cost without
+/// buying any guarantee a consumer relies on. The lone read-modify-write loop
+/// in [`checked_fetch_add_u64`](Self::checked_fetch_add_u64) is a standard
+/// `compare_exchange_weak` CAS retry — see the note there for why both its
+/// success and failure orderings are `Relaxed`.
 #[derive(Debug)]
 pub struct PriceLevelStatistics {
     /// Number of orders added
@@ -49,6 +65,8 @@ impl PriceLevelStatistics {
         value: u64,
         field: &str,
     ) -> Result<(), PriceLevelError> {
+        // `Relaxed`: this is an advisory observability counter (see the
+        // struct-level "Atomic ordering" note) — no happens-before rides on it.
         let mut current = target.load(Ordering::Relaxed);
 
         loop {
@@ -59,6 +77,13 @@ impl PriceLevelStatistics {
                         message: format!("{field} overflow"),
                     })?;
 
+            // Standard lock-free CAS retry. Both the success and failure
+            // orderings are `Relaxed`: the only invariant is that the stored
+            // value is a checked sum of monotonic increments (the loop re-reads
+            // `observed` and re-validates on contention). The counter publishes
+            // nothing to another thread, so neither acquire on failure nor
+            // release on success is needed. The retry body is allocation-free,
+            // per the tight-CAS-loop rule.
             match target.compare_exchange_weak(current, next, Ordering::Relaxed, Ordering::Relaxed)
             {
                 Ok(_) => return Ok(()),

--- a/src/price_level/statistics.rs
+++ b/src/price_level/statistics.rs
@@ -24,8 +24,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// published through them. They carry no happens-before relationship — each
 /// counter is independent and may be read mid-update, so a multi-field read
 /// (serde, [`Display`](std::fmt::Display), [`Clone`]) is an explicitly
-/// best-effort, non-transactional point-in-time view (the same contract as
-/// `PriceLevel::snapshot`). `Relaxed` is therefore both correct and the
+/// best-effort, non-transactional point-in-time view that can be torn across
+/// fields. This is unlike `PriceLevel::snapshot`, which is internally
+/// consistent (it derives its aggregates from one materialized order vector);
+/// these statistics counters are not part of that consistency guarantee.
+/// `Relaxed` is therefore both correct and the
 /// cheapest valid choice; a stronger ordering would only add cost without
 /// buying any guarantee a consumer relies on. The lone read-modify-write loop
 /// in [`checked_fetch_add_u64`](Self::checked_fetch_add_u64) is a standard

--- a/src/utils/uuid.rs
+++ b/src/utils/uuid.rs
@@ -77,6 +77,14 @@ impl UuidGenerator {
     ///
     /// A new UUID that is deterministically derived from the namespace and the current counter value.
     pub fn next(&self) -> Uuid {
+        // The only invariant is that each caller observes a distinct, monotonic
+        // counter value so the minted trade ids are unique (a `fetch_add` is
+        // atomic, so even `Relaxed` would guarantee uniqueness — no
+        // happens-before rides on this value, it is consumed locally to build
+        // the v5 UUID). `SeqCst` is kept deliberately: id minting is not on a
+        // measured hot path, and the global total order it provides makes the
+        // counter trivially auditable across threads. Behavior is intentionally
+        // unchanged here.
         let counter = self.counter.fetch_add(1, Ordering::SeqCst);
         let name = counter.to_string();
         // Generate a UUID v5 (name-based) using the namespace and counter


### PR DESCRIPTION
## Summary

The Concurrency rules require a justifying comment next to every non-`SeqCst`
atomic ordering and that over-strong orderings be downgraded. The atomic
orderings in `price_level/` carried none. This adds them and downgrades the
advisory counters.

## Changes

- **`level.rs`** — every counter ordering now has a justifying comment, and all
  `visible_quantity` / `hidden_quantity` / `order_count` accessor loads and the
  `add_order` / `match_order` / `update_order` RMWs are downgraded
  `Acquire`/`AcqRel` → `Relaxed`.
- **`statistics.rs`** — added a struct-level rationale for the all-`Relaxed`
  observability counters and a note at the `compare_exchange_weak` CAS loop. No
  ordering changed.
- **`uuid.rs`** — commented the `SeqCst` id counter (unchanged).

## Technical decisions

- The downgrade rests on the merged #68 determination: the level counters are
  advisory / eventually-consistent. The lock-free `SkipMap` + `DashMap` in
  `OrderQueue` carry the real producer→consumer happens-before, and `snapshot()`
  (consistent since #62) derives aggregates from a single materialized order
  vector — not from these atomics. No happens-before rides on the counters, so
  `Relaxed` is correct and only the atomicity of each `fetch_add`/`fetch_sub` is
  required (preserved). `match_order` terminates on the queue (`pop_entry`),
  never on a counter.
- **Verified SOUND by a dedicated concurrency audit** (every counter call site
  enumerated; no gating read relies on the `Acquire` edge; `snapshot()` is
  independent of the orderings). No behavioral change.

## Testing

- [x] `make pre-push` clean; existing concurrency/snapshot tests pass

`cargo test`: 340 unit + 1 integration + 9 doctests = 350 passed, 0 failed.
`cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all
--check`, `cargo build --release`: all clean.

## Checklist

- [x] Every non-`SeqCst` ordering carries a justifying comment
- [x] Downgrades limited to advisory counters with no happens-before; queue
      structures unchanged
- [x] No counter↔queue consistency regression (snapshot() per #62/#68 intact)
- [x] No new deps; `tracing` only; module boundaries respected
- [x] No matching-semantics change

Closes #67
