### PR TITLE
Serde cleanup: drop redundant aliases; deny_unknown_fields on PriceLevelData (#75)

### DIFF
--- a/src/orders/base.rs
+++ b/src/orders/base.rs
@@ -11,11 +11,11 @@ use std::str::FromStr;
 pub enum Side {
     /// Buy side (bids)
     #[serde(rename(serialize = "BUY"))]
-    #[serde(alias = "buy", alias = "Buy", alias = "BUY")]
+    #[serde(alias = "buy", alias = "BUY")]
     Buy,
     /// Sell side (asks)
     #[serde(rename(serialize = "SELL"))]
-    #[serde(alias = "sell", alias = "Sell", alias = "SELL")]
+    #[serde(alias = "sell", alias = "SELL")]
     Sell,
 }
 

--- a/src/orders/tests/base.rs
+++ b/src/orders/tests/base.rs
@@ -86,4 +86,33 @@ mod tests_side {
         assert_eq!(serde_json::to_string(&Side::Buy).unwrap().len(), 5); // "BUY"
         assert_eq!(serde_json::to_string(&Side::Sell).unwrap().len(), 6); // "SELL"
     }
+
+    // After dropping the redundant `alias = "Buy"` / `alias = "Sell"` (the
+    // variant names serde already accepts on deserialize by default), the
+    // serialize form ("BUY"/"SELL", kept as an alias), the lowercase form
+    // (kept as an alias), and the bare variant name must all still deserialize.
+    #[test]
+    fn test_deserialize_all_accepted_forms_after_alias_cleanup() {
+        for s in ["\"BUY\"", "\"buy\"", "\"Buy\""] {
+            assert_eq!(
+                serde_json::from_str::<Side>(s).unwrap(),
+                Side::Buy,
+                "Side::Buy should deserialize from {s}"
+            );
+        }
+        for s in ["\"SELL\"", "\"sell\"", "\"Sell\""] {
+            assert_eq!(
+                serde_json::from_str::<Side>(s).unwrap(),
+                Side::Sell,
+                "Side::Sell should deserialize from {s}"
+            );
+        }
+
+        // Wire format proof: serialize emits the uppercase form and it
+        // round-trips back via the kept uppercase alias.
+        for side in [Side::Buy, Side::Sell] {
+            let wire = serde_json::to_string(&side).unwrap();
+            assert_eq!(serde_json::from_str::<Side>(&wire).unwrap(), side);
+        }
+    }
 }

--- a/src/orders/tests/time_in_force.rs
+++ b/src/orders/tests/time_in_force.rs
@@ -330,4 +330,51 @@ mod tests {
         let time_in_force = TimeInForce::Day;
         assert_eq!(time_in_force.to_string(), "DAY");
     }
+
+    // After dropping the redundant `alias = "Gtc"` / `"Ioc"` / `"Fok"` / `"Gtd"`
+    // / `"Day"` (the variant names serde accepts on deserialize by default),
+    // the uppercase serialize form (kept as an alias), the lowercase form
+    // (kept as an alias), and the bare variant name must all still deserialize,
+    // and every variant must round-trip through its serialized wire form.
+    #[test]
+    fn test_deserialize_all_accepted_forms_after_alias_cleanup() {
+        let unit_cases = [
+            (["\"GTC\"", "\"gtc\"", "\"Gtc\""], TimeInForce::Gtc),
+            (["\"IOC\"", "\"ioc\"", "\"Ioc\""], TimeInForce::Ioc),
+            (["\"FOK\"", "\"fok\"", "\"Fok\""], TimeInForce::Fok),
+            (["\"DAY\"", "\"day\"", "\"Day\""], TimeInForce::Day),
+        ];
+        for (forms, expected) in unit_cases {
+            for s in forms {
+                assert_eq!(
+                    serde_json::from_str::<TimeInForce>(s).unwrap(),
+                    expected,
+                    "{expected:?} should deserialize from {s}"
+                );
+            }
+        }
+
+        // Gtd carries a payload; the uppercase, lowercase, and variant-name
+        // keys must all still deserialize.
+        for s in ["{\"GTD\":12345}", "{\"gtd\":12345}", "{\"Gtd\":12345}"] {
+            assert_eq!(
+                serde_json::from_str::<TimeInForce>(s).unwrap(),
+                TimeInForce::Gtd(12345),
+                "Gtd should deserialize from {s}"
+            );
+        }
+
+        // Wire format proof: every variant round-trips through its serialized
+        // form via the kept uppercase alias.
+        for tif in [
+            TimeInForce::Gtc,
+            TimeInForce::Ioc,
+            TimeInForce::Fok,
+            TimeInForce::Gtd(12345),
+            TimeInForce::Day,
+        ] {
+            let wire = serde_json::to_string(&tif).unwrap();
+            assert_eq!(serde_json::from_str::<TimeInForce>(&wire).unwrap(), tif);
+        }
+    }
 }

