### PR TITLE
Inline/cold attribute policy, iter_orders bench, bump sha2 to 0.11 (#73)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,4 +71,4 @@ crossbeam-skiplist = "0.1"
 uuid = { version = "1.23", features = ["v4", "v5", "serde"] }
 ulid = { version = "1.2", features = ["serde"] }
 dashmap = "6.1"
-sha2 = "0.10"
+sha2 = "0.11"

--- a/benches/price_level/iter_orders.rs
+++ b/benches/price_level/iter_orders.rs
@@ -1,0 +1,69 @@
+use criterion::{BenchmarkId, Criterion};
+use pricelevel::{
+    Hash32, Id, OrderType, Price, PriceLevel, Quantity, Side, TimeInForce, TimestampMs,
+};
+use std::hint::black_box;
+
+/// Register benchmarks for the zero-alloc `iter_orders` read path.
+///
+/// `iter_orders` returns an `impl Iterator` over the resting orders without
+/// materializing an intermediate `Vec`. These benchmarks populate a level with
+/// `N` resting orders and traverse it via `iter_orders()`, so a future
+/// regression that re-introduces materialization (an allocating `Vec` return)
+/// is caught by a throughput drop.
+pub fn register_benchmarks(c: &mut Criterion) {
+    let mut group = c.benchmark_group("PriceLevel - Iter Orders");
+
+    // Traverse the iterator, touching each order's quantity so the loop body is
+    // not optimized away.
+    for order_count in [10, 100, 1000].iter() {
+        group.bench_with_input(
+            BenchmarkId::new("iter_orders_sum_visible", order_count),
+            order_count,
+            |b, &order_count| {
+                let price_level = setup_level(order_count);
+                b.iter(|| {
+                    let mut total: u64 = 0;
+                    for order in price_level.iter_orders() {
+                        total = total.wrapping_add(black_box(order.visible_quantity()));
+                    }
+                    black_box(total)
+                })
+            },
+        );
+    }
+
+    // Pure traversal: count the resting orders via the iterator without
+    // materializing a Vec.
+    for order_count in [10, 100, 1000].iter() {
+        group.bench_with_input(
+            BenchmarkId::new("iter_orders_count", order_count),
+            order_count,
+            |b, &order_count| {
+                let price_level = setup_level(order_count);
+                b.iter(|| black_box(price_level.iter_orders().count()))
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Populate a price level with `order_count` resting standard orders.
+fn setup_level(order_count: u64) -> PriceLevel {
+    let price_level = PriceLevel::new(10000);
+    for i in 0..order_count {
+        let order = OrderType::Standard {
+            id: Id::from_u64(i),
+            price: Price::new(10000),
+            quantity: Quantity::new(100),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_616_823_000_000 + i),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        };
+        price_level.add_order(order);
+    }
+    price_level
+}

--- a/benches/price_level/mod.rs
+++ b/benches/price_level/mod.rs
@@ -1,6 +1,7 @@
 // benches/price_level/mod.rs
 pub mod add_orders;
 pub mod checked_arithmetic;
+pub mod iter_orders;
 pub mod lifecycle;
 pub mod match_orders;
 pub mod mixed_operations;
@@ -13,6 +14,7 @@ pub mod update_orders;
 // Import common benchmarks into the main bench group
 pub fn register_benchmarks(c: &mut criterion::Criterion) {
     add_orders::register_benchmarks(c);
+    iter_orders::register_benchmarks(c);
     match_orders::register_benchmarks(c);
     update_orders::register_benchmarks(c);
     mixed_operations::register_benchmarks(c);

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -84,6 +84,10 @@ pub enum PriceLevelError {
     },
 }
 impl Display for PriceLevelError {
+    // Error formatting is off the hot match path: keep it out of line and hint
+    // the optimizer that it is rarely reached.
+    #[cold]
+    #[inline(never)]
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             PriceLevelError::ParseError { message } => write!(f, "{message}"),
@@ -112,6 +116,10 @@ impl Display for PriceLevelError {
 }
 
 impl Debug for PriceLevelError {
+    // Error formatting is off the hot match path: keep it out of line and hint
+    // the optimizer that it is rarely reached.
+    #[cold]
+    #[inline(never)]
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             PriceLevelError::ParseError { message } => write!(f, "{message}"),

--- a/src/orders/order_type.rs
+++ b/src/orders/order_type.rs
@@ -205,6 +205,7 @@ pub enum OrderType<T> {
 impl<T: Clone> OrderType<T> {
     /// Get the order ID
     #[must_use]
+    #[inline]
     pub fn id(&self) -> Id {
         match self {
             Self::Standard { id, .. } => *id,
@@ -233,6 +234,7 @@ impl<T: Clone> OrderType<T> {
 
     /// Get the price
     #[must_use]
+    #[inline]
     pub fn price(&self) -> Price {
         match self {
             Self::Standard { price, .. } => *price,
@@ -247,6 +249,7 @@ impl<T: Clone> OrderType<T> {
 
     /// Get the visible quantity
     #[must_use]
+    #[inline]
     pub fn visible_quantity(&self) -> u64 {
         match self {
             Self::Standard { quantity, .. } => quantity.as_u64(),
@@ -265,6 +268,7 @@ impl<T: Clone> OrderType<T> {
 
     /// Get the hidden quantity
     #[must_use]
+    #[inline]
     pub fn hidden_quantity(&self) -> u64 {
         match self {
             Self::IcebergOrder {
@@ -279,6 +283,7 @@ impl<T: Clone> OrderType<T> {
 
     /// Get the order side
     #[must_use]
+    #[inline]
     pub fn side(&self) -> Side {
         match self {
             Self::Standard { side, .. } => *side,
@@ -307,6 +312,7 @@ impl<T: Clone> OrderType<T> {
 
     /// Get the timestamp
     #[must_use]
+    #[inline]
     pub fn timestamp(&self) -> u64 {
         match self {
             Self::Standard { timestamp, .. } => timestamp.as_u64(),

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -93,6 +93,7 @@ impl OrderQueue {
 
     /// Search for an order with the given ID. O(1) operation.
     #[must_use]
+    #[inline]
     pub fn find(&self, order_id: Id) -> Option<Arc<OrderType<()>>> {
         self.orders.get(&order_id).map(|o| o.value().1.clone())
     }
@@ -190,6 +191,7 @@ impl OrderQueue {
     /// Check if the queue is empty
     #[allow(dead_code)]
     #[must_use]
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.orders.is_empty()
     }
@@ -201,6 +203,7 @@ impl OrderQueue {
     /// * `usize` - The total count of orders in the queue.
     ///
     #[must_use]
+    #[inline]
     pub fn len(&self) -> usize {
         self.orders.len()
     }

--- a/src/price_level/snapshot.rs
+++ b/src/price_level/snapshot.rs
@@ -291,6 +291,8 @@ impl PriceLevelSnapshotPackage {
     }
 
     /// Validates the checksum contained in the package against the serialized snapshot data.
+    // Snapshot restoration / validation is a cold path: keep it out of line.
+    #[inline(never)]
     pub fn validate(&self) -> Result<(), PriceLevelError> {
         if self.version != SNAPSHOT_FORMAT_VERSION {
             return Err(PriceLevelError::InvalidOperation {
@@ -318,7 +320,10 @@ impl PriceLevelSnapshotPackage {
         Ok(self.snapshot)
     }
 
+    #[inline(never)]
     fn compute_checksum(snapshot: &PriceLevelSnapshot) -> Result<String, PriceLevelError> {
+        use std::fmt::Write as _;
+
         let payload =
             serde_json::to_vec(snapshot).map_err(|error| PriceLevelError::SerializationError {
                 message: error.to_string(),
@@ -327,12 +332,27 @@ impl PriceLevelSnapshotPackage {
         let mut hasher = Sha256::new();
         hasher.update(payload);
 
+        // `digest` 0.11 returns the digest as a `hybrid_array::Array`, which —
+        // unlike the `generic_array::GenericArray` from 0.10 — does not
+        // implement `LowerHex`. Encode the raw SHA-256 bytes to lowercase hex
+        // by hand. The bytes are defined by the algorithm and are unchanged, so
+        // the produced checksum string is byte-identical to the 0.10 output.
         let checksum_bytes = hasher.finalize();
-        Ok(format!("{:x}", checksum_bytes))
+        let mut checksum = String::with_capacity(checksum_bytes.len() * 2);
+        for byte in checksum_bytes {
+            // Writing to a `String` is infallible; `{byte:02x}` is the same
+            // lowercase, zero-padded, two-hex-digits-per-byte encoding the
+            // previous `format!("{:x}", checksum_bytes)` produced.
+            let _ = write!(checksum, "{byte:02x}");
+        }
+        Ok(checksum)
     }
 }
 
 impl Serialize for PriceLevelSnapshot {
+    // Snapshot serialization is a cold path (taken/restored, not per-match):
+    // keep it out of line.
+    #[inline(never)]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -360,6 +380,9 @@ impl Serialize for PriceLevelSnapshot {
 }
 
 impl<'de> Deserialize<'de> for PriceLevelSnapshot {
+    // Snapshot restoration is a cold path (taken/restored, not per-match):
+    // keep it out of line.
+    #[inline(never)]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,


### PR DESCRIPTION
## Summary

Applies the crate's compiler-attribute policy to the hot and cold paths, adds a
Criterion bench guarding the zero-alloc `iter_orders` read path, and bumps `sha2`
0.10 → 0.11 (requested).

## Changes

- **`#[inline]`** on the per-fill leaf accessors (`OrderType::id` / `price` /
  `visible_quantity` / `hidden_quantity` / `side` / `timestamp`) and
  `OrderQueue::find` / `is_empty` / `len`.
- **`#[cold]` + `#[inline(never)]`** on `PriceLevelError`'s `Display`/`Debug`
  `fmt`; **`#[inline(never)]`** on the cold snapshot paths (`compute_checksum`,
  `Serialize`/`Deserialize` for `PriceLevelSnapshot`, and `validate`).
- New bench `benches/price_level/iter_orders.rs` (wired into `mod.rs`) iterating
  a populated level via `iter_orders()`, so a future regression to a
  materializing `Vec` shows up as a step change. Indicative: sum_visible 10 →
  ~1.0µs, 100 → ~1.4µs, 1000 → ~6.5µs (≈ linear in N).
- **`sha2` 0.10 → 0.11.** `digest` 0.11's `finalize()` returns a
  `hybrid_array::Array` (no `LowerHex`), so `compute_checksum` now hex-encodes
  the digest bytes explicitly (`{:02x}` per byte).

## Technical decisions

- The new hex encoding is byte-for-byte identical to the old `format!("{:x}",
  ..)` (same lowercase, zero-padded, two-digits-per-byte over the same SHA-256
  output), so **embedded checksums stay valid**: the round-trip and tampered-
  checksum (`ChecksumMismatch`) tests pass unchanged.

## Testing

- [x] Checksum round-trip + tamper tests pass unchanged (proves hash bytes
      identical after the sha2 bump)
- [x] New `iter_orders` bench runs
- [x] `make pre-push` clean

`cargo test`: 343 (lib) + 1 (integration) + 9 (doctests) = 353 passed, 0 failed.
`cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all
--check`, `cargo build --release`: all clean.

## Checklist

- [x] `#[inline]` on small hot helpers; `#[cold]`/`#[inline(never)]` on error/snapshot paths
- [x] `iter_orders` stays a zero-alloc `impl Iterator`; bench added
- [x] `sha2` bumped (existing approved dep, user-requested); SHA-256 bytes unchanged
- [x] No new dependencies beyond the sha2 minor bump; no `unsafe`; no production `.unwrap()`
- [x] Snapshot wire format + checksum bytes unchanged

Closes #73
