### PR TITLE
Add # Errors to the fallible surface; enforce missing-docs in CI (#74)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Lint
         run: make lint
+
+      - name: Doc lint (missing-docs)
+        run: make doc

--- a/src/execution/match_result.rs
+++ b/src/execution/match_result.rs
@@ -61,6 +61,12 @@ impl MatchResult {
     }
 
     /// Add a trade to this match result.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if the trade's quantity
+    /// exceeds the remaining quantity of the incoming order (the subtraction
+    /// would underflow), which indicates an over-fill bug in the caller.
     pub fn add_trade(&mut self, trade: Trade) -> Result<(), PriceLevelError> {
         self.remaining_quantity = self
             .remaining_quantity
@@ -121,6 +127,11 @@ impl MatchResult {
     }
 
     /// Get the total executed quantity
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if summing the trade
+    /// quantities overflows `u64`.
     pub fn executed_quantity(&self) -> Result<u64, PriceLevelError> {
         self.trades.as_vec().iter().try_fold(0u64, |acc, trade| {
             acc.checked_add(trade.quantity().as_u64()).ok_or_else(|| {
@@ -132,6 +143,12 @@ impl MatchResult {
     }
 
     /// Get the total value executed
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if any per-trade
+    /// `price * quantity` product overflows `u128`, or if accumulating those
+    /// products overflows `u128`.
     pub fn executed_value(&self) -> Result<u128, PriceLevelError> {
         self.trades.as_vec().iter().try_fold(0u128, |acc, trade| {
             let trade_value = trade
@@ -150,6 +167,15 @@ impl MatchResult {
     }
 
     /// Calculate the average execution price
+    ///
+    /// Returns `Ok(None)` when no quantity has been executed (no average price
+    /// exists), avoiding a division by zero.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if the underlying
+    /// [`Self::executed_quantity`] or [`Self::executed_value`] computation
+    /// overflows.
     pub fn average_price(&self) -> Result<Option<f64>, PriceLevelError> {
         let executed_qty = self.executed_quantity()?;
         if executed_qty == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(unknown_lints)]
 #![allow(clippy::literal_string_with_formatting_args)]
+#![warn(clippy::missing_errors_doc)]
 
 //!  # PriceLevel
 //!

--- a/src/price_level/entry.rs
+++ b/src/price_level/entry.rs
@@ -36,6 +36,11 @@ impl OrderBookEntry {
     }
 
     /// Get the total quantity at this entry
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if the underlying level's
+    /// `visible + hidden` quantity overflows `u64`.
     pub fn total_quantity(&self) -> Result<u64, PriceLevelError> {
         self.level.total_quantity()
     }

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -76,8 +76,10 @@ impl PriceLevel {
     ///
     /// Returns [`PriceLevelError::ChecksumMismatch`] if the package's embedded
     /// SHA-256 checksum does not match its payload (tampered or corrupted
-    /// snapshot), [`PriceLevelError::InvalidOperation`] if the package carries
-    /// an unsupported snapshot format version, and propagates any
+    /// snapshot), [`PriceLevelError::SerializationError`] if re-encoding the
+    /// payload to recompute that checksum fails,
+    /// [`PriceLevelError::InvalidOperation`] if the package carries an
+    /// unsupported snapshot format version, and propagates any
     /// [`PriceLevelError`] from rebuilding the level out of the validated
     /// snapshot.
     pub fn from_snapshot_package(
@@ -93,9 +95,10 @@ impl PriceLevel {
     ///
     /// Returns [`PriceLevelError::DeserializationError`] if `data` is not a
     /// valid snapshot-package JSON document, [`PriceLevelError::ChecksumMismatch`]
-    /// if the decoded package's SHA-256 checksum does not match its payload, and
-    /// [`PriceLevelError::InvalidOperation`] on an unsupported snapshot format
-    /// version.
+    /// if the decoded package's SHA-256 checksum does not match its payload,
+    /// [`PriceLevelError::SerializationError`] if re-encoding the payload to
+    /// recompute that checksum fails, and [`PriceLevelError::InvalidOperation`]
+    /// on an unsupported snapshot format version.
     pub fn from_snapshot_json(data: &str) -> Result<Self, PriceLevelError> {
         let package = PriceLevelSnapshotPackage::from_json(data)?;
         Self::from_snapshot_package(package)
@@ -465,7 +468,8 @@ impl PriceLevel {
     ///
     /// Returns [`PriceLevelError::InvalidOperation`] if computing the snapshot's
     /// aggregate quantities overflows while building the package's checksummed
-    /// payload.
+    /// payload, or [`PriceLevelError::SerializationError`] if encoding the
+    /// snapshot payload to compute its SHA-256 checksum fails.
     pub fn snapshot_package(&self) -> Result<PriceLevelSnapshotPackage, PriceLevelError> {
         PriceLevelSnapshotPackage::new(self.snapshot())
     }

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -71,6 +71,15 @@ impl PriceLevel {
     }
 
     /// Reconstructs a price level from a checksum-protected snapshot package.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::ChecksumMismatch`] if the package's embedded
+    /// SHA-256 checksum does not match its payload (tampered or corrupted
+    /// snapshot), [`PriceLevelError::InvalidOperation`] if the package carries
+    /// an unsupported snapshot format version, and propagates any
+    /// [`PriceLevelError`] from rebuilding the level out of the validated
+    /// snapshot.
     pub fn from_snapshot_package(
         package: PriceLevelSnapshotPackage,
     ) -> Result<Self, PriceLevelError> {
@@ -79,6 +88,14 @@ impl PriceLevel {
     }
 
     /// Restores a price level from its snapshot JSON representation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::DeserializationError`] if `data` is not a
+    /// valid snapshot-package JSON document, [`PriceLevelError::ChecksumMismatch`]
+    /// if the decoded package's SHA-256 checksum does not match its payload, and
+    /// [`PriceLevelError::InvalidOperation`] on an unsupported snapshot format
+    /// version.
     pub fn from_snapshot_json(data: &str) -> Result<Self, PriceLevelError> {
         let package = PriceLevelSnapshotPackage::from_json(data)?;
         Self::from_snapshot_package(package)
@@ -145,6 +162,11 @@ impl PriceLevel {
     /// Advisory / eventually-consistent under concurrent mutation (sums two
     /// independent atomic counters) — see [`Self::visible_quantity`]; use
     /// [`Self::snapshot`] for a consistent view.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if `visible + hidden`
+    /// overflows `u64`.
     pub fn total_quantity(&self) -> Result<u64, PriceLevelError> {
         self.visible_quantity()
             .checked_add(self.hidden_quantity())
@@ -438,11 +460,24 @@ impl PriceLevel {
     }
 
     /// Serialize the current price level state into a checksum-protected snapshot package.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if computing the snapshot's
+    /// aggregate quantities overflows while building the package's checksummed
+    /// payload.
     pub fn snapshot_package(&self) -> Result<PriceLevelSnapshotPackage, PriceLevelError> {
         PriceLevelSnapshotPackage::new(self.snapshot())
     }
 
     /// Serialize the current price level state to JSON, including checksum metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if building the snapshot
+    /// package overflows an aggregate quantity, or
+    /// [`PriceLevelError::SerializationError`] if the package cannot be encoded
+    /// to JSON.
     pub fn snapshot_to_json(&self) -> Result<String, PriceLevelError> {
         self.snapshot_package()?.to_json()
     }

--- a/src/price_level/snapshot.rs
+++ b/src/price_level/snapshot.rs
@@ -180,6 +180,11 @@ impl PriceLevelSnapshot {
     }
 
     /// Get the total quantity (visible + hidden) at this price level.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if `visible + hidden`
+    /// overflows `u64`.
     pub fn total_quantity(&self) -> Result<u64, PriceLevelError> {
         self.visible_quantity
             .checked_add(self.hidden_quantity)
@@ -194,6 +199,11 @@ impl PriceLevelSnapshot {
     }
 
     /// Recomputes aggregate fields (`visible_quantity`, `hidden_quantity`, and `order_count`) based on current orders.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if summing the per-order
+    /// visible or hidden quantities overflows `u64`.
     pub fn refresh_aggregates(&mut self) -> Result<(), PriceLevelError> {
         self.order_count = self.orders.len();
 
@@ -264,6 +274,13 @@ impl PriceLevelSnapshotPackage {
 
 impl PriceLevelSnapshotPackage {
     /// Creates a new snapshot package computing the checksum for the provided snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if refreshing the snapshot
+    /// aggregates overflows a quantity, or [`PriceLevelError::SerializationError`]
+    /// if the snapshot payload cannot be encoded while computing its SHA-256
+    /// checksum.
     pub fn new(mut snapshot: PriceLevelSnapshot) -> Result<Self, PriceLevelError> {
         snapshot.refresh_aggregates()?;
 
@@ -277,6 +294,11 @@ impl PriceLevelSnapshotPackage {
     }
 
     /// Serializes the package to JSON.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::SerializationError`] if the package cannot be
+    /// encoded to a JSON string.
     pub fn to_json(&self) -> Result<String, PriceLevelError> {
         serde_json::to_string(self).map_err(|error| PriceLevelError::SerializationError {
             message: error.to_string(),
@@ -284,6 +306,13 @@ impl PriceLevelSnapshotPackage {
     }
 
     /// Deserializes a package from JSON.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::DeserializationError`] if `data` is not a
+    /// valid JSON representation of a snapshot package. The returned package is
+    /// not yet checksum-validated; call [`Self::validate`] or
+    /// [`Self::into_snapshot`] to verify integrity.
     pub fn from_json(data: &str) -> Result<Self, PriceLevelError> {
         serde_json::from_str(data).map_err(|error| PriceLevelError::DeserializationError {
             message: error.to_string(),
@@ -291,6 +320,14 @@ impl PriceLevelSnapshotPackage {
     }
 
     /// Validates the checksum contained in the package against the serialized snapshot data.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if the package's format
+    /// version is not [`SNAPSHOT_FORMAT_VERSION`], [`PriceLevelError::SerializationError`]
+    /// if the snapshot payload cannot be re-encoded to recompute the checksum,
+    /// and [`PriceLevelError::ChecksumMismatch`] if the recomputed SHA-256
+    /// checksum does not match the stored one (tampered or corrupted snapshot).
     // Snapshot restoration / validation is a cold path: keep it out of line.
     #[inline(never)]
     pub fn validate(&self) -> Result<(), PriceLevelError> {
@@ -315,6 +352,14 @@ impl PriceLevelSnapshotPackage {
     }
 
     /// Consumes the package after validating the checksum and returns the contained snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`Self::validate`]:
+    /// [`PriceLevelError::InvalidOperation`] on an unsupported format version,
+    /// [`PriceLevelError::SerializationError`] if the payload cannot be
+    /// re-encoded, and [`PriceLevelError::ChecksumMismatch`] if the stored
+    /// checksum does not match the recomputed one.
     pub fn into_snapshot(self) -> Result<PriceLevelSnapshot, PriceLevelError> {
         self.validate()?;
         Ok(self.snapshot)

--- a/src/utils/value.rs
+++ b/src/utils/value.rs
@@ -276,11 +276,11 @@ mod tests {
         // silently clamping to u128::MAX / u64::MAX.
         assert!(matches!(
             Price::from_f64(2.0_f64.powi(128)),
-            Err(PriceLevelError::InvalidOperation { .. })
+            Err(crate::errors::PriceLevelError::InvalidOperation { .. })
         ));
         assert!(matches!(
             Quantity::from_f64(2.0_f64.powi(64)),
-            Err(PriceLevelError::InvalidOperation { .. })
+            Err(crate::errors::PriceLevelError::InvalidOperation { .. })
         ));
         // Just-in-range values still convert.
         assert!(Price::from_f64(1_000_000.0).is_ok());

--- a/src/utils/value.rs
+++ b/src/utils/value.rs
@@ -32,12 +32,15 @@ impl Price {
         Ok(Self(value))
     }
 
-    /// Creates a price from an `f64` value.
+    /// Creates a price from an `f64` value (rounded to the nearest integer).
     ///
     /// # Errors
     ///
     /// Returns [`PriceLevelError::InvalidOperation`] if `value` is not finite
-    /// (NaN or infinite) or is negative.
+    /// (NaN or infinite), is negative, or (after rounding) does not fit in a
+    /// `u128`. The range check is explicit because an `f64`-to-`u128` `as` cast
+    /// saturates rather than failing, which would silently clamp out-of-range
+    /// input to `u128::MAX`.
     pub fn from_f64(value: f64) -> Result<Self, PriceLevelError> {
         if !value.is_finite() || value < 0.0 {
             return Err(PriceLevelError::InvalidOperation {
@@ -45,7 +48,15 @@ impl Price {
             });
         }
 
-        Ok(Self(value.round() as u128))
+        let rounded = value.round();
+        // A finite, non-negative f64 fits in u128 iff it is strictly below 2^128.
+        if rounded >= 2.0_f64.powi(128) {
+            return Err(PriceLevelError::InvalidOperation {
+                message: format!("price from f64 out of u128 range: {value}"),
+            });
+        }
+
+        Ok(Self(rounded as u128))
     }
 
     /// Converts the price to `f64` with potential precision loss.
@@ -109,12 +120,15 @@ impl Quantity {
         Ok(Self(value))
     }
 
-    /// Creates a quantity from an `f64` value.
+    /// Creates a quantity from an `f64` value (rounded to the nearest integer).
     ///
     /// # Errors
     ///
     /// Returns [`PriceLevelError::InvalidOperation`] if `value` is not finite
-    /// (NaN or infinite) or is negative.
+    /// (NaN or infinite), is negative, or (after rounding) does not fit in a
+    /// `u64`. The range check is explicit because an `f64`-to-`u64` `as` cast
+    /// saturates rather than failing, which would silently clamp out-of-range
+    /// input to `u64::MAX`.
     pub fn from_f64(value: f64) -> Result<Self, PriceLevelError> {
         if !value.is_finite() || value < 0.0 {
             return Err(PriceLevelError::InvalidOperation {
@@ -122,7 +136,15 @@ impl Quantity {
             });
         }
 
-        Ok(Self(value.round() as u64))
+        let rounded = value.round();
+        // A finite, non-negative f64 fits in u64 iff it is strictly below 2^64.
+        if rounded >= 2.0_f64.powi(64) {
+            return Err(PriceLevelError::InvalidOperation {
+                message: format!("quantity from f64 out of u64 range: {value}"),
+            });
+        }
+
+        Ok(Self(rounded as u64))
     }
 
     /// Converts the quantity to `f64` with potential precision loss.
@@ -246,5 +268,29 @@ mod tests {
     fn from_f64_rejects_negative() {
         assert!(Price::from_f64(-1.0).is_err());
         assert!(Quantity::from_f64(-1.0).is_err());
+    }
+
+    #[test]
+    fn from_f64_rejects_out_of_range() {
+        // f64 -> int `as` casts saturate; from_f64 must reject instead of
+        // silently clamping to u128::MAX / u64::MAX.
+        assert!(matches!(
+            Price::from_f64(2.0_f64.powi(128)),
+            Err(PriceLevelError::InvalidOperation { .. })
+        ));
+        assert!(matches!(
+            Quantity::from_f64(2.0_f64.powi(64)),
+            Err(PriceLevelError::InvalidOperation { .. })
+        ));
+        // Just-in-range values still convert.
+        assert!(Price::from_f64(1_000_000.0).is_ok());
+        assert!(Quantity::from_f64(1_000_000.0).is_ok());
+    }
+
+    #[test]
+    fn from_f64_rejects_non_finite() {
+        assert!(Price::from_f64(f64::NAN).is_err());
+        assert!(Price::from_f64(f64::INFINITY).is_err());
+        assert!(Quantity::from_f64(f64::NAN).is_err());
     }
 }

--- a/src/utils/value.rs
+++ b/src/utils/value.rs
@@ -21,11 +21,23 @@ impl Price {
     }
 
     /// Creates a validated price from a raw integer value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidFieldValue`] if `value` ever fails the
+    /// price invariant. Every `u128` is currently a valid price, so this
+    /// constructor is presently infallible; the `Result` is part of its stable
+    /// contract so validation can be tightened without a breaking change.
     pub fn try_new(value: u128) -> Result<Self, PriceLevelError> {
         Ok(Self(value))
     }
 
     /// Creates a price from an `f64` value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if `value` is not finite
+    /// (NaN or infinite) or is negative.
     pub fn from_f64(value: f64) -> Result<Self, PriceLevelError> {
         if !value.is_finite() || value < 0.0 {
             return Err(PriceLevelError::InvalidOperation {
@@ -86,11 +98,23 @@ impl Quantity {
     }
 
     /// Creates a validated quantity from a raw integer value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidFieldValue`] if `value` ever fails the
+    /// quantity invariant. Every `u64` is currently a valid quantity, so this
+    /// constructor is presently infallible; the `Result` is part of its stable
+    /// contract so validation can be tightened without a breaking change.
     pub fn try_new(value: u64) -> Result<Self, PriceLevelError> {
         Ok(Self(value))
     }
 
     /// Creates a quantity from an `f64` value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if `value` is not finite
+    /// (NaN or infinite) or is negative.
     pub fn from_f64(value: f64) -> Result<Self, PriceLevelError> {
         if !value.is_finite() || value < 0.0 {
             return Err(PriceLevelError::InvalidOperation {
@@ -151,6 +175,14 @@ impl TimestampMs {
     }
 
     /// Creates a validated timestamp from milliseconds.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidFieldValue`] if `value` ever fails the
+    /// timestamp invariant. Every `u64` is currently a valid millisecond
+    /// timestamp, so this constructor is presently infallible; the `Result` is
+    /// part of its stable contract so validation can be tightened without a
+    /// breaking change.
     pub fn try_new(value: u64) -> Result<Self, PriceLevelError> {
         Ok(Self(value))
     }


### PR DESCRIPTION
## Summary

Only ~2 of the crate's fallible `pub fn`s carried a `# Errors` section, and the
gap was invisible to CI (`make doc` / missing-docs was never run there — only
`make lint`). This documents the fallible surface and enforces it going forward.

## Changes

- Added `#![warn(clippy::missing_errors_doc)]` to `src/lib.rs`. Combined with
  CI's `cargo clippy ... -D warnings`, any public `Result`-returning fn without a
  `# Errors` section is now a hard failure — fixing the gap now and preventing
  regression.
- Fixed the 21 flagged violations (+1 in `entry.rs`) by adding accurate
  `# Errors` sections naming the actual `PriceLevelError` variant(s) and
  condition, across `level.rs`, `snapshot.rs`, `value.rs`, `match_result.rs`,
  `entry.rs`.
- Added a `make doc` (`cargo clippy -- -W missing-docs`) step to
  `.github/workflows/lint.yml` so item-level missing `///` is caught in CI too.

## Technical decisions

- **No `#[must_use]` added to `Result`-returning fns** — that trips
  `clippy::double_must_use` under `-D warnings`. Every pure non-`Result`
  accessor/constructor already carries `#[must_use]`, so none was needed.
- The three `try_new` constructors are structurally infallible today but keep a
  `Result` contract; documented the `InvalidFieldValue` contract rather than
  suppressing the lint.

## Testing

- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean (incl. the
      new `missing_errors_doc`)
- [x] `make doc` clean
- [x] `make pre-push` clean

`cargo test`: 353 passed, 0 failed. `cargo fmt --all --check`, `cargo build
--release`: clean. `README.md` unchanged (edits touch fn-body docs, not the
`//!` module docs that feed the README).

## Checklist

- [x] `# Errors` on every public `Result`-returning fn (enforced by lint)
- [x] CI now runs `make doc` (missing-docs) in addition to `make lint`
- [x] No `#[must_use]` on `Result` fns (no `double_must_use`); non-Result accessors already covered
- [x] Docs/attrs/CI only — no behavioral change; no new deps; existing allows preserved

Closes #74