--- a/src/orders/time_in_force.rs
+++ b/src/orders/time_in_force.rs
@@ -9,29 +9,29 @@ use std::str::FromStr;
 pub enum TimeInForce {
     /// Good 'Til Canceled - The order remains active until it is filled or canceled.
     #[serde(rename(serialize = "GTC"))]
-    #[serde(alias = "gtc", alias = "Gtc", alias = "GTC")]
+    #[serde(alias = "gtc", alias = "GTC")]
     Gtc,
 
     /// Immediate Or Cancel - The order must be filled immediately in its entirety.
     /// If the order cannot be filled completely, the unfilled portion is canceled.
     #[serde(rename(serialize = "IOC"))]
-    #[serde(alias = "ioc", alias = "Ioc", alias = "IOC")]
+    #[serde(alias = "ioc", alias = "IOC")]
     Ioc,
 
     /// Fill Or Kill - The order must be filled immediately and completely.
     /// If the order cannot be filled entirely, the entire order is canceled.
     #[serde(rename(serialize = "FOK"))]
-    #[serde(alias = "fok", alias = "Fok", alias = "FOK")]
+    #[serde(alias = "fok", alias = "FOK")]
     Fok,
 
     /// Good 'Til Date - The order remains active until a specified date and time, expressed as a Unix timestamp (seconds since epoch).
     #[serde(rename(serialize = "GTD"))]
-    #[serde(alias = "gtd", alias = "Gtd", alias = "GTD")]
+    #[serde(alias = "gtd", alias = "GTD")]
     Gtd(u64),
 
     /// Good for the trading Day - The order remains active until the end of the current trading day.
     #[serde(rename(serialize = "DAY"))]
-    #[serde(alias = "day", alias = "Day", alias = "DAY")]
+    #[serde(alias = "day", alias = "DAY")]
     Day,
 }
 

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -748,6 +748,7 @@ impl PriceLevel {
 
 /// Serializable representation of a price level for easier data transfer and storage
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PriceLevelData {
     /// The price of this level
     pub price: u128,

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -1991,6 +1991,60 @@ mod tests {
         assert_eq!(orders[0].visible_quantity(), 100);
     }
 
+    // `PriceLevelData` is a plain input/transfer DTO: with `deny_unknown_fields`
+    // an unexpected key must be rejected rather than silently ignored.
+    #[test]
+    fn test_price_level_data_unknown_field_rejected() {
+        let json = r#"{
+            "price": 10000,
+            "visible_quantity": 100,
+            "hidden_quantity": 0,
+            "order_count": 0,
+            "orders": [],
+            "unexpected_field": 42
+        }"#;
+
+        let result = serde_json::from_str::<PriceLevelData>(json);
+        assert!(
+            result.is_err(),
+            "deny_unknown_fields should reject the unexpected key"
+        );
+
+        // The same payload without the unknown field still deserializes,
+        // proving the wire format itself is unchanged.
+        let valid_json = r#"{
+            "price": 10000,
+            "visible_quantity": 100,
+            "hidden_quantity": 0,
+            "order_count": 0,
+            "orders": []
+        }"#;
+        let data = serde_json::from_str::<PriceLevelData>(valid_json)
+            .expect("valid PriceLevelData must deserialize");
+        assert_eq!(data.price, 10000);
+        assert_eq!(data.visible_quantity, 100);
+    }
+
+    // Deserializing a `PriceLevel` (which routes through `PriceLevelData`) from a
+    // payload carrying an unknown field is likewise rejected.
+    #[test]
+    fn test_price_level_deserialize_unknown_field_rejected() {
+        let json = r#"{
+            "price": 10000,
+            "visible_quantity": 0,
+            "hidden_quantity": 0,
+            "order_count": 0,
+            "orders": [],
+            "bogus": "value"
+        }"#;
+
+        let result = serde_json::from_str::<PriceLevel>(json);
+        assert!(
+            result.is_err(),
+            "PriceLevel deserialize must reject unknown fields via PriceLevelData"
+        );
+    }
+
     // In price_level/level.rs test module or in a separate test file
 
     #[test]


### PR DESCRIPTION
## Summary

Serde hygiene: drop genuinely-redundant aliases on `Side`/`TimeInForce` and
reject unknown fields on the `PriceLevelData` transfer DTO. The serialized wire
format is unchanged (verified by the round-trip tests).

## Changes

- **Removed the redundant `alias = "<VariantName>"` entries** (`Buy`/`Sell` on
  `Side`; `Gtc`/`Ioc`/`Fok`/`Gtd`/`Day` on `TimeInForce`). `rename(serialize =
  "BUY")` only sets the serialize name; serde already accepts the bare variant
  name on deserialize, so those aliases were no-ops.
- **Kept** the uppercase serialize-form aliases (`BUY`/`GTC`/…) — load-bearing:
  they let a serialized value round-trip back — and the lowercase tolerance
  aliases. No switch to `rename_all` (variants serialize UPPERCASE; that would
  change the wire casing).
- **Added `#[serde(deny_unknown_fields)]` to `PriceLevelData`** — a symmetric
  input/transfer DTO (`PriceLevel`'s `Serialize`/`Deserialize` both route through
  its 5 fields), so the wire format is unchanged.

## Technical decisions

- **Not** added to `OrderBookEntry`'s `Wrapper`: its `serialize` emits 4 fields
  but `deserialize` intentionally knows only `price` + `index` (the rest are
  computed), so `deny_unknown_fields` would break its own round-trip. Left as-is.
- **Not** added to `PriceLevelSnapshot` (hand-written `Deserialize`, must stay
  forward-compatible). Confirmed off.

## Testing

- [x] Existing `Side`/`TimeInForce` deserialize tests (capitalized / mixed-case /
      standard / gtd) still pass — proves the removed forms still deserialize
- [x] New: `test_deserialize_all_accepted_forms_after_alias_cleanup` (Side + TIF
      wire round-trips), `test_price_level_data_unknown_field_rejected`,
      `test_price_level_deserialize_unknown_field_rejected`
- [x] `make pre-push` clean

`cargo test`: 349 (lib) + 1 (integration) + 9 (doctests) = 359 passed, 0 failed.
`cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all
--check`, `cargo build --release`: all clean.

## Checklist

- [x] Serde wire format unchanged (round-trip tests pass)
- [x] `deny_unknown_fields` on the input DTO; NOT on the snapshot DTO
- [x] Only redundant aliases removed; load-bearing ones kept
- [x] No new deps; no behavioral change beyond stricter input validation

Closes #75
