### PR TITLE
Use NonZeroU64 for the reserve replenish amount (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,26 @@ The performance characteristics demonstrate that the `pricelevel` library is sui
   calls on the *same* level — or a `match_order` racing a `cancel` of the
   resting order it is currently matching — are the caller's responsibility
   to serialize.
+- **Reserve replenish amounts are now `NonZeroU64`** (issue #70). A
+  replenish amount of `0` is structurally invalid: it would draw an empty
+  visible tranche from the hidden quantity, silently leaving nothing
+  visible. The reserve replenish surface therefore moved from `Quantity`
+  (which permits `0`) and raw `u64` to [`std::num::NonZeroU64`]:
+
+  | v0.8 (before) | v0.8 (now) |
+  |---------------|------------|
+  | `ReserveOrder.replenish_amount: Option<Quantity>` | `Option<NonZeroU64>` |
+  | `DEFAULT_RESERVE_REPLENISH_AMOUNT: u64` | `NonZeroU64` (value `80`) |
+  | `OrderType::refresh_iceberg(&self, u64)` | `refresh_iceberg(&self, NonZeroU64)` |
+
+  Constructing a reserve order with a zero replenish is now impossible at
+  the type level. Build the amount with [`std::num::NonZeroU64::new`]
+  (`Some(NonZeroU64::new(n).unwrap())` or `NonZeroU64::new(n)` directly into
+  the `Option` field). On the text / JSON deserialization path a
+  `replenish_amount` of `0` is rejected with a typed
+  [`PriceLevelError::InvalidFieldValue`] (text) or a deserialization error
+  (JSON) rather than silently accepted — never a panic. Reading the default
+  as a raw integer now requires `DEFAULT_RESERVE_REPLENISH_AMOUNT.get()`.
 
 ### Migration Guide (v0.6 → v0.7)
 

--- a/README.md
+++ b/README.md
@@ -179,13 +179,18 @@ The performance characteristics demonstrate that the `pricelevel` library is sui
   | `OrderType::refresh_iceberg(&self, u64)` | `refresh_iceberg(&self, NonZeroU64)` |
 
   Constructing a reserve order with a zero replenish is now impossible at
-  the type level. Build the amount with [`std::num::NonZeroU64::new`]
-  (`Some(NonZeroU64::new(n).unwrap())` or `NonZeroU64::new(n)` directly into
-  the `Option` field). On the text / JSON deserialization path a
-  `replenish_amount` of `0` is rejected with a typed
-  [`PriceLevelError::InvalidFieldValue`] (text) or a deserialization error
-  (JSON) rather than silently accepted — never a panic. Reading the default
-  as a raw integer now requires `DEFAULT_RESERVE_REPLENISH_AMOUNT.get()`.
+  the type level. Build the amount with [`std::num::NonZeroU64::new`], which
+  returns an `Option`. For a known-good literal, a compile-time constant is
+  simplest. For a **runtime** value `n`, match on `NonZeroU64::new(n)` and
+  treat `None` as an invalid amount to reject — do **not** blindly
+  `.unwrap()` it (that panics on `0`), and do **not** pass `NonZeroU64::new(n)`
+  straight into the `Option` field (that silently maps `0` to `None`, which
+  falls back to the default replenish instead of flagging the bad input). On
+  the text / JSON deserialization path a `replenish_amount` of `0` is rejected
+  with a typed [`PriceLevelError::InvalidFieldValue`] (text) or a
+  deserialization error (JSON) rather than silently accepted — never a panic.
+  Reading the default as a raw integer now requires
+  `DEFAULT_RESERVE_REPLENISH_AMOUNT.get()`.
 
 ### Migration Guide (v0.6 → v0.7)
 

--- a/benches/concurrent/register.rs
+++ b/benches/concurrent/register.rs
@@ -3,6 +3,7 @@ use pricelevel::{
     Hash32, Id, OrderType, OrderUpdate, PegReferenceType, Price, PriceLevel, Quantity, Side,
     TimeInForce, TimestampMs, UuidGenerator,
 };
+use std::num::NonZeroU64;
 use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -420,7 +421,7 @@ fn create_reserve_order(
         timestamp: TimestampMs::new(1616823000000),
         time_in_force: TimeInForce::Gtc,
         replenish_threshold: Quantity::new(threshold),
-        replenish_amount: replenish_amount.map(Quantity::new),
+        replenish_amount: replenish_amount.and_then(NonZeroU64::new),
         auto_replenish,
         extra_fields: (),
     }

--- a/benches/price_level/add_orders.rs
+++ b/benches/price_level/add_orders.rs
@@ -3,6 +3,7 @@ use pricelevel::{
     Hash32, Id, OrderType, Price, PriceLevel, Quantity, Side, TimeInForce, TimestampMs,
 };
 use std::hint::black_box;
+use std::num::NonZeroU64;
 
 /// Register all benchmarks for adding orders to a price level
 pub fn register_benchmarks(c: &mut Criterion) {
@@ -143,7 +144,7 @@ fn create_reserve_order(
         timestamp: TimestampMs::new(1616823000000),
         time_in_force: TimeInForce::Gtc,
         replenish_threshold: Quantity::new(threshold),
-        replenish_amount: replenish_amount.map(Quantity::new),
+        replenish_amount: replenish_amount.and_then(NonZeroU64::new),
         auto_replenish,
         extra_fields: (),
     }

--- a/benches/price_level/checked_arithmetic.rs
+++ b/benches/price_level/checked_arithmetic.rs
@@ -4,6 +4,7 @@ use pricelevel::{
     TimestampMs, Trade, UuidGenerator,
 };
 use std::hint::black_box;
+use std::num::NonZeroU64;
 use uuid::Uuid;
 
 /// Register benchmarks for checked arithmetic APIs and error-path performance.
@@ -172,7 +173,7 @@ fn setup_mixed_level(order_count: u64) -> PriceLevel {
                 timestamp: TimestampMs::new(1_616_823_000_000 + i),
                 time_in_force: TimeInForce::Gtc,
                 replenish_threshold: Quantity::new(5),
-                replenish_amount: Some(Quantity::new(10)),
+                replenish_amount: NonZeroU64::new(10),
                 auto_replenish: true,
                 extra_fields: (),
             },

--- a/benches/price_level/match_orders.rs
+++ b/benches/price_level/match_orders.rs
@@ -4,6 +4,7 @@ use pricelevel::{
     UuidGenerator,
 };
 use std::hint::black_box;
+use std::num::NonZeroU64;
 use uuid::Uuid;
 
 /// Register all benchmarks for matching orders at a price level
@@ -215,7 +216,7 @@ fn setup_reserve_orders(order_count: u64) -> PriceLevel {
             timestamp: TimestampMs::new(1616823000000 + i),
             time_in_force: TimeInForce::Gtc,
             replenish_threshold: Quantity::new(2),
-            replenish_amount: Some(Quantity::new(5)),
+            replenish_amount: NonZeroU64::new(5),
             auto_replenish: true,
             extra_fields: (),
         };
@@ -262,7 +263,7 @@ fn setup_mixed_orders(order_count: u64) -> PriceLevel {
                 timestamp: TimestampMs::new(1616823000000 + i),
                 time_in_force: TimeInForce::Gtc,
                 replenish_threshold: Quantity::new(2),
-                replenish_amount: Some(Quantity::new(5)),
+                replenish_amount: NonZeroU64::new(5),
                 auto_replenish: true,
                 extra_fields: (),
             },

--- a/benches/price_level/mixed_operations.rs
+++ b/benches/price_level/mixed_operations.rs
@@ -4,6 +4,7 @@ use pricelevel::{
     TimestampMs, UuidGenerator,
 };
 use std::hint::black_box;
+use std::num::NonZeroU64;
 use uuid::Uuid;
 
 /// Register benchmarks for mixed/realistic price level operations
@@ -211,7 +212,7 @@ fn create_reserve_order(
         timestamp: TimestampMs::new(1616823000000 + id),
         time_in_force: TimeInForce::Gtc,
         replenish_threshold: Quantity::new(threshold),
-        replenish_amount: replenish_amount.map(Quantity::new),
+        replenish_amount: replenish_amount.and_then(NonZeroU64::new),
         auto_replenish,
         extra_fields: (),
     }

--- a/benches/price_level/snapshot_recovery.rs
+++ b/benches/price_level/snapshot_recovery.rs
@@ -4,6 +4,7 @@ use pricelevel::{
     TimeInForce, TimestampMs,
 };
 use std::hint::black_box;
+use std::num::NonZeroU64;
 
 /// Register benchmarks for snapshot checksum creation, JSON roundtrip, and recovery.
 pub fn register_benchmarks(c: &mut Criterion) {
@@ -118,7 +119,7 @@ fn setup_mixed_level(order_count: u64) -> PriceLevel {
                 timestamp: TimestampMs::new(1_616_823_000_000 + i),
                 time_in_force: TimeInForce::Gtc,
                 replenish_threshold: Quantity::new(5),
-                replenish_amount: Some(Quantity::new(10)),
+                replenish_amount: NonZeroU64::new(10),
                 auto_replenish: true,
                 extra_fields: (),
             },

--- a/examples/src/bin/hft_simulation.rs
+++ b/examples/src/bin/hft_simulation.rs
@@ -4,6 +4,7 @@ use pricelevel::{
     Hash32, Id, OrderType, OrderUpdate, PegReferenceType, Price, PriceLevel, Quantity, Side,
     TimeInForce, TimestampMs, UuidGenerator, setup_logger,
 };
+use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
@@ -372,7 +373,7 @@ fn create_reserve_order(id: u64) -> OrderType<()> {
         timestamp: TimestampMs::new(get_current_timestamp()),
         time_in_force: TimeInForce::Gtc,
         replenish_threshold: Quantity::new(2),
-        replenish_amount: Some(Quantity::new(5)),
+        replenish_amount: NonZeroU64::new(5),
         auto_replenish: true,
         extra_fields: (),
     }

--- a/examples/src/bin/integration_snapshot_recovery.rs
+++ b/examples/src/bin/integration_snapshot_recovery.rs
@@ -8,6 +8,7 @@ use pricelevel::{
     Hash32, Id, OrderType, Price, PriceLevel, PriceLevelError, PriceLevelSnapshot,
     PriceLevelSnapshotPackage, Quantity, Side, TimeInForce, TimestampMs,
 };
+use std::num::NonZeroU64;
 use std::process;
 
 fn main() {
@@ -59,7 +60,7 @@ fn main() {
         timestamp: TimestampMs::new(ts),
         time_in_force: TimeInForce::Gtc,
         replenish_threshold: Quantity::new(5),
-        replenish_amount: Some(Quantity::new(10)),
+        replenish_amount: NonZeroU64::new(10),
         auto_replenish: true,
         extra_fields: (),
     });

--- a/examples/src/bin/integration_special_orders.rs
+++ b/examples/src/bin/integration_special_orders.rs
@@ -8,6 +8,7 @@ use pricelevel::{
     DEFAULT_RESERVE_REPLENISH_AMOUNT, Hash32, Id, OrderType, OrderUpdate, PegReferenceType, Price,
     PriceLevel, Quantity, Side, TimeInForce, TimestampMs, UuidGenerator,
 };
+use std::num::NonZeroU64;
 use std::process;
 use uuid::Uuid;
 
@@ -85,7 +86,7 @@ fn test_reserve_order(id_gen: &UuidGenerator) {
         timestamp: TimestampMs::new(1_000_001),
         time_in_force: TimeInForce::Gtc,
         replenish_threshold: Quantity::new(2),
-        replenish_amount: Some(Quantity::new(10)),
+        replenish_amount: NonZeroU64::new(10),
         auto_replenish: true,
         extra_fields: (),
     });
@@ -109,9 +110,10 @@ fn test_reserve_order(id_gen: &UuidGenerator) {
         "reserve should not be fully filled",
     );
 
-    // Verify default replenish amount constant is accessible
+    // Verify default replenish amount constant is accessible. The constant is a
+    // `NonZeroU64`, so a zero replenish is structurally impossible.
     assert_or_exit(
-        DEFAULT_RESERVE_REPLENISH_AMOUNT > 0,
+        DEFAULT_RESERVE_REPLENISH_AMOUNT.get() > 0,
         "DEFAULT_RESERVE_REPLENISH_AMOUNT should be positive",
     );
 

--- a/examples/src/bin/simple.rs
+++ b/examples/src/bin/simple.rs
@@ -4,6 +4,7 @@ use pricelevel::{
     Hash32, Id, OrderType, OrderUpdate, Price, PriceLevel, Quantity, Side, TimeInForce,
     TimestampMs, UuidGenerator, setup_logger,
 };
+use std::num::NonZeroU64;
 use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -242,7 +243,7 @@ fn setup_initial_orders(price_level: &PriceLevel) {
             timestamp: TimestampMs::new(1616823000000 + i),
             time_in_force: TimeInForce::Gtc,
             replenish_threshold: Quantity::new(2),
-            replenish_amount: Some(Quantity::new(5)),
+            replenish_amount: NonZeroU64::new(5),
             auto_replenish: true,
             extra_fields: (),
         };
@@ -300,7 +301,7 @@ fn create_order(thread_id: usize, order_id: u64) -> OrderType<()> {
             timestamp: TimestampMs::new(current_time),
             time_in_force: TimeInForce::Gtc,
             replenish_threshold: Quantity::new(2),
-            replenish_amount: Some(Quantity::new(5)),
+            replenish_amount: NonZeroU64::new(5),
             auto_replenish: true,
             extra_fields: (),
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,13 +170,18 @@
 //!   | `OrderType::refresh_iceberg(&self, u64)` | `refresh_iceberg(&self, NonZeroU64)` |
 //!
 //!   Constructing a reserve order with a zero replenish is now impossible at
-//!   the type level. Build the amount with [`std::num::NonZeroU64::new`]
-//!   (`Some(NonZeroU64::new(n).unwrap())` or `NonZeroU64::new(n)` directly into
-//!   the `Option` field). On the text / JSON deserialization path a
-//!   `replenish_amount` of `0` is rejected with a typed
-//!   [`PriceLevelError::InvalidFieldValue`] (text) or a deserialization error
-//!   (JSON) rather than silently accepted — never a panic. Reading the default
-//!   as a raw integer now requires `DEFAULT_RESERVE_REPLENISH_AMOUNT.get()`.
+//!   the type level. Build the amount with [`std::num::NonZeroU64::new`], which
+//!   returns an `Option`. For a known-good literal, a compile-time constant is
+//!   simplest. For a **runtime** value `n`, match on `NonZeroU64::new(n)` and
+//!   treat `None` as an invalid amount to reject — do **not** blindly
+//!   `.unwrap()` it (that panics on `0`), and do **not** pass `NonZeroU64::new(n)`
+//!   straight into the `Option` field (that silently maps `0` to `None`, which
+//!   falls back to the default replenish instead of flagging the bad input). On
+//!   the text / JSON deserialization path a `replenish_amount` of `0` is rejected
+//!   with a typed [`PriceLevelError::InvalidFieldValue`] (text) or a
+//!   deserialization error (JSON) rather than silently accepted — never a panic.
+//!   Reading the default as a raw integer now requires
+//!   `DEFAULT_RESERVE_REPLENISH_AMOUNT.get()`.
 //!
 //! ## Migration Guide (v0.6 → v0.7)
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,26 @@
 //!   calls on the *same* level — or a `match_order` racing a `cancel` of the
 //!   resting order it is currently matching — are the caller's responsibility
 //!   to serialize.
+//! - **Reserve replenish amounts are now `NonZeroU64`** (issue #70). A
+//!   replenish amount of `0` is structurally invalid: it would draw an empty
+//!   visible tranche from the hidden quantity, silently leaving nothing
+//!   visible. The reserve replenish surface therefore moved from `Quantity`
+//!   (which permits `0`) and raw `u64` to [`std::num::NonZeroU64`]:
+//!
+//!   | v0.8 (before) | v0.8 (now) |
+//!   |---------------|------------|
+//!   | `ReserveOrder.replenish_amount: Option<Quantity>` | `Option<NonZeroU64>` |
+//!   | `DEFAULT_RESERVE_REPLENISH_AMOUNT: u64` | `NonZeroU64` (value `80`) |
+//!   | `OrderType::refresh_iceberg(&self, u64)` | `refresh_iceberg(&self, NonZeroU64)` |
+//!
+//!   Constructing a reserve order with a zero replenish is now impossible at
+//!   the type level. Build the amount with [`std::num::NonZeroU64::new`]
+//!   (`Some(NonZeroU64::new(n).unwrap())` or `NonZeroU64::new(n)` directly into
+//!   the `Option` field). On the text / JSON deserialization path a
+//!   `replenish_amount` of `0` is rejected with a typed
+//!   [`PriceLevelError::InvalidFieldValue`] (text) or a deserialization error
+//!   (JSON) rather than silently accepted — never a panic. Reading the default
+//!   as a raw integer now requires `DEFAULT_RESERVE_REPLENISH_AMOUNT.get()`.
 //!
 //! ## Migration Guide (v0.6 → v0.7)
 //!

--- a/src/orders/order_type.rs
+++ b/src/orders/order_type.rs
@@ -6,6 +6,7 @@ use crate::orders::{Hash32, Id, PegReferenceType, Side, TimeInForce};
 use crate::utils::{Price, Quantity, TimestampMs};
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::num::NonZeroU64;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -17,8 +18,20 @@ fn user_id_from_str(value: &str) -> Result<Hash32, PriceLevelError> {
     })
 }
 
-/// Default amount to replenish the reserve with.
-pub const DEFAULT_RESERVE_REPLENISH_AMOUNT: u64 = 80;
+/// Default amount to replenish the reserve with, in quantity units.
+///
+/// A replenish amount is structurally non-zero: a zero replenish would draw an
+/// empty visible tranche from hidden, silently leaving nothing visible. The
+/// type therefore is [`NonZeroU64`] rather than a raw `u64`. The constant is
+/// built in a `const`-evaluable form (a `match` on [`NonZeroU64::new`]) so it
+/// carries no runtime `unwrap`/`expect`.
+pub const DEFAULT_RESERVE_REPLENISH_AMOUNT: NonZeroU64 = match NonZeroU64::new(80) {
+    Some(value) => value,
+    // Unreachable: 80 is a non-zero literal, so `NonZeroU64::new` is always
+    // `Some` here. The branch is resolved at compile time, so this carries no
+    // runtime `unwrap`/`expect`.
+    None => unreachable!(),
+};
 
 /// Represents different types of limit orders
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -177,8 +190,11 @@ pub enum OrderType<T> {
         time_in_force: TimeInForce,
         /// Threshold at which to replenish
         replenish_threshold: Quantity,
-        /// Optional amount to replenish by. If None, uses DEFAULT_RESERVE_REPLENISH_AMOUNT
-        replenish_amount: Option<Quantity>,
+        /// Optional amount to replenish by, in quantity units. If `None`, uses
+        /// [`DEFAULT_RESERVE_REPLENISH_AMOUNT`]. A replenish amount is
+        /// structurally non-zero ([`NonZeroU64`]): a zero replenish would draw
+        /// an empty visible tranche from hidden.
+        replenish_amount: Option<NonZeroU64>,
         /// Whether to replenish automatically when below threshold. If false, only replenish on next match
         auto_replenish: bool,
         /// Additional custom fields
@@ -393,9 +409,19 @@ impl<T: Clone> OrderType<T> {
         }
     }
 
-    /// Update an iceberg order, refreshing visible part from hidden
+    /// Update an iceberg or reserve order, refreshing the visible part from
+    /// hidden.
+    ///
+    /// `refresh_amount` is the tranche size to draw from the hidden quantity,
+    /// in quantity units. It is [`NonZeroU64`] because a zero refresh would
+    /// draw an empty visible tranche, silently leaving nothing visible. The
+    /// amount actually drawn is capped at the remaining hidden quantity.
+    ///
+    /// Returns the refreshed order and the quantity drawn from hidden. For a
+    /// non-iceberg / non-reserve order the order is returned unchanged with a
+    /// drawn quantity of `0`.
     #[must_use]
-    pub fn refresh_iceberg(&self, refresh_amount: u64) -> (Self, u64) {
+    pub fn refresh_iceberg(&self, refresh_amount: NonZeroU64) -> (Self, u64) {
         match self {
             Self::IcebergOrder {
                 id,
@@ -408,7 +434,7 @@ impl<T: Clone> OrderType<T> {
                 time_in_force,
                 extra_fields,
             } => {
-                let used_hidden = refresh_amount.min(hidden_quantity.as_u64());
+                let used_hidden = refresh_amount.get().min(hidden_quantity.as_u64());
                 let new_hidden = hidden_quantity.as_u64() - used_hidden;
 
                 (
@@ -440,7 +466,7 @@ impl<T: Clone> OrderType<T> {
                 auto_replenish,
                 extra_fields,
             } => {
-                let used_hidden = refresh_amount.min(hidden_quantity.as_u64());
+                let used_hidden = refresh_amount.get().min(hidden_quantity.as_u64());
                 let new_hidden = hidden_quantity.as_u64() - used_hidden;
 
                 (
@@ -604,8 +630,8 @@ impl<T: Clone> OrderType<T> {
                 };
 
                 let replenish_qty = replenish_amount
-                    .unwrap_or(Quantity::new(DEFAULT_RESERVE_REPLENISH_AMOUNT))
-                    .as_u64()
+                    .unwrap_or(DEFAULT_RESERVE_REPLENISH_AMOUNT)
+                    .get()
                     .min(hidden_quantity.as_u64());
 
                 if visible_quantity.as_u64() <= incoming_quantity {
@@ -1140,7 +1166,17 @@ impl<T: Default> FromStr for OrderType<T> {
                 let replenish_amount = if replenish_amount_str == "None" {
                     None
                 } else {
-                    Some(parse_quantity("replenish_amount", replenish_amount_str)?)
+                    // A replenish amount is structurally non-zero. Parse into
+                    // `NonZeroU64` so a literal `0` (or a non-numeric value) is
+                    // surfaced as a typed `InvalidFieldValue` rather than a
+                    // silently-accepted empty tranche.
+                    let value = replenish_amount_str.parse::<NonZeroU64>().map_err(|_| {
+                        PriceLevelError::InvalidFieldValue {
+                            field: "replenish_amount".to_string(),
+                            value: replenish_amount_str.to_string(),
+                        }
+                    })?;
+                    Some(value)
                 };
                 let auto_replenish_str = get_field("auto_replenish")?;
                 let auto_replenish = match auto_replenish_str {

--- a/src/orders/tests/order_type.rs
+++ b/src/orders/tests/order_type.rs
@@ -3,8 +3,14 @@ mod tests {
     use crate::orders::time_in_force::TimeInForce;
     use crate::orders::{Hash32, Id, OrderType, PegReferenceType, Side};
     use crate::utils::{Price, Quantity, TimestampMs};
+    use std::num::NonZeroU64;
     use std::str::FromStr;
     use tracing::info;
+
+    /// Build a `NonZeroU64` from a non-zero test literal.
+    fn nz(value: u64) -> NonZeroU64 {
+        NonZeroU64::new(value).expect("test literal must be non-zero")
+    }
 
     fn create_standard_order() -> OrderType<()> {
         OrderType::<()>::Standard {
@@ -106,7 +112,7 @@ mod tests {
             timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             replenish_threshold: Quantity::new(0),
-            replenish_amount: Some(Quantity::new(1)),
+            replenish_amount: Some(nz(1)),
             auto_replenish: false,
             extra_fields: (),
         }
@@ -332,7 +338,7 @@ mod tests {
     fn test_refresh_iceberg() {
         // Test iceberg order refresh
         let order = create_iceberg_order();
-        let (refreshed, used) = order.refresh_iceberg(2);
+        let (refreshed, used) = order.refresh_iceberg(nz(2));
 
         if let OrderType::<()>::IcebergOrder {
             visible_quantity,
@@ -349,7 +355,7 @@ mod tests {
 
         // Test reserve order refresh
         let order = create_reserve_order();
-        let (refreshed, used) = order.refresh_iceberg(3);
+        let (refreshed, used) = order.refresh_iceberg(nz(3));
 
         if let OrderType::<()>::ReserveOrder {
             visible_quantity,
@@ -366,13 +372,55 @@ mod tests {
 
         // Test non-iceberg order (should not refresh)
         let order = create_standard_order();
-        let (refreshed, used) = order.refresh_iceberg(2);
+        let (refreshed, used) = order.refresh_iceberg(nz(2));
 
         if let OrderType::<()>::Standard { quantity, .. } = refreshed {
             assert_eq!(quantity, Quantity::new(5)); // Should remain unchanged
             assert_eq!(used, 0);
         } else {
             panic!("Expected StandardOrder");
+        }
+    }
+
+    #[test]
+    fn test_match_reserve_order_min_replenish_draws_visible_tranche() {
+        // A minimal NonZeroU64 replenish (value 1) must still draw a fresh
+        // visible tranche of exactly one unit from hidden when the visible
+        // portion is fully consumed.
+        let order = OrderType::<()>::ReserveOrder {
+            id: Id::from_u64(129),
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(2),
+            hidden_quantity: Quantity::new(5),
+            side: Side::Sell,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1616823000000),
+            time_in_force: TimeInForce::Gtc,
+            replenish_threshold: Quantity::new(1),
+            replenish_amount: Some(nz(1)),
+            auto_replenish: true,
+            extra_fields: (),
+        };
+
+        // Consume the full visible portion (2). The order must replenish a
+        // tranche of size 1 from the hidden quantity.
+        let (consumed, updated, hidden_reduced, remaining) = order.match_against(2);
+        assert_eq!(consumed, 2);
+        assert_eq!(hidden_reduced, 1);
+        assert_eq!(remaining, 0);
+
+        match updated {
+            Some(OrderType::<()>::ReserveOrder {
+                visible_quantity,
+                hidden_quantity,
+                replenish_amount,
+                ..
+            }) => {
+                assert_eq!(visible_quantity, Quantity::new(1));
+                assert_eq!(hidden_quantity, Quantity::new(4));
+                assert_eq!(replenish_amount, Some(nz(1)));
+            }
+            _ => panic!("Expected replenished ReserveOrder"),
         }
     }
 
@@ -739,7 +787,7 @@ mod tests {
             extra_fields: (),
         };
 
-        let (refreshed, used) = standard_order.refresh_iceberg(5);
+        let (refreshed, used) = standard_order.refresh_iceberg(nz(5));
 
         // Non-iceberg orders should remain unchanged and return 0 used
         assert_eq!(used, 0);
@@ -795,7 +843,13 @@ mod test_order_type_display {
     use crate::orders::time_in_force::TimeInForce;
     use crate::orders::{Hash32, Id, OrderType, PegReferenceType, Side};
     use crate::utils::{Price, Quantity, TimestampMs};
+    use std::num::NonZeroU64;
     use std::str::FromStr;
+
+    /// Build a `NonZeroU64` from a non-zero test literal.
+    fn nz(value: u64) -> NonZeroU64 {
+        NonZeroU64::new(value).expect("test literal must be non-zero")
+    }
 
     #[test]
     fn test_standard_order_display() {
@@ -1021,7 +1075,7 @@ mod test_order_type_display {
             timestamp: TimestampMs::new(1616823000000),
             time_in_force: TimeInForce::Gtc,
             replenish_threshold: Quantity::new(0),
-            replenish_amount: Some(Quantity::new(1)),
+            replenish_amount: Some(nz(1)),
             auto_replenish: false,
             extra_fields: (),
         };
@@ -1049,7 +1103,13 @@ mod test_order_type_display {
 mod from_str_specific_tests {
     use crate::orders::{Hash32, Id, OrderType, PegReferenceType, Side, TimeInForce};
     use crate::utils::{Price, Quantity, TimestampMs};
+    use std::num::NonZeroU64;
     use std::str::FromStr;
+
+    /// Build a `NonZeroU64` from a non-zero test literal.
+    fn nz(value: u64) -> NonZeroU64 {
+        NonZeroU64::new(value).expect("test literal must be non-zero")
+    }
 
     #[test]
     fn test_from_str_reserve_order() {
@@ -1079,7 +1139,7 @@ mod from_str_specific_tests {
                 assert_eq!(timestamp, TimestampMs::new(1616823000000));
                 assert_eq!(time_in_force, TimeInForce::Gtc);
                 assert_eq!(replenish_threshold, Quantity::new(0));
-                assert_eq!(replenish_amount, Some(Quantity::new(1)));
+                assert_eq!(replenish_amount, Some(nz(1)));
                 assert!(!auto_replenish);
             }
             _ => panic!("Expected ReserveOrder"),
@@ -1117,7 +1177,7 @@ mod from_str_specific_tests {
             } => {
                 assert_eq!(time_in_force, TimeInForce::Gtd(1617000000000));
                 assert_eq!(replenish_threshold, Quantity::new(5));
-                assert_eq!(replenish_amount, Some(Quantity::new(2)));
+                assert_eq!(replenish_amount, Some(nz(2)));
                 assert!(auto_replenish);
             }
             _ => panic!("Expected ReserveOrder"),
@@ -1287,6 +1347,59 @@ mod from_str_specific_tests {
     }
 
     #[test]
+    fn test_from_str_reserve_order_zero_replenish_rejected() {
+        // A zero replenish amount is structurally invalid: it must be rejected
+        // with a typed `InvalidFieldValue` error rather than accepted.
+        let input = "ReserveOrder:id=00000000-0000-0081-0000-000000000000;price=10000;visible_quantity=1;hidden_quantity=4;side=SELL;timestamp=1616823000000;time_in_force=GTC;replenish_threshold=0;replenish_amount=0;auto_replenish=false";
+        let result: Result<OrderType<()>, _> = OrderType::from_str(input);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            crate::errors::PriceLevelError::InvalidFieldValue { field, value } => {
+                assert_eq!(field, "replenish_amount");
+                assert_eq!(value, "0");
+            }
+            err => panic!("Expected InvalidFieldValue error, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn test_json_reserve_order_zero_replenish_rejected() {
+        // The derived serde path rejects a zero `replenish_amount` because
+        // `NonZeroU64` cannot deserialize from `0`. The failure surfaces as a
+        // typed deserialization error, never a panic.
+        let original = OrderType::<()>::ReserveOrder {
+            id: Id::from_u64(129),
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(1),
+            hidden_quantity: Quantity::new(4),
+            side: Side::Sell,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1616823000000),
+            time_in_force: TimeInForce::Gtc,
+            replenish_threshold: Quantity::new(0),
+            replenish_amount: Some(nz(1)),
+            auto_replenish: false,
+            extra_fields: (),
+        };
+
+        // Round-trip a valid order first.
+        let json = serde_json::to_string(&original).expect("serialize");
+        let parsed: OrderType<()> = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, original);
+
+        // Now tamper the payload to set replenish_amount to 0 and confirm the
+        // deserialization is rejected.
+        let tampered = json.replace("\"replenish_amount\":1", "\"replenish_amount\":0");
+        assert!(tampered.contains("\"replenish_amount\":0"));
+        let result: Result<OrderType<()>, _> = serde_json::from_str(&tampered);
+        assert!(
+            result.is_err(),
+            "zero replenish_amount must be rejected on deserialize"
+        );
+    }
+
+    #[test]
     fn test_edge_cases() {
         // Test case-insensitivity for side
         let input = "MarketToLimit:id=00000000-0000-0080-0000-000000000000;price=10000;quantity=5;side=bUY;timestamp=1616823000000;time_in_force=GTC";
@@ -1364,7 +1477,7 @@ mod from_str_specific_tests {
                 timestamp: TimestampMs::new(1616823000000),
                 time_in_force: TimeInForce::Gtc,
                 replenish_threshold: Quantity::new(0),
-                replenish_amount: Some(Quantity::new(1)),
+                replenish_amount: Some(nz(1)),
                 auto_replenish: false,
                 extra_fields: (),
             },

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -7,6 +7,7 @@ mod tests {
     use crate::price_level::snapshot::SNAPSHOT_FORMAT_VERSION;
     use crate::utils::{Price, Quantity, TimestampMs};
     use crate::{DEFAULT_RESERVE_REPLENISH_AMOUNT, UuidGenerator};
+    use std::num::NonZeroU64;
     use std::str::FromStr;
     use std::sync::atomic::{AtomicU64, Ordering};
     use tracing::error;
@@ -368,7 +369,8 @@ mod tests {
             timestamp: TimestampMs::new(timestamp),
             time_in_force: TimeInForce::Gtc,
             replenish_threshold: Quantity::new(threshold),
-            replenish_amount: replenish_amount.map(Quantity::new),
+            replenish_amount: replenish_amount
+                .map(|amount| NonZeroU64::new(amount).expect("test replenish amount must be > 0")),
             auto_replenish,
             extra_fields: (),
         }
@@ -964,11 +966,11 @@ mod tests {
         // The order should be replenished with the default amount
         assert_eq!(
             price_level.visible_quantity(),
-            DEFAULT_RESERVE_REPLENISH_AMOUNT
+            DEFAULT_RESERVE_REPLENISH_AMOUNT.get()
         );
         assert_eq!(
             price_level.hidden_quantity(),
-            150 - DEFAULT_RESERVE_REPLENISH_AMOUNT
+            150 - DEFAULT_RESERVE_REPLENISH_AMOUNT.get()
         );
         assert_eq!(price_level.order_count(), 1);
     }

--- a/src/price_level/tests/snapshot.rs
+++ b/src/price_level/tests/snapshot.rs
@@ -465,6 +465,7 @@ mod pricelevel_snapshot_serialization_tests {
     use crate::price_level::PriceLevelSnapshot;
     use crate::utils::{Price, Quantity, TimestampMs};
 
+    use std::num::NonZeroU64;
     use std::str::FromStr;
     use std::sync::Arc;
 
@@ -847,7 +848,7 @@ mod pricelevel_snapshot_serialization_tests {
                 timestamp: TimestampMs::new(1616823000005),
                 time_in_force: TimeInForce::Gtc,
                 replenish_threshold: Quantity::new(1),
-                replenish_amount: Some(Quantity::new(2)),
+                replenish_amount: NonZeroU64::new(2),
                 auto_replenish: true,
                 extra_fields: (),
             }),


### PR DESCRIPTION
## Summary

A reserve replenish amount of `0` is structurally invalid — it would draw an
empty visible tranche from the hidden quantity, silently leaving nothing
visible. The rules name "replenish amounts" explicitly as a `NonZeroU64` site,
but the field was `Option<Quantity>` (Quantity permits 0) and the default const /
`refresh_iceberg` param were raw `u64`. This encodes the invariant in the type.

## Changes

- `ReserveOrder.replenish_amount`: `Option<Quantity>` → `Option<NonZeroU64>`
- `DEFAULT_RESERVE_REPLENISH_AMOUNT`: `u64` → `NonZeroU64` (value 80), built with
  a `const`-evaluable `match` on `NonZeroU64::new(80)` — no runtime `unwrap`, no
  `unsafe`
- `OrderType::refresh_iceberg(&self, u64)` → `refresh_iceberg(&self, NonZeroU64)`
- Replenish math converts to `u64` via `.get()` only where the arithmetic needs it
- All construction sites updated (orders/price_level tests, examples, benches)

## Technical decisions

- Constructing a zero replenish is now impossible at the type level. On the text
  (`FromStr`) path a `replenish_amount` of `0` is rejected with a typed
  `PriceLevelError::InvalidFieldValue`; on the JSON path `Option<NonZeroU64>`
  cannot deserialize `0`, yielding a deserialization error — never a panic.

## Public API impact

Breaking (pre-0.9 window): the const type, the `ReserveOrder.replenish_amount`
field type, and the `refresh_iceberg` signature changed. Reading the default as a
raw integer now needs `DEFAULT_RESERVE_REPLENISH_AMOUNT.get()`. Migration note
added to the `src/lib.rs` guide; `README.md` regenerated via `make readme`.

## Testing

- [x] `test_match_reserve_order_min_replenish_draws_visible_tranche` — minimal
      `NonZeroU64` (1) draws a fresh visible tranche
- [x] `test_from_str_reserve_order_zero_replenish_rejected` /
      `test_json_reserve_order_zero_replenish_rejected` — 0 rejected with a typed
      error, no panic
- [x] Existing iceberg/reserve replenish tests still pass
- [x] `make pre-push` clean

`cargo test`: 343 (lib) + 1 (integration) + 9 (doctests) = 353 passed, 0 failed.
`cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all
--check`, `cargo build --release`: all clean.

## Checklist

- [x] `NonZeroU64` where zero is structurally invalid (replenish amount)
- [x] No `.unwrap()`/`.expect()` in production (const built via `match`, no `unsafe`)
- [x] Hand-rolled `PriceLevelError`; serde rejects 0 with a typed error
- [x] No new dependencies; `tracing` only; module boundaries respected
- [x] `src/lib.rs` migration guide + `README.md` (via `make readme`) updated

Closes #70
