### PR TITLE
average_price edges; pin current IOC/GTD behavior at the level (#79)

### DIFF
--- a/src/execution/tests/match_result_trade.rs
+++ b/src/execution/tests/match_result_trade.rs
@@ -86,4 +86,143 @@ mod tests {
         assert!(result.add_trade(trade).is_ok());
         assert!(result.executed_value().is_err());
     }
+
+    // ----- average_price edge cases -----
+    //
+    // `average_price()` returns `Result<Option<f64>, PriceLevelError>` and
+    // computes `executed_value as f64 / executed_quantity as f64`, guarding
+    // the zero-quantity case so it never divides by zero. These tests pin the
+    // zero-quantity, precision-loss, and never-NaN/Inf behavior. The
+    // happy-path average (`test_average_price`) is verified via real
+    // `match_order` output in the price-level tests.
+
+    /// No trades have been added, so executed quantity is zero and there is no
+    /// average price to report: `average_price()` must return `Ok(None)`
+    /// (never an error, never a division by zero, never NaN).
+    #[test]
+    fn test_average_price_zero_executed_quantity_returns_none() {
+        let result = MatchResult::new(Id::from_u64(10), 100);
+
+        match result.average_price() {
+            Ok(None) => {}
+            other => panic!("expected Ok(None) for zero executed quantity, got {other:?}"),
+        }
+    }
+
+    /// A single trade whose `price` and `quantity` are exactly representable in
+    /// `f64` yields an exact average. Pins that the common case is precise and
+    /// never NaN/Inf.
+    #[test]
+    fn test_average_price_exact_small_values_is_precise() {
+        let mut result = MatchResult::new(Id::from_u64(10), 100);
+
+        // price 1000, quantity 30 -> value 30_000, avg 1000.0 exactly.
+        assert!(result.add_trade(sample_trade(30)).is_ok());
+
+        match result.average_price() {
+            Ok(Some(avg)) => {
+                assert!(avg.is_finite(), "average price must be finite");
+                assert!((avg - 1000.0_f64).abs() < f64::EPSILON);
+            }
+            other => panic!("expected Ok(Some(1000.0)), got {other:?}"),
+        }
+    }
+
+    /// Large value/quantity case where `f64`'s 53-bit integer mantissa cannot
+    /// represent the exact integer average.
+    ///
+    /// A single trade with `price = 2^53 + 1` and `quantity = 1` has an exact
+    /// integer average of `9_007_199_254_740_993`, but `average_price()`
+    /// returns `9_007_199_254_740_992.0` because `2^53 + 1` is not
+    /// representable as an `f64` (it rounds to `2^53`). This is a documented,
+    /// intrinsic limitation of using `f64` for the analytics average — the
+    /// matching path itself keeps exact integer `Price`/`Quantity` math and
+    /// only `average_price` drops to `f64`.
+    ///
+    /// We therefore do NOT assert exact equality with the integer average.
+    /// Instead we assert the result is finite and within a small absolute
+    /// tolerance (well under 1 ULP-worth of drift at this magnitude, here a
+    /// fixed difference of exactly 1).
+    #[test]
+    fn test_average_price_large_values_loses_f64_precision_but_stays_finite() {
+        const PRICE: u128 = (1_u128 << 53) + 1; // 9_007_199_254_740_993
+        const EXACT_INT_AVG: u128 = PRICE; // quantity == 1, so average == price
+
+        let mut result = MatchResult::new(Id::from_u64(10), 1);
+        let trade = Trade::with_timestamp(
+            Id::from_uuid(parse_uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
+            Id::from_u64(10),
+            Id::from_u64(20),
+            Price::new(PRICE),
+            Quantity::new(1),
+            Side::Buy,
+            TimestampMs::new(1_616_823_000_000),
+        );
+        assert!(result.add_trade(trade).is_ok());
+
+        match result.average_price() {
+            Ok(Some(avg)) => {
+                // Never NaN/Inf for a valid, in-range input.
+                assert!(avg.is_finite(), "average price must be finite");
+                assert!(!avg.is_nan(), "average price must not be NaN");
+                assert!(!avg.is_infinite(), "average price must not be Inf");
+
+                // Precision genuinely drifts: the f64 average differs from the
+                // exact integer average by exactly 1 here. Assert it is close,
+                // not equal.
+                let exact = EXACT_INT_AVG as f64;
+                let abs_err = (avg - exact).abs();
+                assert!(
+                    abs_err <= 2.0,
+                    "f64 average should be within tolerance of the exact \
+                     integer average; abs_err = {abs_err}"
+                );
+
+                // Document the observed drift: the exact integer average is
+                // 2^53 + 1, but f64 cannot represent it and returns 2^53.
+                assert_eq!(
+                    avg, 9_007_199_254_740_992.0_f64,
+                    "observed f64 average rounds 2^53 + 1 down to 2^53"
+                );
+            }
+            other => panic!("expected Ok(Some(_)), got {other:?}"),
+        }
+    }
+
+    /// For valid inputs producing trades, `average_price()` must never yield a
+    /// NaN or infinite value. Sweeps a handful of (price, quantity) inputs and
+    /// asserts finiteness on each.
+    #[test]
+    fn test_average_price_valid_inputs_never_nan_or_inf() {
+        let cases: [(u128, u64); 4] = [
+            (1, 1),
+            (1_000, 7),
+            (u64::MAX as u128, 3),
+            ((1_u128 << 60) + 5, 11),
+        ];
+
+        for (idx, (price, quantity)) in cases.into_iter().enumerate() {
+            let mut result = MatchResult::new(Id::from_u64(10), quantity);
+            let trade = Trade::with_timestamp(
+                Id::from_uuid(parse_uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
+                Id::from_u64(10),
+                Id::from_u64(20),
+                Price::new(price),
+                Quantity::new(quantity),
+                Side::Buy,
+                TimestampMs::new(1_616_823_000_000),
+            );
+            assert!(result.add_trade(trade).is_ok());
+
+            match result.average_price() {
+                Ok(Some(avg)) => {
+                    assert!(
+                        avg.is_finite(),
+                        "case {idx}: average must be finite (price={price}, qty={quantity})"
+                    );
+                }
+                other => panic!("case {idx}: expected Ok(Some(_)), got {other:?}"),
+            }
+        }
+    }
 }

--- a/src/execution/tests/match_result_trade.rs
+++ b/src/execution/tests/match_result_trade.rs
@@ -93,8 +93,8 @@ mod tests {
     // computes `executed_value as f64 / executed_quantity as f64`, guarding
     // the zero-quantity case so it never divides by zero. These tests pin the
     // zero-quantity, precision-loss, and never-NaN/Inf behavior. The
-    // happy-path average (`test_average_price`) is verified via real
-    // `match_order` output in the price-level tests.
+    // happy-path (exact) average is covered by
+    // `test_average_price_exact_small_values_is_precise` below.
 
     /// No trades have been added, so executed quantity is zero and there is no
     /// average price to report: `average_price()` must return `Ok(None)`
@@ -167,22 +167,23 @@ mod tests {
                 assert!(!avg.is_nan(), "average price must not be NaN");
                 assert!(!avg.is_infinite(), "average price must not be Inf");
 
-                // Precision genuinely drifts: the f64 average differs from the
-                // exact integer average by exactly 1 here. Assert it is close,
-                // not equal.
-                let exact = EXACT_INT_AVG as f64;
-                let abs_err = (avg - exact).abs();
-                assert!(
-                    abs_err <= 2.0,
-                    "f64 average should be within tolerance of the exact \
-                     integer average; abs_err = {abs_err}"
-                );
-
                 // Document the observed drift: the exact integer average is
-                // 2^53 + 1, but f64 cannot represent it and returns 2^53.
+                // 2^53 + 1, but f64 has only a 53-bit mantissa and the division
+                // rounds it down to 2^53.
                 assert_eq!(
                     avg, 9_007_199_254_740_992.0_f64,
                     "observed f64 average rounds 2^53 + 1 down to 2^53"
+                );
+
+                // Show the loss in INTEGER space. Comparing `EXACT_INT_AVG as
+                // f64` would round the same way and hide the drift (abs_err
+                // would be 0), so convert the f64 result back to an integer and
+                // prove it is short of the exact integer average by exactly 1.
+                let avg_as_int = avg as u128;
+                assert_eq!(
+                    EXACT_INT_AVG - avg_as_int,
+                    1,
+                    "f64 average loses exactly 1 vs the exact integer average (2^53 + 1)"
                 );
             }
             other => panic!("expected Ok(Some(_)), got {other:?}"),

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -251,6 +251,12 @@ impl PriceLevel {
     /// and filled orders are removed from the queue.  The function also updates the visible and hidden
     /// quantity counters and records statistics for each execution.
     ///
+    /// Time-in-force EXPIRY is NOT enforced here: a resting maker's
+    /// [`TimeInForce`](crate::orders::TimeInForce) (e.g. `Gtd` / `Day`) is not
+    /// consulted, so an expired maker still matches. Evicting or skipping
+    /// expired orders is the caller's / order book's responsibility, keeping
+    /// the match path a pure, deterministic sweep over the resting queue.
+    ///
     /// # Arguments
     ///
     /// * `incoming_quantity`: The quantity of the incoming order to be matched.

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -1865,6 +1865,14 @@ mod tests {
 
     #[test]
     fn test_match_fill_or_kill_order() {
+        // NOTE: the FOK time-in-force on the resting *maker* is NOT enforced at
+        // this layer. `match_order` does not consult the maker's TIF — the FOK
+        // order matches exactly like a `TimeInForce::Gtc` standard order. This
+        // test only pins that "a resting FOK maker is consumable like any
+        // other"; it does NOT assert all-or-nothing "kill" semantics, because
+        // the engine cannot enforce them here. Real FOK/IOC *taker* semantics
+        // (all-or-nothing fill, discard-remainder) require `match_order` to
+        // accept a taker TIF and are gated on issue #65.
         let price_level = PriceLevel::new(10000);
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
@@ -1888,6 +1896,15 @@ mod tests {
 
     #[test]
     fn test_match_immediate_or_cancel_order() {
+        // NOTE: the IOC time-in-force on the resting *maker* is NOT enforced at
+        // this layer. `match_order` does not consult the maker's TIF — the IOC
+        // order matches and the unfilled remainder keeps resting exactly like a
+        // `TimeInForce::Gtc` standard order. This test only pins that "a resting
+        // IOC maker is partially consumable like any other and the unmatched
+        // part stays in the queue"; it does NOT assert IOC discard semantics on
+        // the maker. Real FOK/IOC *taker* semantics (the taker discarding its
+        // own remainder rather than the maker) require `match_order` to accept a
+        // taker TIF and are gated on issue #65.
         let price_level = PriceLevel::new(10000);
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
@@ -1930,6 +1947,120 @@ mod tests {
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.order_count(), 0);
+    }
+
+    /// Pin the de-facto IOC behavior of `match_order` for a taker larger than
+    /// the available resting depth.
+    ///
+    /// `match_order` takes no taker `TimeInForce` and NEVER enqueues the taker:
+    /// it fills every unit it can against the resting queue and reports the
+    /// unfilled remainder via `remaining_quantity()`. With a taker (150) that
+    /// exceeds total depth (100), this is exactly the observable IOC outcome —
+    /// "fill what you can, discard the rest" — even though no IOC flag is
+    /// consulted: the resting depth is fully consumed, `remaining_quantity()`
+    /// stays positive, `is_complete()` is false, and nothing of the taker is
+    /// left resting at the level (the level only holds makers, and `match_order`
+    /// adds no new order).
+    ///
+    /// Explicit IOC/FOK *taker* semantics — distinguishing "discard remainder"
+    /// (IOC) from "all-or-nothing kill" (FOK) — require `match_order` to accept
+    /// a taker TIF and are gated on issue #65; they are intentionally NOT
+    /// asserted here.
+    #[test]
+    fn test_match_order_taker_exceeds_depth_fills_available_and_reports_remainder() {
+        let price_level = PriceLevel::new(10000);
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let trade_id_generator = UuidGenerator::new(namespace);
+
+        // Total resting depth = 100 (two Buy makers).
+        price_level.add_order(create_standard_order(1, 10000, 60));
+        price_level.add_order(create_standard_order(2, 10000, 40));
+        assert_eq!(price_level.visible_quantity(), 100);
+        assert_eq!(price_level.order_count(), 2);
+
+        // Taker of 150 exceeds the resting depth of 100.
+        let taker_id = Id::from_u64(999);
+        let result = price_level.match_order(
+            150,
+            taker_id,
+            TimestampMs::new(1_716_000_000_000),
+            &trade_id_generator,
+        );
+
+        // All available depth filled (100 of 150); 50 reported as remainder.
+        assert_eq!(result.executed_quantity().expect("real output is Ok"), 100);
+        assert_eq!(result.remaining_quantity(), 50);
+        assert!(
+            result.remaining_quantity() > 0,
+            "taker remainder must be strictly positive"
+        );
+        assert!(
+            !result.is_complete(),
+            "an under-filled taker must not be reported complete"
+        );
+
+        // Both resting makers were fully consumed and removed.
+        assert_eq!(result.filled_order_ids().len(), 2);
+
+        // The taker is NOT left resting: `match_order` never enqueues it. The
+        // level is now empty — only the (consumed) makers ever lived here.
+        assert_eq!(price_level.order_count(), 0);
+        assert_eq!(price_level.visible_quantity(), 0);
+
+        // Makers were Buy, so the taker is Sell.
+        assert_match_result_consistent(&result, 10000, Side::Buy);
+    }
+
+    /// Pin that `match_order` does NOT enforce maker time-in-force expiry.
+    ///
+    /// A `TimeInForce::Gtd` maker whose expiry timestamp is in the *past*
+    /// relative to the match timestamp still matches normally — the engine does
+    /// not consult `TimeInForce::is_expired` inside the match path. Enforcing
+    /// expiry (skipping or evicting expired makers) is intentionally the
+    /// caller's / order book's responsibility, not the price level's:
+    /// `TimeInForce::is_expired(current_ts, market_close_ts)` exists and is unit
+    /// tested in isolation (`src/orders/tests/time_in_force.rs`), but it is
+    /// deliberately not invoked here, so the match path stays a pure,
+    /// timestamp-driven, deterministic sweep over the resting queue.
+    #[test]
+    fn test_match_order_does_not_enforce_gtd_maker_expiry() {
+        let price_level = PriceLevel::new(10000);
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let trade_id_generator = UuidGenerator::new(namespace);
+
+        // Maker expiry is in the PAST relative to the match timestamp below.
+        let past_expiry: u64 = 1_000_000_000_000;
+        let match_ts: u64 = 1_716_000_000_000;
+        assert!(
+            match_ts > past_expiry,
+            "fixture: match time is after expiry"
+        );
+
+        // Sanity-check the isolated helper to make explicit WHAT the level is
+        // choosing not to consult: this maker IS expired by `is_expired`.
+        assert!(
+            TimeInForce::Gtd(past_expiry).is_expired(match_ts, None),
+            "fixture: the GTD maker is expired per TimeInForce::is_expired"
+        );
+
+        price_level.add_order(create_good_till_date_order(1, 10000, 100, past_expiry));
+
+        // Despite the expired maker, the match fills it like a standard order.
+        let result = price_level.match_order(
+            100,
+            Id::from_u64(999),
+            TimestampMs::new(match_ts),
+            &trade_id_generator,
+        );
+
+        assert_eq!(result.remaining_quantity(), 0);
+        assert!(result.is_complete());
+        assert_eq!(result.trades().len(), 1);
+        assert_eq!(price_level.visible_quantity(), 0);
+        assert_eq!(price_level.order_count(), 0);
+
+        // Maker was Buy, so the taker is Sell.
+        assert_match_result_consistent(&result, 10000, Side::Buy);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds the non-gated parts of the TIF / expiry / `average_price` test coverage:
`average_price` edge cases, a pin of the level's de-facto IOC behavior, and a
test + doc note that time-in-force expiry is the caller's responsibility. The
parts that need taker-TIF enforcement (FOK all-or-nothing, true IOC discard) are
deferred to the gated #65.

## Changes

- **`average_price` edges** (`match_result_trade.rs`): zero-executed → `Ok(None)`;
  exact small values; the `f64` precision-loss case; and a never-`NaN`/`Inf`
  sweep over valid inputs.
- **IOC de-facto pin** (`level.rs` tests):
  `test_match_order_taker_exceeds_depth_fills_available_and_reports_remainder` —
  a larger-than-depth taker fills available, leaves `remaining_quantity() > 0`,
  `is_complete() == false`, and is never enqueued.
- **GTD/Day**: `test_match_order_does_not_enforce_gtd_maker_expiry` — a Gtd maker
  with a past expiry still matches; added a `match_order` rustdoc note that TIF
  expiry is not enforced at the level (caller/order-book responsibility).
- Clarifying comments on the existing `test_match_fill_or_kill_order` /
  `test_match_immediate_or_cancel_order` (maker TIF not enforced; matches like
  Gtc).

## Technical decisions

- **`average_price` precision (no bug):** for `price = 2^53 + 1, quantity = 1`
  the exact average is `9_007_199_254_740_993` but the `f64` division yields
  `…992.0` (off by 1) — `2^53 + 1` isn't representable in an f64 mantissa. The
  matching path keeps exact integer math; only `average_price` analytics drop to
  `f64`. Never `NaN`/`Inf` for valid inputs. Tests assert closeness + finiteness
  and document the limitation.
- **Deferred to #65:** FOK all-or-nothing "kill" and IOC discard *enforcement* —
  `match_order` takes no taker `TimeInForce` and never enqueues the taker, so it
  can't distinguish fill-or-kill from fill-what-you-can. The IOC test pins only
  the observable behavior the engine already has.

## Testing

- [x] `make pre-push` clean

`cargo test`: 380 (unit) + 1 (integration) + 9 (doctests) passed, 0 failed.
`cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all
--check`, `cargo build --release`: all clean.

## Checklist

- [x] `average_price` zero / precision / NaN-guard edges covered
- [x] Current IOC + GTD/Day behavior pinned and documented (expiry = caller-side)
- [x] FOK/IOC *enforcement* explicitly deferred to #65 (no faked behavior)
- [x] Tests + one rustdoc note only; no behavior change; no new deps

Closes #79
