### PR TITLE
Return domain newtypes from accessors (Quantity/TimestampMs/Price) (#71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ this completes the quantity / timestamp surface). Call `.as_u64()` /
 | [`MatchResult::executed_quantity`] | `Result<u64, _>` | `Result<`[`Quantity`]`, _>` |
 | [`PriceLevelSnapshot::new`] (`price`) | `u128` | [`Price`] |
 | [`PriceLevelSnapshot::with_orders`] (`price`) | `u128` | [`Price`] |
+| [`PriceLevelSnapshot::with_orders_and_stats`] (`price`) | `u128` | [`Price`] |
 | [`PriceLevelSnapshot::price`] | `u128` | [`Price`] |
 | [`PriceLevelSnapshot::visible_quantity`] | `u64` | [`Quantity`] |
 | [`PriceLevelSnapshot::hidden_quantity`] | `u64` | [`Quantity`] |

--- a/README.md
+++ b/README.md
@@ -462,6 +462,41 @@ arithmetic of [`MatchResult::executed_value`](crate::execution::MatchResult::exe
 which previously used an unchecked `*` that could panic in debug or wrap in
 release. Callers must handle the `Result` (e.g. `trade.total_value()?`).
 
+### Migration Guide (newtypes at the accessor boundary — breaking)
+
+Accessors that previously returned raw integers for a domain concept now
+return the crate newtype, so raw `u64` / `u128` no longer leak across module
+boundaries (`OrderType::price` / `id` / `side` already returned newtypes —
+this completes the quantity / timestamp surface). Call `.as_u64()` /
+`.as_u128()` to recover the primitive, or keep working in the newtype.
+
+| Method | Before | After |
+|--------|--------|-------|
+| [`OrderType::visible_quantity`] | `u64` | [`Quantity`] |
+| [`OrderType::hidden_quantity`] | `u64` | [`Quantity`] |
+| [`OrderType::timestamp`] | `u64` | [`TimestampMs`] |
+| [`MatchResult::new`] (`initial_quantity`) | `u64` | [`Quantity`] |
+| [`MatchResult::with_capacity`] (`initial_quantity`) | `u64` | [`Quantity`] |
+| [`MatchResult::remaining_quantity`] | `u64` | [`Quantity`] |
+| [`MatchResult::executed_quantity`] | `Result<u64, _>` | `Result<`[`Quantity`]`, _>` |
+| [`PriceLevelSnapshot::new`] (`price`) | `u128` | [`Price`] |
+| [`PriceLevelSnapshot::with_orders`] (`price`) | `u128` | [`Price`] |
+| [`PriceLevelSnapshot::price`] | `u128` | [`Price`] |
+| [`PriceLevelSnapshot::visible_quantity`] | `u64` | [`Quantity`] |
+| [`PriceLevelSnapshot::hidden_quantity`] | `u64` | [`Quantity`] |
+| [`PriceLevelSnapshot::total_quantity`] | `Result<u64, _>` | `Result<`[`Quantity`]`, _>` |
+
+[`MatchResult::executed_value`] / [`Trade::total_value`](crate::execution::Trade::total_value)
+still return `u128` — there is no monetary newtype. [`PriceLevel::match_order`]
+keeps its `incoming_quantity: u64` input (it is converted to [`Quantity`] at
+the [`MatchResult`] boundary internally); its 124 call sites are unchanged.
+
+**Snapshot wire format is unchanged.** [`Price`] and [`Quantity`] are
+`#[serde(transparent)]`, so a snapshot serializes the same JSON numbers as
+before; the snapshot format version is **not** bumped and the SHA-256
+checksum over an unchanged payload still validates. Existing snapshot JSON
+restores without migration.
+
 
  ## Setup Instructions
 

--- a/benches/price_level/checked_arithmetic.rs
+++ b/benches/price_level/checked_arithmetic.rs
@@ -73,7 +73,7 @@ pub fn register_benchmarks(c: &mut Criterion) {
     // Benchmark MatchResult::new + add_trade sequence
     group.bench_function("match_result_add_trades", |b| {
         b.iter(|| {
-            let mut mr = MatchResult::new(Id::from_u64(1), 1000);
+            let mut mr = MatchResult::new(Id::from_u64(1), Quantity::new(1000));
             for i in 0..50_u64 {
                 let trade = Trade::new(
                     Id::from_u64(100 + i),

--- a/benches/price_level/iter_orders.rs
+++ b/benches/price_level/iter_orders.rs
@@ -25,7 +25,7 @@ pub fn register_benchmarks(c: &mut Criterion) {
                 b.iter(|| {
                     let mut total: u64 = 0;
                     for order in price_level.iter_orders() {
-                        total = total.wrapping_add(black_box(order.visible_quantity()));
+                        total = total.wrapping_add(black_box(order.visible_quantity().as_u64()));
                     }
                     black_box(total)
                 })

--- a/examples/src/bin/hft_simulation.rs
+++ b/examples/src/bin/hft_simulation.rs
@@ -148,7 +148,12 @@ fn main() {
                 );
 
                 // Count successful matches
-                if result.executed_quantity().unwrap_or(0) > 0 {
+                if result
+                    .executed_quantity()
+                    .unwrap_or(Quantity::ZERO)
+                    .as_u64()
+                    > 0
+                {
                     local_counter += 1;
                 }
 

--- a/examples/src/bin/integration_basic_lifecycle.rs
+++ b/examples/src/bin/integration_basic_lifecycle.rs
@@ -136,8 +136,12 @@ fn main() {
     let executed_qty = match_result
         .executed_quantity()
         .unwrap_or_else(|e| exit_err(&format!("executed_quantity: {e}")));
-    assert_eq_or_exit(executed_qty, 200, "executed_quantity");
-    assert_eq_or_exit(match_result.remaining_quantity(), 0, "remaining_quantity");
+    assert_eq_or_exit(executed_qty.as_u64(), 200, "executed_quantity");
+    assert_eq_or_exit(
+        match_result.remaining_quantity().as_u64(),
+        0,
+        "remaining_quantity",
+    );
     assert_or_exit(match_result.is_complete(), "match should be complete");
     assert_or_exit(
         !match_result.trades().as_vec().is_empty(),
@@ -170,7 +174,7 @@ fn main() {
         "partial match should not be complete",
     );
     assert_or_exit(
-        partial.remaining_quantity() > 0,
+        partial.remaining_quantity().as_u64() > 0,
         "should have remaining quantity",
     );
     println!(

--- a/examples/src/bin/integration_checked_arithmetic.rs
+++ b/examples/src/bin/integration_checked_arithmetic.rs
@@ -97,7 +97,7 @@ fn test_executed_quantity_and_value(id_gen: &UuidGenerator) {
     let executed_qty = result
         .executed_quantity()
         .unwrap_or_else(|e| exit_err(&format!("executed_quantity: {e}")));
-    assert_eq_or_exit(executed_qty, 250, "executed_quantity");
+    assert_eq_or_exit(executed_qty.as_u64(), 250, "executed_quantity");
 
     let executed_val = result
         .executed_value()
@@ -106,7 +106,11 @@ fn test_executed_quantity_and_value(id_gen: &UuidGenerator) {
     assert_eq_or_exit(executed_val, 1_250_000, "executed_value");
 
     // Verify remaining
-    assert_eq_or_exit(result.remaining_quantity(), 0, "remaining_quantity");
+    assert_eq_or_exit(
+        result.remaining_quantity().as_u64(),
+        0,
+        "remaining_quantity",
+    );
     assert_or_exit(result.is_complete(), "should be complete");
 
     // Verify filled_order_ids: first 2 orders fully filled (100 each), third partially filled
@@ -176,8 +180,12 @@ fn test_empty_match_result(id_gen: &UuidGenerator) {
     let executed = result
         .executed_quantity()
         .unwrap_or_else(|e| exit_err(&format!("executed_quantity: {e}")));
-    assert_eq_or_exit(executed, 0, "empty level executed_quantity");
-    assert_eq_or_exit(result.remaining_quantity(), 100, "empty level remaining");
+    assert_eq_or_exit(executed.as_u64(), 0, "empty level executed_quantity");
+    assert_eq_or_exit(
+        result.remaining_quantity().as_u64(),
+        100,
+        "empty level remaining",
+    );
     assert_or_exit(!result.is_complete(), "empty level should not be complete");
     assert_or_exit(
         result.trades().is_empty(),

--- a/examples/src/bin/integration_snapshot_recovery.rs
+++ b/examples/src/bin/integration_snapshot_recovery.rs
@@ -110,14 +110,18 @@ fn main() {
 
     // Verify snapshot accessors
     let snap: &PriceLevelSnapshot = restored_package.snapshot();
-    assert_eq_or_exit(snap.price(), orig_price, "snapshot price");
+    assert_eq_or_exit(snap.price().as_u128(), orig_price, "snapshot price");
     assert_eq_or_exit(snap.order_count(), orig_order_count, "snapshot order_count");
     assert_eq_or_exit(
-        snap.visible_quantity(),
+        snap.visible_quantity().as_u64(),
         orig_visible,
         "snapshot visible_qty",
     );
-    assert_eq_or_exit(snap.hidden_quantity(), orig_hidden, "snapshot hidden_qty");
+    assert_eq_or_exit(
+        snap.hidden_quantity().as_u64(),
+        orig_hidden,
+        "snapshot hidden_qty",
+    );
     assert_eq_or_exit(snap.orders().len(), orig_order_count, "snapshot orders len");
     println!("  ✓ Restored snapshot aggregates match original.");
 
@@ -214,7 +218,11 @@ fn main() {
     let total = snap2
         .total_quantity()
         .unwrap_or_else(|e| exit_err(&format!("total_quantity: {e}")));
-    assert_eq_or_exit(total, orig_visible + orig_hidden, "snapshot total_quantity");
+    assert_eq_or_exit(
+        total.as_u64(),
+        orig_visible + orig_hidden,
+        "snapshot total_quantity",
+    );
     println!(
         "  ✓ Snapshot total_quantity = {} (visible {} + hidden {}).",
         total, orig_visible, orig_hidden

--- a/examples/src/bin/integration_special_orders.rs
+++ b/examples/src/bin/integration_special_orders.rs
@@ -59,7 +59,10 @@ fn test_iceberg_order(id_gen: &UuidGenerator) {
         TimestampMs::new(1_716_000_000_000),
         id_gen,
     );
-    let executed = result.executed_quantity().unwrap_or(0);
+    let executed = result
+        .executed_quantity()
+        .unwrap_or(Quantity::ZERO)
+        .as_u64();
     assert_eq_or_exit(executed, 10, "iceberg match executed");
     assert_or_exit(result.is_complete(), "taker should be fully filled");
 
@@ -105,7 +108,10 @@ fn test_reserve_order(id_gen: &UuidGenerator) {
         TimestampMs::new(1_716_000_000_000),
         id_gen,
     );
-    let executed = result.executed_quantity().unwrap_or(0);
+    let executed = result
+        .executed_quantity()
+        .unwrap_or(Quantity::ZERO)
+        .as_u64();
     assert_eq_or_exit(executed, 8, "reserve match executed");
 
     // Reserve order should still be present (not fully consumed)
@@ -152,7 +158,10 @@ fn test_post_only_order(id_gen: &UuidGenerator) {
         id_gen,
     );
     assert_eq_or_exit(
-        result.executed_quantity().unwrap_or(0),
+        result
+            .executed_quantity()
+            .unwrap_or(Quantity::ZERO)
+            .as_u64(),
         50,
         "postonly match executed",
     );
@@ -196,7 +205,10 @@ fn test_trailing_stop_order(id_gen: &UuidGenerator) {
         id_gen,
     );
     assert_eq_or_exit(
-        result.executed_quantity().unwrap_or(0),
+        result
+            .executed_quantity()
+            .unwrap_or(Quantity::ZERO)
+            .as_u64(),
         30,
         "trailing match executed",
     );
@@ -233,7 +245,10 @@ fn test_pegged_order(id_gen: &UuidGenerator) {
         id_gen,
     );
     assert_eq_or_exit(
-        result.executed_quantity().unwrap_or(0),
+        result
+            .executed_quantity()
+            .unwrap_or(Quantity::ZERO)
+            .as_u64(),
         25,
         "pegged match executed",
     );
@@ -269,7 +284,10 @@ fn test_market_to_limit_order(id_gen: &UuidGenerator) {
         id_gen,
     );
     assert_eq_or_exit(
-        result.executed_quantity().unwrap_or(0),
+        result
+            .executed_quantity()
+            .unwrap_or(Quantity::ZERO)
+            .as_u64(),
         15,
         "m2l partial match",
     );

--- a/examples/src/bin/integration_trade_roundtrip.rs
+++ b/examples/src/bin/integration_trade_roundtrip.rs
@@ -144,7 +144,10 @@ fn main() {
     );
 
     assert_eq_or_exit(
-        result.executed_quantity().unwrap_or(0),
+        result
+            .executed_quantity()
+            .unwrap_or(Quantity::ZERO)
+            .as_u64(),
         50,
         "executed_quantity",
     );

--- a/examples/src/bin/simple.rs
+++ b/examples/src/bin/simple.rs
@@ -81,7 +81,7 @@ fn main() {
                             info!(
                                 "Thread {} match result: executed={}, remaining={}, complete={}",
                                 thread_id,
-                                match_result.executed_quantity().unwrap_or(0),
+                                match_result.executed_quantity().unwrap_or(Quantity::ZERO),
                                 match_result.remaining_quantity(),
                                 match_result.is_complete()
                             );

--- a/src/execution/match_result.rs
+++ b/src/execution/match_result.rs
@@ -2,6 +2,7 @@ use crate::errors::PriceLevelError;
 use crate::execution::list::TradeList;
 use crate::execution::trade::Trade;
 use crate::orders::Id;
+use crate::utils::Quantity;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
@@ -98,18 +99,19 @@ pub struct MatchResult {
 }
 
 impl MatchResult {
-    /// Create a new empty match result
+    /// Create a new empty match result for an incoming taker of
+    /// `initial_quantity` quantity units.
     #[must_use]
-    pub fn new(order_id: Id, initial_quantity: u64) -> Self {
+    pub fn new(order_id: Id, initial_quantity: Quantity) -> Self {
         // A zero-quantity result is vacuously complete (nothing to fill), so keep
         // is_complete / outcome consistent at construction — matching
         // `finalize`'s `remaining == 0 => Filled` rule. A non-zero result starts
         // incomplete / NotFilled until a trade or `finalize` updates it.
-        let is_complete = initial_quantity == 0;
+        let is_complete = initial_quantity.as_u64() == 0;
         Self {
             order_id,
             trades: TradeList::new(),
-            remaining_quantity: initial_quantity,
+            remaining_quantity: initial_quantity.as_u64(),
             is_complete,
             filled_order_ids: Vec::new(),
             outcome: if is_complete {
@@ -128,13 +130,13 @@ impl MatchResult {
     /// the level's resting order count. Pre-sizing both vectors removes the
     /// per-fill reallocations on the match hot path.
     #[must_use]
-    pub fn with_capacity(order_id: Id, initial_quantity: u64, capacity: usize) -> Self {
+    pub fn with_capacity(order_id: Id, initial_quantity: Quantity, capacity: usize) -> Self {
         // Same zero-quantity consistency as `new` (see there).
-        let is_complete = initial_quantity == 0;
+        let is_complete = initial_quantity.as_u64() == 0;
         Self {
             order_id,
             trades: TradeList::with_capacity(capacity),
-            remaining_quantity: initial_quantity,
+            remaining_quantity: initial_quantity.as_u64(),
             is_complete,
             filled_order_ids: Vec::with_capacity(capacity),
             outcome: if is_complete {
@@ -193,10 +195,11 @@ impl MatchResult {
         &self.trades
     }
 
-    /// Returns the remaining quantity of the incoming order after matching.
+    /// Returns the remaining quantity of the incoming order after matching, in
+    /// quantity units.
     #[must_use]
-    pub fn remaining_quantity(&self) -> u64 {
-        self.remaining_quantity
+    pub fn remaining_quantity(&self) -> Quantity {
+        Quantity::new(self.remaining_quantity)
     }
 
     /// Returns whether the order was completely filled.
@@ -247,9 +250,9 @@ impl MatchResult {
     /// no liquidity). Kill and rejection are set by their dedicated helpers
     /// because they are decided *before* any sweep and must not be
     /// re-derived from the (deliberately untouched) fields.
-    pub(crate) fn finalize(&mut self, remaining_quantity: u64) {
-        self.remaining_quantity = remaining_quantity;
-        self.is_complete = remaining_quantity == 0;
+    pub(crate) fn finalize(&mut self, remaining_quantity: Quantity) {
+        self.remaining_quantity = remaining_quantity.as_u64();
+        self.is_complete = self.remaining_quantity == 0;
         self.outcome = if self.is_complete {
             MatchOutcome::Filled
         } else if self.trades.is_empty() {
@@ -286,20 +289,24 @@ impl MatchResult {
         self.outcome = MatchOutcome::Rejected;
     }
 
-    /// Get the total executed quantity
+    /// Get the total executed quantity, in quantity units.
     ///
     /// # Errors
     ///
     /// Returns [`PriceLevelError::InvalidOperation`] if summing the trade
     /// quantities overflows `u64`.
-    pub fn executed_quantity(&self) -> Result<u64, PriceLevelError> {
-        self.trades.as_vec().iter().try_fold(0u64, |acc, trade| {
-            acc.checked_add(trade.quantity().as_u64()).ok_or_else(|| {
-                PriceLevelError::InvalidOperation {
-                    message: "executed quantity overflow".to_string(),
-                }
+    pub fn executed_quantity(&self) -> Result<Quantity, PriceLevelError> {
+        self.trades
+            .as_vec()
+            .iter()
+            .try_fold(0u64, |acc, trade| {
+                acc.checked_add(trade.quantity().as_u64()).ok_or_else(|| {
+                    PriceLevelError::InvalidOperation {
+                        message: "executed quantity overflow".to_string(),
+                    }
+                })
             })
-        })
+            .map(Quantity::new)
     }
 
     /// Get the total value executed
@@ -337,7 +344,7 @@ impl MatchResult {
     /// [`Self::executed_quantity`] or [`Self::executed_value`] computation
     /// overflows.
     pub fn average_price(&self) -> Result<Option<f64>, PriceLevelError> {
-        let executed_qty = self.executed_quantity()?;
+        let executed_qty = self.executed_quantity()?.as_u64();
         if executed_qty == 0 {
             Ok(None)
         } else {

--- a/src/execution/tests/match_result_trade.rs
+++ b/src/execution/tests/match_result_trade.rs
@@ -28,17 +28,17 @@ mod tests {
 
     #[test]
     fn add_trade_updates_remaining_and_trades() {
-        let mut result = MatchResult::new(Id::from_u64(10), 100);
+        let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(100));
         assert!(result.add_trade(sample_trade(25)).is_ok());
 
-        assert_eq!(result.remaining_quantity(), 75);
+        assert_eq!(result.remaining_quantity().as_u64(), 75);
         assert_eq!(result.trades().len(), 1);
         assert!(!result.is_complete());
     }
 
     #[test]
     fn display_and_parse_use_trades_field() {
-        let mut result = MatchResult::new(Id::from_u64(10), 100);
+        let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(100));
         assert!(result.add_trade(sample_trade(40)).is_ok());
 
         let rendered = result.to_string();
@@ -50,13 +50,13 @@ mod tests {
         };
 
         assert_eq!(parsed.trades().len(), 1);
-        assert_eq!(parsed.remaining_quantity(), 60);
+        assert_eq!(parsed.remaining_quantity().as_u64(), 60);
     }
 
     #[test]
     fn add_trade_keeps_outcome_in_sync() {
         // No trades yet -> the default benign classification.
-        let mut result = MatchResult::new(Id::from_u64(10), 100);
+        let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(100));
         assert_eq!(result.outcome(), MatchOutcome::NotFilled);
 
         // Partial fill.
@@ -73,14 +73,14 @@ mod tests {
 
     #[test]
     fn outcome_survives_serde_json_roundtrip() {
-        let mut result = MatchResult::new(Id::from_u64(10), 100);
+        let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(100));
         assert!(result.add_trade(sample_trade(40)).is_ok());
 
         let json = serde_json::to_string(&result).expect("serialize match result");
         let parsed: MatchResult = serde_json::from_str(&json).expect("deserialize match result");
 
         assert_eq!(parsed.outcome(), MatchOutcome::PartiallyFilled);
-        assert_eq!(parsed.remaining_quantity(), 60);
+        assert_eq!(parsed.remaining_quantity().as_u64(), 60);
         assert_eq!(parsed.trades().len(), 1);
     }
 
@@ -89,7 +89,7 @@ mod tests {
         // A JSON payload written before the `outcome` field existed must still
         // deserialize (the field is `#[serde(default)]`). Build a current JSON,
         // then strip the `outcome` key to emulate the legacy shape.
-        let result = MatchResult::new(Id::from_u64(10), 70);
+        let result = MatchResult::new(Id::from_u64(10), Quantity::new(70));
         let mut value: serde_json::Value =
             serde_json::to_value(&result).expect("serialize match result");
         value
@@ -102,7 +102,7 @@ mod tests {
         let parsed: MatchResult =
             serde_json::from_str(&legacy).expect("legacy match result must deserialize");
         assert_eq!(parsed.outcome(), MatchOutcome::NotFilled);
-        assert_eq!(parsed.remaining_quantity(), 70);
+        assert_eq!(parsed.remaining_quantity().as_u64(), 70);
     }
 
     #[test]
@@ -114,16 +114,16 @@ mod tests {
 
     #[test]
     fn add_trade_rejects_underflow() {
-        let mut result = MatchResult::new(Id::from_u64(10), 10);
+        let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(10));
         let error = result.add_trade(sample_trade(11));
         assert!(error.is_err());
-        assert_eq!(result.remaining_quantity(), 10);
+        assert_eq!(result.remaining_quantity().as_u64(), 10);
         assert_eq!(result.trades().len(), 0);
     }
 
     #[test]
     fn executed_value_rejects_overflow() {
-        let mut result = MatchResult::new(Id::from_u64(10), 4);
+        let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(4));
 
         let trade = Trade::with_timestamp(
             Id::from_uuid(parse_uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
@@ -153,7 +153,7 @@ mod tests {
     /// (never an error, never a division by zero, never NaN).
     #[test]
     fn test_average_price_zero_executed_quantity_returns_none() {
-        let result = MatchResult::new(Id::from_u64(10), 100);
+        let result = MatchResult::new(Id::from_u64(10), Quantity::new(100));
 
         match result.average_price() {
             Ok(None) => {}
@@ -166,7 +166,7 @@ mod tests {
     /// never NaN/Inf.
     #[test]
     fn test_average_price_exact_small_values_is_precise() {
-        let mut result = MatchResult::new(Id::from_u64(10), 100);
+        let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(100));
 
         // price 1000, quantity 30 -> value 30_000, avg 1000.0 exactly.
         assert!(result.add_trade(sample_trade(30)).is_ok());
@@ -200,7 +200,7 @@ mod tests {
         const PRICE: u128 = (1_u128 << 53) + 1; // 9_007_199_254_740_993
         const EXACT_INT_AVG: u128 = PRICE; // quantity == 1, so average == price
 
-        let mut result = MatchResult::new(Id::from_u64(10), 1);
+        let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(1));
         let trade = Trade::with_timestamp(
             Id::from_uuid(parse_uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
             Id::from_u64(10),
@@ -255,7 +255,7 @@ mod tests {
         ];
 
         for (idx, (price, quantity)) in cases.into_iter().enumerate() {
-            let mut result = MatchResult::new(Id::from_u64(10), quantity);
+            let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(quantity));
             let trade = Trade::with_timestamp(
                 Id::from_uuid(parse_uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
                 Id::from_u64(10),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,6 +454,41 @@
 //! which previously used an unchecked `*` that could panic in debug or wrap in
 //! release. Callers must handle the `Result` (e.g. `trade.total_value()?`).
 //!
+//! ## Migration Guide (newtypes at the accessor boundary — breaking)
+//!
+//! Accessors that previously returned raw integers for a domain concept now
+//! return the crate newtype, so raw `u64` / `u128` no longer leak across module
+//! boundaries (`OrderType::price` / `id` / `side` already returned newtypes —
+//! this completes the quantity / timestamp surface). Call `.as_u64()` /
+//! `.as_u128()` to recover the primitive, or keep working in the newtype.
+//!
+//! | Method | Before | After |
+//! |--------|--------|-------|
+//! | [`OrderType::visible_quantity`] | `u64` | [`Quantity`] |
+//! | [`OrderType::hidden_quantity`] | `u64` | [`Quantity`] |
+//! | [`OrderType::timestamp`] | `u64` | [`TimestampMs`] |
+//! | [`MatchResult::new`] (`initial_quantity`) | `u64` | [`Quantity`] |
+//! | [`MatchResult::with_capacity`] (`initial_quantity`) | `u64` | [`Quantity`] |
+//! | [`MatchResult::remaining_quantity`] | `u64` | [`Quantity`] |
+//! | [`MatchResult::executed_quantity`] | `Result<u64, _>` | `Result<`[`Quantity`]`, _>` |
+//! | [`PriceLevelSnapshot::new`] (`price`) | `u128` | [`Price`] |
+//! | [`PriceLevelSnapshot::with_orders`] (`price`) | `u128` | [`Price`] |
+//! | [`PriceLevelSnapshot::price`] | `u128` | [`Price`] |
+//! | [`PriceLevelSnapshot::visible_quantity`] | `u64` | [`Quantity`] |
+//! | [`PriceLevelSnapshot::hidden_quantity`] | `u64` | [`Quantity`] |
+//! | [`PriceLevelSnapshot::total_quantity`] | `Result<u64, _>` | `Result<`[`Quantity`]`, _>` |
+//!
+//! [`MatchResult::executed_value`] / [`Trade::total_value`](crate::execution::Trade::total_value)
+//! still return `u128` — there is no monetary newtype. [`PriceLevel::match_order`]
+//! keeps its `incoming_quantity: u64` input (it is converted to [`Quantity`] at
+//! the [`MatchResult`] boundary internally); its 124 call sites are unchanged.
+//!
+//! **Snapshot wire format is unchanged.** [`Price`] and [`Quantity`] are
+//! `#[serde(transparent)]`, so a snapshot serializes the same JSON numbers as
+//! before; the snapshot format version is **not** bumped and the SHA-256
+//! checksum over an unchanged payload still validates. Existing snapshot JSON
+//! restores without migration.
+//!
 
 mod orders;
 mod price_level;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,6 +473,7 @@
 //! | [`MatchResult::executed_quantity`] | `Result<u64, _>` | `Result<`[`Quantity`]`, _>` |
 //! | [`PriceLevelSnapshot::new`] (`price`) | `u128` | [`Price`] |
 //! | [`PriceLevelSnapshot::with_orders`] (`price`) | `u128` | [`Price`] |
+//! | [`PriceLevelSnapshot::with_orders_and_stats`] (`price`) | `u128` | [`Price`] |
 //! | [`PriceLevelSnapshot::price`] | `u128` | [`Price`] |
 //! | [`PriceLevelSnapshot::visible_quantity`] | `u64` | [`Quantity`] |
 //! | [`PriceLevelSnapshot::hidden_quantity`] | `u64` | [`Quantity`] |

--- a/src/orders/order_type.rs
+++ b/src/orders/order_type.rs
@@ -247,37 +247,39 @@ impl<T: Clone> OrderType<T> {
         }
     }
 
-    /// Get the visible quantity
+    /// Get the visible quantity, in quantity units.
     #[must_use]
     #[inline]
-    pub fn visible_quantity(&self) -> u64 {
+    pub fn visible_quantity(&self) -> Quantity {
         match self {
-            Self::Standard { quantity, .. } => quantity.as_u64(),
+            Self::Standard { quantity, .. } => *quantity,
             Self::IcebergOrder {
                 visible_quantity, ..
-            } => visible_quantity.as_u64(),
-            Self::PostOnly { quantity, .. } => quantity.as_u64(),
-            Self::TrailingStop { quantity, .. } => quantity.as_u64(),
-            Self::PeggedOrder { quantity, .. } => quantity.as_u64(),
-            Self::MarketToLimit { quantity, .. } => quantity.as_u64(),
+            } => *visible_quantity,
+            Self::PostOnly { quantity, .. } => *quantity,
+            Self::TrailingStop { quantity, .. } => *quantity,
+            Self::PeggedOrder { quantity, .. } => *quantity,
+            Self::MarketToLimit { quantity, .. } => *quantity,
             Self::ReserveOrder {
                 visible_quantity, ..
-            } => visible_quantity.as_u64(),
+            } => *visible_quantity,
         }
     }
 
-    /// Get the hidden quantity
+    /// Get the hidden quantity, in quantity units.
+    ///
+    /// Order types without a hidden tranche return [`Quantity::ZERO`].
     #[must_use]
     #[inline]
-    pub fn hidden_quantity(&self) -> u64 {
+    pub fn hidden_quantity(&self) -> Quantity {
         match self {
             Self::IcebergOrder {
                 hidden_quantity, ..
-            } => hidden_quantity.as_u64(),
+            } => *hidden_quantity,
             Self::ReserveOrder {
                 hidden_quantity, ..
-            } => hidden_quantity.as_u64(),
-            _ => 0,
+            } => *hidden_quantity,
+            _ => Quantity::ZERO,
         }
     }
 
@@ -301,7 +303,7 @@ impl<T: Clone> OrderType<T> {
     #[must_use]
     #[inline]
     pub fn is_matchable(&self) -> bool {
-        if self.visible_quantity() > 0 {
+        if self.visible_quantity().as_u64() > 0 {
             return true;
         }
         match self {
@@ -346,18 +348,18 @@ impl<T: Clone> OrderType<T> {
         }
     }
 
-    /// Get the timestamp
+    /// Get the timestamp at which the order was created, in milliseconds.
     #[must_use]
     #[inline]
-    pub fn timestamp(&self) -> u64 {
+    pub fn timestamp(&self) -> TimestampMs {
         match self {
-            Self::Standard { timestamp, .. } => timestamp.as_u64(),
-            Self::IcebergOrder { timestamp, .. } => timestamp.as_u64(),
-            Self::PostOnly { timestamp, .. } => timestamp.as_u64(),
-            Self::TrailingStop { timestamp, .. } => timestamp.as_u64(),
-            Self::PeggedOrder { timestamp, .. } => timestamp.as_u64(),
-            Self::MarketToLimit { timestamp, .. } => timestamp.as_u64(),
-            Self::ReserveOrder { timestamp, .. } => timestamp.as_u64(),
+            Self::Standard { timestamp, .. } => *timestamp,
+            Self::IcebergOrder { timestamp, .. } => *timestamp,
+            Self::PostOnly { timestamp, .. } => *timestamp,
+            Self::TrailingStop { timestamp, .. } => *timestamp,
+            Self::PeggedOrder { timestamp, .. } => *timestamp,
+            Self::MarketToLimit { timestamp, .. } => *timestamp,
+            Self::ReserveOrder { timestamp, .. } => *timestamp,
         }
     }
 
@@ -784,7 +786,7 @@ impl<T: Clone> OrderType<T> {
 
             // For all other order types, use standard matching logic
             _ => {
-                let visible_qty = self.visible_quantity();
+                let visible_qty = self.visible_quantity().as_u64();
 
                 if visible_qty <= incoming_quantity {
                     // Full match

--- a/src/orders/tests/order_type.rs
+++ b/src/orders/tests/order_type.rs
@@ -142,24 +142,27 @@ mod tests {
 
     #[test]
     fn test_visible_quantity() {
-        assert_eq!(create_standard_order().visible_quantity(), 5);
-        assert_eq!(create_iceberg_order().visible_quantity(), 1);
-        assert_eq!(create_post_only_order().visible_quantity(), 5);
-        assert_eq!(create_trailing_stop_order().visible_quantity(), 5);
-        assert_eq!(create_pegged_order().visible_quantity(), 5);
-        assert_eq!(create_market_to_limit_order().visible_quantity(), 5);
-        assert_eq!(create_reserve_order().visible_quantity(), 1);
+        assert_eq!(create_standard_order().visible_quantity().as_u64(), 5);
+        assert_eq!(create_iceberg_order().visible_quantity().as_u64(), 1);
+        assert_eq!(create_post_only_order().visible_quantity().as_u64(), 5);
+        assert_eq!(create_trailing_stop_order().visible_quantity().as_u64(), 5);
+        assert_eq!(create_pegged_order().visible_quantity().as_u64(), 5);
+        assert_eq!(
+            create_market_to_limit_order().visible_quantity().as_u64(),
+            5
+        );
+        assert_eq!(create_reserve_order().visible_quantity().as_u64(), 1);
     }
 
     #[test]
     fn test_hidden_quantity() {
-        assert_eq!(create_standard_order().hidden_quantity(), 0);
-        assert_eq!(create_iceberg_order().hidden_quantity(), 4);
-        assert_eq!(create_post_only_order().hidden_quantity(), 0);
-        assert_eq!(create_trailing_stop_order().hidden_quantity(), 0);
-        assert_eq!(create_pegged_order().hidden_quantity(), 0);
-        assert_eq!(create_market_to_limit_order().hidden_quantity(), 0);
-        assert_eq!(create_reserve_order().hidden_quantity(), 4);
+        assert_eq!(create_standard_order().hidden_quantity().as_u64(), 0);
+        assert_eq!(create_iceberg_order().hidden_quantity().as_u64(), 4);
+        assert_eq!(create_post_only_order().hidden_quantity().as_u64(), 0);
+        assert_eq!(create_trailing_stop_order().hidden_quantity().as_u64(), 0);
+        assert_eq!(create_pegged_order().hidden_quantity().as_u64(), 0);
+        assert_eq!(create_market_to_limit_order().hidden_quantity().as_u64(), 0);
+        assert_eq!(create_reserve_order().hidden_quantity().as_u64(), 4);
     }
 
     #[test]
@@ -192,13 +195,19 @@ mod tests {
 
     #[test]
     fn test_timestamp() {
-        assert_eq!(create_standard_order().timestamp(), 1616823000000);
-        assert_eq!(create_iceberg_order().timestamp(), 1616823000000);
-        assert_eq!(create_post_only_order().timestamp(), 1616823000000);
-        assert_eq!(create_trailing_stop_order().timestamp(), 1616823000000);
-        assert_eq!(create_pegged_order().timestamp(), 1616823000000);
-        assert_eq!(create_market_to_limit_order().timestamp(), 1616823000000);
-        assert_eq!(create_reserve_order().timestamp(), 1616823000000);
+        assert_eq!(create_standard_order().timestamp().as_u64(), 1616823000000);
+        assert_eq!(create_iceberg_order().timestamp().as_u64(), 1616823000000);
+        assert_eq!(create_post_only_order().timestamp().as_u64(), 1616823000000);
+        assert_eq!(
+            create_trailing_stop_order().timestamp().as_u64(),
+            1616823000000
+        );
+        assert_eq!(create_pegged_order().timestamp().as_u64(), 1616823000000);
+        assert_eq!(
+            create_market_to_limit_order().timestamp().as_u64(),
+            1616823000000
+        );
+        assert_eq!(create_reserve_order().timestamp().as_u64(), 1616823000000);
     }
 
     #[test]

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -53,9 +53,9 @@ impl PriceLevel {
         snapshot.refresh_aggregates()?;
 
         let order_count = snapshot.orders().len();
-        let visible_quantity = snapshot.visible_quantity();
-        let hidden_quantity = snapshot.hidden_quantity();
-        let price = snapshot.price();
+        let visible_quantity = snapshot.visible_quantity().as_u64();
+        let hidden_quantity = snapshot.hidden_quantity().as_u64();
+        let price = snapshot.price().as_u128();
         // Clone the persisted statistics before consuming the snapshot's orders.
         let stats = (*snapshot.statistics()).clone();
         let queue = OrderQueue::from(snapshot.into_orders());
@@ -198,8 +198,8 @@ impl PriceLevel {
     /// Add an order to this price level
     pub fn add_order(&self, order: OrderType<()>) -> Arc<OrderType<()>> {
         // Calculate quantities
-        let visible_qty = order.visible_quantity();
-        let hidden_qty = order.hidden_quantity();
+        let visible_qty = order.visible_quantity().as_u64();
+        let hidden_qty = order.hidden_quantity().as_u64();
 
         // On this path, publish to the queue FIRST, then bump the counters, so a
         // concurrent reader of this add tends to see the order resting before it
@@ -448,7 +448,7 @@ impl PriceLevel {
                 price = self.price,
                 "post-only taker rejected: would take liquidity"
             );
-            let mut result = MatchResult::new(taker_order_id, incoming_quantity);
+            let mut result = MatchResult::new(taker_order_id, Quantity::new(incoming_quantity));
             result.mark_rejected(incoming_quantity);
             return result;
         }
@@ -465,7 +465,7 @@ impl PriceLevel {
                     price = self.price,
                     "fill-or-kill taker killed: insufficient depth"
                 );
-                let mut result = MatchResult::new(taker_order_id, incoming_quantity);
+                let mut result = MatchResult::new(taker_order_id, Quantity::new(incoming_quantity));
                 result.mark_killed(incoming_quantity);
                 return result;
             }
@@ -478,7 +478,8 @@ impl PriceLevel {
         // concurrent `add_order` lands mid-sweep — capacity is a hint, not a
         // bound.
         let capacity = self.order_count();
-        let mut result = MatchResult::with_capacity(taker_order_id, incoming_quantity, capacity);
+        let mut result =
+            MatchResult::with_capacity(taker_order_id, Quantity::new(incoming_quantity), capacity);
         let mut remaining = incoming_quantity;
 
         // No-progress safety guard. A popped maker that yields no progress
@@ -567,7 +568,7 @@ impl PriceLevel {
                     let _ = self.stats.record_execution(
                         consumed,
                         order_arc.price().as_u128(),
-                        order_arc.timestamp(),
+                        order_arc.timestamp().as_u64(),
                         timestamp.as_u64(),
                     );
                 }
@@ -633,7 +634,7 @@ impl PriceLevel {
             self.orders.reinsert(seq, order);
         }
 
-        result.finalize(remaining);
+        result.finalize(Quantity::new(remaining));
 
         result
     }
@@ -668,7 +669,7 @@ impl PriceLevel {
             // On that impossible branch we fall back to the live atomic counter —
             // the engine's own authoritative `u64` total (best-effort, since the
             // branch cannot occur for representable state).
-            match visible_quantity.checked_add(order.visible_quantity()) {
+            match visible_quantity.checked_add(order.visible_quantity().as_u64()) {
                 Some(total) => visible_quantity = total,
                 None => {
                     debug_assert!(false, "snapshot visible quantity overflow is unreachable");
@@ -676,7 +677,7 @@ impl PriceLevel {
                 }
             }
 
-            match hidden_quantity.checked_add(order.hidden_quantity()) {
+            match hidden_quantity.checked_add(order.hidden_quantity().as_u64()) {
                 Some(total) => hidden_quantity = total,
                 None => {
                     debug_assert!(false, "snapshot hidden quantity overflow is unreachable");
@@ -691,9 +692,9 @@ impl PriceLevel {
         // other read path); statistics are independent counters, not part of
         // the queue / counter consistency invariant.
         PriceLevelSnapshot::from_raw_parts_with_stats(
-            self.price,
-            visible_quantity,
-            hidden_quantity,
+            Price::new(self.price),
+            Quantity::new(visible_quantity),
+            Quantity::new(hidden_quantity),
             order_count,
             orders,
             (*self.stats).clone(),
@@ -773,8 +774,8 @@ impl PriceLevel {
                         // from the queue above. `Relaxed` on all three: advisory
                         // counters (issue #68); the `OrderQueue::remove` carries
                         // the happens-before, not these counters.
-                        let visible_qty = order_arc.visible_quantity();
-                        let hidden_qty = order_arc.hidden_quantity();
+                        let visible_qty = order_arc.visible_quantity().as_u64();
+                        let hidden_qty = order_arc.hidden_quantity().as_u64();
 
                         self.visible_quantity
                             .fetch_sub(visible_qty, Ordering::Relaxed);
@@ -811,7 +812,8 @@ impl PriceLevel {
 
                 let prev_total = order
                     .visible_quantity()
-                    .checked_add(order.hidden_quantity())
+                    .as_u64()
+                    .checked_add(order.hidden_quantity().as_u64())
                     .ok_or_else(|| PriceLevelError::InvalidOperation {
                         message: "order total quantity overflow".to_string(),
                     })?;
@@ -822,8 +824,8 @@ impl PriceLevel {
                 // to an unchanged clone, so `new_total` equals the old total for
                 // them and they take the position-preserving in-place branch.
                 let new_order = order.with_reduced_quantity(new_quantity.as_u64());
-                let new_visible = new_order.visible_quantity();
-                let new_hidden = new_order.hidden_quantity();
+                let new_visible = new_order.visible_quantity().as_u64();
+                let new_hidden = new_order.hidden_quantity().as_u64();
                 let new_total = new_visible.checked_add(new_hidden).ok_or_else(|| {
                     PriceLevelError::InvalidOperation {
                         message: "order total quantity overflow".to_string(),
@@ -863,8 +865,8 @@ impl PriceLevel {
                 // direction even when the total shrinks or is unchanged, because
                 // quantity can shift between the visible and hidden portions, so
                 // handle both signs.
-                let old_visible = old.visible_quantity();
-                let old_hidden = old.hidden_quantity();
+                let old_visible = old.visible_quantity().as_u64();
+                let old_hidden = old.hidden_quantity().as_u64();
                 // `Relaxed` on both branches: advisory counters (issue #68); the
                 // queue mutation above (`update_in_place` / `remove` + `push`)
                 // carries the happens-before, not these counter RMWs.
@@ -895,8 +897,8 @@ impl PriceLevel {
                         // from the queue above. `Relaxed` on all three: advisory
                         // counters (issue #68); the `OrderQueue::remove` carries
                         // the happens-before, not these counters.
-                        let visible_qty = order_arc.visible_quantity();
-                        let hidden_qty = order_arc.hidden_quantity();
+                        let visible_qty = order_arc.visible_quantity().as_u64();
+                        let hidden_qty = order_arc.hidden_quantity().as_u64();
 
                         self.visible_quantity
                             .fetch_sub(visible_qty, Ordering::Relaxed);
@@ -926,8 +928,8 @@ impl PriceLevel {
                     // the queue above. `Relaxed` on all three: advisory counters
                     // (issue #68); the `OrderQueue::remove` carries the
                     // happens-before, not these counters.
-                    let visible_qty = order_arc.visible_quantity();
-                    let hidden_qty = order_arc.hidden_quantity();
+                    let visible_qty = order_arc.visible_quantity().as_u64();
+                    let hidden_qty = order_arc.hidden_quantity().as_u64();
 
                     self.visible_quantity
                         .fetch_sub(visible_qty, Ordering::Relaxed);
@@ -958,8 +960,8 @@ impl PriceLevel {
                         // from the queue above. `Relaxed` on all three: advisory
                         // counters (issue #68); the `OrderQueue::remove` carries
                         // the happens-before, not these counters.
-                        let visible_qty = order_arc.visible_quantity();
-                        let hidden_qty = order_arc.hidden_quantity();
+                        let visible_qty = order_arc.visible_quantity().as_u64();
+                        let hidden_qty = order_arc.hidden_quantity().as_u64();
 
                         self.visible_quantity
                             .fetch_sub(visible_qty, Ordering::Relaxed);
@@ -1021,9 +1023,9 @@ impl From<&PriceLevelSnapshot> for PriceLevel {
         let _ = snapshot.refresh_aggregates();
 
         let order_count = snapshot.orders().len();
-        let visible_quantity = snapshot.visible_quantity();
-        let hidden_quantity = snapshot.hidden_quantity();
-        let price = snapshot.price();
+        let visible_quantity = snapshot.visible_quantity().as_u64();
+        let hidden_quantity = snapshot.hidden_quantity().as_u64();
+        let price = snapshot.price().as_u128();
         // Preserve the persisted statistics instead of resetting them.
         let stats = (*snapshot.statistics()).clone();
         let queue = OrderQueue::from(snapshot.into_orders());

--- a/src/price_level/snapshot.rs
+++ b/src/price_level/snapshot.rs
@@ -1,6 +1,7 @@
 use crate::errors::PriceLevelError;
 use crate::orders::OrderType;
 use crate::price_level::statistics::PriceLevelStatistics;
+use crate::utils::{Price, Quantity};
 use serde::de::{self, MapAccess, Visitor};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -14,12 +15,12 @@ use std::sync::Arc;
 /// at that level, and the per-level execution statistics.
 #[derive(Debug, Default, Clone)]
 pub struct PriceLevelSnapshot {
-    /// The price of this level.
-    price: u128,
-    /// Total visible quantity at this level in the smallest unit.
-    visible_quantity: u64,
-    /// Total hidden quantity at this level in the smallest unit.
-    hidden_quantity: u64,
+    /// The price of this level, in price ticks.
+    price: Price,
+    /// Total visible quantity at this level, in quantity units.
+    visible_quantity: Quantity,
+    /// Total hidden quantity at this level, in quantity units.
+    hidden_quantity: Quantity,
     /// Number of orders at this level.
     order_count: usize,
     /// Orders at this level.
@@ -37,11 +38,11 @@ pub struct PriceLevelSnapshot {
 impl PriceLevelSnapshot {
     /// Create a new empty snapshot at the given price.
     #[must_use]
-    pub fn new(price: u128) -> Self {
+    pub fn new(price: Price) -> Self {
         Self {
             price,
-            visible_quantity: 0,
-            hidden_quantity: 0,
+            visible_quantity: Quantity::ZERO,
+            hidden_quantity: Quantity::ZERO,
             order_count: 0,
             orders: Vec::new(),
             statistics: PriceLevelStatistics::new(),
@@ -58,7 +59,7 @@ impl PriceLevelSnapshot {
     /// Returns [`PriceLevelError::InvalidOperation`] if summing the per-order
     /// visible / hidden quantities overflows `u64`.
     pub fn with_orders(
-        price: u128,
+        price: Price,
         orders: Vec<Arc<OrderType<()>>>,
     ) -> Result<Self, PriceLevelError> {
         Self::with_orders_and_stats(price, orders, PriceLevelStatistics::new())
@@ -72,14 +73,14 @@ impl PriceLevelSnapshot {
     /// Returns [`PriceLevelError::InvalidOperation`] if summing the per-order
     /// visible / hidden quantities overflows `u64`.
     pub fn with_orders_and_stats(
-        price: u128,
+        price: Price,
         orders: Vec<Arc<OrderType<()>>>,
         statistics: PriceLevelStatistics,
     ) -> Result<Self, PriceLevelError> {
         let mut snapshot = Self {
             price,
-            visible_quantity: 0,
-            hidden_quantity: 0,
+            visible_quantity: Quantity::ZERO,
+            hidden_quantity: Quantity::ZERO,
             order_count: 0,
             orders,
             statistics,
@@ -88,21 +89,21 @@ impl PriceLevelSnapshot {
         Ok(snapshot)
     }
 
-    /// Returns the price of this level.
+    /// Returns the price of this level, in price ticks.
     #[must_use]
-    pub fn price(&self) -> u128 {
+    pub fn price(&self) -> Price {
         self.price
     }
 
-    /// Returns the total visible quantity.
+    /// Returns the total visible quantity, in quantity units.
     #[must_use]
-    pub fn visible_quantity(&self) -> u64 {
+    pub fn visible_quantity(&self) -> Quantity {
         self.visible_quantity
     }
 
-    /// Returns the total hidden quantity.
+    /// Returns the total hidden quantity, in quantity units.
     #[must_use]
-    pub fn hidden_quantity(&self) -> u64 {
+    pub fn hidden_quantity(&self) -> Quantity {
         self.hidden_quantity
     }
 
@@ -139,9 +140,9 @@ impl PriceLevelSnapshot {
     #[cfg(test)]
     #[must_use]
     pub(crate) fn from_raw_parts(
-        price: u128,
-        visible_quantity: u64,
-        hidden_quantity: u64,
+        price: Price,
+        visible_quantity: Quantity,
+        hidden_quantity: Quantity,
         order_count: usize,
         orders: Vec<Arc<OrderType<()>>>,
     ) -> Self {
@@ -162,9 +163,9 @@ impl PriceLevelSnapshot {
     /// preserve the level's execution statistics through the snapshot.
     #[must_use]
     pub(crate) fn from_raw_parts_with_stats(
-        price: u128,
-        visible_quantity: u64,
-        hidden_quantity: u64,
+        price: Price,
+        visible_quantity: Quantity,
+        hidden_quantity: Quantity,
         order_count: usize,
         orders: Vec<Arc<OrderType<()>>>,
         statistics: PriceLevelStatistics,
@@ -185,9 +186,11 @@ impl PriceLevelSnapshot {
     ///
     /// Returns [`PriceLevelError::InvalidOperation`] if `visible + hidden`
     /// overflows `u64`.
-    pub fn total_quantity(&self) -> Result<u64, PriceLevelError> {
+    pub fn total_quantity(&self) -> Result<Quantity, PriceLevelError> {
         self.visible_quantity
-            .checked_add(self.hidden_quantity)
+            .as_u64()
+            .checked_add(self.hidden_quantity.as_u64())
+            .map(Quantity::new)
             .ok_or_else(|| PriceLevelError::InvalidOperation {
                 message: "snapshot total quantity overflow".to_string(),
             })
@@ -212,20 +215,20 @@ impl PriceLevelSnapshot {
 
         for order in &self.orders {
             visible_total = visible_total
-                .checked_add(order.visible_quantity())
+                .checked_add(order.visible_quantity().as_u64())
                 .ok_or_else(|| PriceLevelError::InvalidOperation {
                     message: "snapshot visible quantity overflow".to_string(),
                 })?;
 
             hidden_total = hidden_total
-                .checked_add(order.hidden_quantity())
+                .checked_add(order.hidden_quantity().as_u64())
                 .ok_or_else(|| PriceLevelError::InvalidOperation {
                     message: "snapshot hidden quantity overflow".to_string(),
                 })?;
         }
 
-        self.visible_quantity = visible_total;
-        self.hidden_quantity = hidden_total;
+        self.visible_quantity = Quantity::new(visible_total);
+        self.hidden_quantity = Quantity::new(hidden_total);
 
         Ok(())
     }
@@ -666,9 +669,9 @@ impl FromStr for PriceLevelSnapshot {
         // serialized/deserialized in this simple, human-readable format. Use the
         // JSON snapshot package for a lossless round-trip.
         Ok(PriceLevelSnapshot {
-            price,
-            visible_quantity,
-            hidden_quantity,
+            price: Price::new(price),
+            visible_quantity: Quantity::new(visible_quantity),
+            hidden_quantity: Quantity::new(hidden_quantity),
             order_count,
             orders: Vec::new(),
             statistics: PriceLevelStatistics::new(),

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -470,7 +470,7 @@ mod tests {
         // Verify the returned Arc contains the expected order
         assert_eq!(order_arc.id(), Id::from_u64(1));
         assert_eq!(order_arc.price(), Price::new(10000));
-        assert_eq!(order_arc.visible_quantity(), 100);
+        assert_eq!(order_arc.visible_quantity().as_u64(), 100);
 
         // Verify stats
         assert_eq!(price_level.stats().orders_added(), 1);
@@ -590,7 +590,7 @@ mod tests {
         );
 
         assert_eq!(match_result.order_id(), taker_id);
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.order_count(), 0);
@@ -663,8 +663,8 @@ mod tests {
 
         // Crossed two full makers (40 + 30) and partially filled the third (20).
         assert_eq!(first_trades.len(), 3);
-        assert_eq!(first.executed_quantity().unwrap_or_default(), 90);
-        assert_eq!(second.executed_quantity().unwrap_or_default(), 90);
+        assert_eq!(first.executed_quantity().unwrap_or_default().as_u64(), 90);
+        assert_eq!(second.executed_quantity().unwrap_or_default().as_u64(), 90);
 
         // Byte-identical trade streams (Trade derives PartialEq over every
         // field, including the timestamp).
@@ -697,7 +697,7 @@ mod tests {
 
         // Verificar el resultado de matching
         assert_eq!(match_result.order_id(), taker_id);
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 40);
         assert_eq!(price_level.order_count(), 1);
@@ -739,7 +739,7 @@ mod tests {
         );
 
         assert_eq!(match_result.order_id(), taker_id);
-        assert_eq!(match_result.remaining_quantity(), 50); // 150 - 100 = 50 remaining
+        assert_eq!(match_result.remaining_quantity().as_u64(), 50); // 150 - 100 = 50 remaining
         assert!(!match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.order_count(), 0);
@@ -783,7 +783,7 @@ mod tests {
 
         // Assertions to validate the match result.
         assert_eq!(match_result.order_id(), taker_id);
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 50);
         assert_eq!(price_level.hidden_quantity(), 50); // Hidden quantity reduced
@@ -809,7 +809,7 @@ mod tests {
             TimestampMs::new(1_716_000_000_000),
             &transaction_id_generator,
         );
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 50); // Visible quantity replenished
         assert_eq!(price_level.hidden_quantity(), 0); // Hidden quantity reduced
@@ -833,7 +833,7 @@ mod tests {
             TimestampMs::new(1_716_000_000_000),
             &transaction_id_generator,
         );
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.hidden_quantity(), 0);
@@ -864,7 +864,7 @@ mod tests {
 
         // Assertions to validate the match result.
         assert_eq!(match_result.order_id(), taker_id);
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 50);
         assert_eq!(price_level.hidden_quantity(), 100); // Hidden quantity reduced
@@ -890,7 +890,7 @@ mod tests {
             TimestampMs::new(1_716_000_000_000),
             &transaction_id_generator,
         );
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 50); // Visible quantity replenished
         assert_eq!(price_level.hidden_quantity(), 50); // Hidden quantity reduced
@@ -916,7 +916,7 @@ mod tests {
             TimestampMs::new(1_716_000_000_000),
             &transaction_id_generator,
         );
-        assert_eq!(match_result.remaining_quantity(), 50);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 50);
         assert!(!match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.hidden_quantity(), 0);
@@ -944,7 +944,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 20);
         assert_eq!(price_level.hidden_quantity(), 150); // Hidden unchanged
@@ -976,7 +976,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         // The order should be removed since the visible quantity reached 0 and auto_replenish is false
         assert_eq!(price_level.visible_quantity(), 0);
@@ -1007,7 +1007,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         // The order should be replenished with the default amount
         assert_eq!(
@@ -1044,7 +1044,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 25); // 50 - 25 = 25
         assert_eq!(price_level.hidden_quantity(), 150); // No change to hidden quantity
@@ -1060,7 +1060,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         // No automatic replenishment because auto_replenish is false
         assert_eq!(price_level.visible_quantity(), 15); // 25 - 10 = 15, no replenishment
@@ -1099,7 +1099,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         // The order should be replenished with the custom amount
         assert_eq!(price_level.visible_quantity(), custom_amount);
@@ -1130,7 +1130,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         // 1 visible unit will remain, which equals the safe threshold (1), so no replenishment occurs
         assert_eq!(price_level.visible_quantity(), 1);
@@ -1160,7 +1160,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         // The order should be removed from the price level
         assert_eq!(price_level.visible_quantity(), 0);
@@ -1190,7 +1190,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         // The order should be removed from the price level
         assert_eq!(price_level.visible_quantity(), 0);
@@ -1220,7 +1220,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 25); // 50 - 25 = 25
         assert_eq!(price_level.hidden_quantity(), 150); // No replenishment yet
@@ -1236,7 +1236,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         // No automatic replenishment because auto_replenish is false
         assert_eq!(price_level.visible_quantity(), 15); // 25 - 10 = 15
@@ -1271,7 +1271,7 @@ mod tests {
 
         // Validate the match result
         assert_eq!(match_result.order_id(), taker_id);
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 20); // 100 - 80 = 20
         assert_eq!(price_level.hidden_quantity(), 100); // Hidden quantity unchanged (still above threshold)
@@ -1298,7 +1298,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 90); // 20 - 10 = 10, then replenished to 90 (10 + 80)
         assert_eq!(price_level.hidden_quantity(), 20); // 100 - 80 (replenish amount) = 20
@@ -1323,7 +1323,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 40); // 150 - 90 - 20 = 40
+        assert_eq!(match_result.remaining_quantity().as_u64(), 40); // 150 - 90 - 20 = 40
         assert!(!match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.hidden_quantity(), 0);
@@ -1370,7 +1370,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 40);
         assert_eq!(price_level.order_count(), 1);
@@ -1395,7 +1395,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.order_count(), 0);
@@ -1420,7 +1420,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 50);
         assert_eq!(price_level.order_count(), 1);
@@ -1445,7 +1445,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.order_count(), 0);
@@ -1496,7 +1496,7 @@ mod tests {
         );
 
         assert!(result.is_complete());
-        assert_eq!(result.remaining_quantity(), 0);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
         assert_eq!(result.trades().len(), 1);
         assert_eq!(result.filled_order_ids().len(), 0);
         assert_eq!(price_level.visible_quantity(), 40);
@@ -1524,7 +1524,7 @@ mod tests {
         );
 
         assert!(result.is_complete());
-        assert_eq!(result.remaining_quantity(), 0);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
         assert_eq!(result.trades().len(), 1);
         assert_eq!(result.filled_order_ids().len(), 1);
         assert_eq!(result.filled_order_ids()[0], Id::from_u64(1));
@@ -1558,7 +1558,7 @@ mod tests {
 
         // Pass-through: maker fully consumed, 50 left over on the taker.
         assert!(!result.is_complete());
-        assert_eq!(result.remaining_quantity(), 50);
+        assert_eq!(result.remaining_quantity().as_u64(), 50);
         assert_eq!(result.trades().len(), 1);
         assert_eq!(result.trades().as_vec()[0].quantity(), Quantity::new(100));
         assert_eq!(result.filled_order_ids().len(), 1);
@@ -1585,7 +1585,7 @@ mod tests {
         );
 
         assert!(!result.is_complete());
-        assert_eq!(result.remaining_quantity(), 75);
+        assert_eq!(result.remaining_quantity().as_u64(), 75);
         assert_eq!(result.trades().len(), 0);
         assert_eq!(result.filled_order_ids().len(), 0);
     }
@@ -1612,7 +1612,7 @@ mod tests {
         );
 
         assert!(result.is_complete());
-        assert_eq!(result.remaining_quantity(), 0);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
         assert_eq!(result.trades().len(), 1);
         assert_eq!(result.filled_order_ids().len(), 0);
         assert_eq!(price_level.visible_quantity(), 60);
@@ -1641,7 +1641,7 @@ mod tests {
         );
 
         assert!(result.is_complete());
-        assert_eq!(result.remaining_quantity(), 0);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
         assert_eq!(result.trades().len(), 1);
         assert_eq!(result.filled_order_ids().len(), 1);
         assert_eq!(result.filled_order_ids()[0], Id::from_u64(1));
@@ -1672,7 +1672,7 @@ mod tests {
         );
 
         assert!(!result.is_complete());
-        assert_eq!(result.remaining_quantity(), 40);
+        assert_eq!(result.remaining_quantity().as_u64(), 40);
         assert_eq!(result.trades().len(), 1);
         assert_eq!(result.trades().as_vec()[0].quantity(), Quantity::new(80));
         assert_eq!(result.filled_order_ids().len(), 1);
@@ -1698,7 +1698,7 @@ mod tests {
         );
 
         assert!(!result.is_complete());
-        assert_eq!(result.remaining_quantity(), 55);
+        assert_eq!(result.remaining_quantity().as_u64(), 55);
         assert_eq!(result.trades().len(), 0);
         assert_eq!(result.filled_order_ids().len(), 0);
     }
@@ -1725,7 +1725,7 @@ mod tests {
         );
 
         assert!(result.is_complete());
-        assert_eq!(result.remaining_quantity(), 0);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
         assert_eq!(result.trades().len(), 1);
         assert_eq!(result.filled_order_ids().len(), 0);
         assert_eq!(price_level.visible_quantity(), 50);
@@ -1753,7 +1753,7 @@ mod tests {
         );
 
         assert!(result.is_complete());
-        assert_eq!(result.remaining_quantity(), 0);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
         assert_eq!(result.trades().len(), 1);
         assert_eq!(result.filled_order_ids().len(), 1);
         assert_eq!(result.filled_order_ids()[0], Id::from_u64(1));
@@ -1783,7 +1783,7 @@ mod tests {
         );
 
         assert!(!result.is_complete());
-        assert_eq!(result.remaining_quantity(), 40);
+        assert_eq!(result.remaining_quantity().as_u64(), 40);
         assert_eq!(result.trades().len(), 1);
         assert_eq!(result.trades().as_vec()[0].quantity(), Quantity::new(90));
         // Pass-through fills at the level price, NOT a pegged reference price.
@@ -1811,7 +1811,7 @@ mod tests {
         );
 
         assert!(!result.is_complete());
-        assert_eq!(result.remaining_quantity(), 33);
+        assert_eq!(result.remaining_quantity().as_u64(), 33);
         assert_eq!(result.trades().len(), 0);
         assert_eq!(result.filled_order_ids().len(), 0);
     }
@@ -1838,7 +1838,7 @@ mod tests {
         );
 
         assert!(result.is_complete());
-        assert_eq!(result.remaining_quantity(), 0);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
         assert_eq!(result.trades().len(), 1);
         assert_eq!(result.filled_order_ids().len(), 0);
         assert_eq!(price_level.visible_quantity(), 30);
@@ -1866,7 +1866,7 @@ mod tests {
         );
 
         assert!(result.is_complete());
-        assert_eq!(result.remaining_quantity(), 0);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
         assert_eq!(result.trades().len(), 1);
         assert_eq!(result.filled_order_ids().len(), 1);
         assert_eq!(result.filled_order_ids()[0], Id::from_u64(1));
@@ -1897,7 +1897,7 @@ mod tests {
         );
 
         assert!(!result.is_complete());
-        assert_eq!(result.remaining_quantity(), 40);
+        assert_eq!(result.remaining_quantity().as_u64(), 40);
         assert_eq!(result.trades().len(), 1);
         assert_eq!(result.trades().as_vec()[0].quantity(), Quantity::new(60));
         assert_eq!(result.filled_order_ids().len(), 1);
@@ -1923,7 +1923,7 @@ mod tests {
         );
 
         assert!(!result.is_complete());
-        assert_eq!(result.remaining_quantity(), 90);
+        assert_eq!(result.remaining_quantity().as_u64(), 90);
         assert_eq!(result.trades().len(), 0);
         assert_eq!(result.filled_order_ids().len(), 0);
     }
@@ -1958,10 +1958,10 @@ mod tests {
         assert_eq!(result.trades().len(), 0);
         assert_eq!(result.filled_order_ids().len(), 0);
         // remaining == 0 and is_complete agree (vacuously complete).
-        assert_eq!(result.remaining_quantity(), 0);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
         assert!(result.is_complete());
         // executed_quantity is 0 and matches the (empty) trade sum.
-        assert!(matches!(result.executed_quantity(), Ok(0)));
+        assert!(matches!(result.executed_quantity(), Ok(q) if q.as_u64() == 0));
         // Resting depth untouched: both makers still rest at full size.
         assert_eq!(price_level.order_count(), 2);
         assert_eq!(price_level.visible_quantity(), 150);
@@ -1987,7 +1987,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(match_result.outcome(), MatchOutcome::Filled);
         assert!(!match_result.was_killed());
@@ -2015,7 +2015,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(match_result.outcome(), MatchOutcome::Filled);
         // The maker keeps the unmatched 50 resting; the IOC taker is never
@@ -2059,8 +2059,8 @@ mod tests {
         assert!(result.is_complete());
         assert_eq!(result.outcome(), MatchOutcome::Filled);
         assert!(!result.was_killed());
-        assert_eq!(result.remaining_quantity(), 0);
-        assert_eq!(result.executed_quantity().expect("ok"), 100);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
+        assert_eq!(result.executed_quantity().expect("ok").as_u64(), 100);
         assert_eq!(result.filled_order_ids().len(), 2);
         assert_eq!(price_level.order_count(), 0);
         assert_eq!(price_level.visible_quantity(), 0);
@@ -2087,10 +2087,10 @@ mod tests {
         assert!(!result.is_complete());
         assert!(result.was_killed());
         assert_eq!(result.outcome(), MatchOutcome::Killed);
-        assert_eq!(result.remaining_quantity(), 101);
+        assert_eq!(result.remaining_quantity().as_u64(), 101);
         assert_eq!(result.trades().len(), 0);
         assert_eq!(result.filled_order_ids().len(), 0);
-        assert_eq!(result.executed_quantity().expect("ok"), 0);
+        assert_eq!(result.executed_quantity().expect("ok").as_u64(), 0);
         // No partial state: the resting depth is fully intact.
         assert_eq!(price_level.order_count(), 2);
         assert_eq!(price_level.visible_quantity(), 100);
@@ -2113,7 +2113,7 @@ mod tests {
 
         assert!(result.was_killed());
         assert_eq!(result.outcome(), MatchOutcome::Killed);
-        assert_eq!(result.remaining_quantity(), 10);
+        assert_eq!(result.remaining_quantity().as_u64(), 10);
         assert_eq!(result.trades().len(), 0);
     }
 
@@ -2137,7 +2137,7 @@ mod tests {
 
         assert!(result.is_complete());
         assert_eq!(result.outcome(), MatchOutcome::Filled);
-        assert_eq!(result.executed_quantity().expect("ok"), 50);
+        assert_eq!(result.executed_quantity().expect("ok").as_u64(), 50);
         assert_eq!(price_level.order_count(), 0);
     }
 
@@ -2165,8 +2165,8 @@ mod tests {
         assert_eq!(result.outcome(), MatchOutcome::PartiallyFilled);
         assert!(!result.was_killed());
         assert!(!result.was_rejected());
-        assert_eq!(result.executed_quantity().expect("ok"), 100);
-        assert_eq!(result.remaining_quantity(), 50);
+        assert_eq!(result.executed_quantity().expect("ok").as_u64(), 100);
+        assert_eq!(result.remaining_quantity().as_u64(), 50);
         assert_eq!(result.filled_order_ids().len(), 2);
         assert_eq!(price_level.order_count(), 0);
         assert_eq!(price_level.visible_quantity(), 0);
@@ -2194,10 +2194,10 @@ mod tests {
         assert!(result.was_rejected());
         assert_eq!(result.outcome(), MatchOutcome::Rejected);
         assert!(!result.is_complete());
-        assert_eq!(result.remaining_quantity(), 60);
+        assert_eq!(result.remaining_quantity().as_u64(), 60);
         assert_eq!(result.trades().len(), 0);
         assert_eq!(result.filled_order_ids().len(), 0);
-        assert_eq!(result.executed_quantity().expect("ok"), 0);
+        assert_eq!(result.executed_quantity().expect("ok").as_u64(), 0);
         // Resting maker untouched.
         assert_eq!(price_level.order_count(), 1);
         assert_eq!(price_level.visible_quantity(), 100);
@@ -2222,7 +2222,7 @@ mod tests {
         assert!(!result.was_rejected());
         assert_eq!(result.outcome(), MatchOutcome::NotFilled);
         assert!(!result.is_complete());
-        assert_eq!(result.remaining_quantity(), 60);
+        assert_eq!(result.remaining_quantity().as_u64(), 60);
         assert_eq!(result.trades().len(), 0);
     }
 
@@ -2246,7 +2246,7 @@ mod tests {
         assert!(!result.was_rejected());
         assert!(result.is_complete());
         assert_eq!(result.outcome(), MatchOutcome::Filled);
-        assert_eq!(result.remaining_quantity(), 0);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
         assert_eq!(price_level.order_count(), 1);
         assert_eq!(price_level.visible_quantity(), 100);
     }
@@ -2274,8 +2274,8 @@ mod tests {
         assert_eq!(result.outcome(), MatchOutcome::PartiallyFilled);
         assert!(!result.was_killed());
         assert!(!result.was_rejected());
-        assert_eq!(result.executed_quantity().expect("ok"), 100);
-        assert_eq!(result.remaining_quantity(), 40);
+        assert_eq!(result.executed_quantity().expect("ok").as_u64(), 100);
+        assert_eq!(result.remaining_quantity().as_u64(), 40);
         assert_eq!(result.filled_order_ids().len(), 1);
         assert_eq!(price_level.order_count(), 0);
     }
@@ -2298,8 +2298,8 @@ mod tests {
 
         assert!(result.is_complete());
         assert_eq!(result.outcome(), MatchOutcome::Filled);
-        assert_eq!(result.remaining_quantity(), 0);
-        assert_eq!(result.executed_quantity().expect("ok"), 100);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
+        assert_eq!(result.executed_quantity().expect("ok").as_u64(), 100);
     }
 
     // ----- resting FOK / IOC makers are consumed like any other liquidity -----
@@ -2367,7 +2367,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.order_count(), 0);
@@ -2409,10 +2409,16 @@ mod tests {
         );
 
         // All available depth filled (100 of 150); 50 reported as remainder.
-        assert_eq!(result.executed_quantity().expect("real output is Ok"), 100);
-        assert_eq!(result.remaining_quantity(), 50);
+        assert_eq!(
+            result
+                .executed_quantity()
+                .expect("real output is Ok")
+                .as_u64(),
+            100
+        );
+        assert_eq!(result.remaining_quantity().as_u64(), 50);
         assert!(
-            result.remaining_quantity() > 0,
+            result.remaining_quantity().as_u64() > 0,
             "taker remainder must be strictly positive"
         );
         assert!(
@@ -2476,7 +2482,7 @@ mod tests {
             &trade_id_generator,
         );
 
-        assert_eq!(result.remaining_quantity(), 0);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
         assert!(result.is_complete());
         assert_eq!(result.trades().len(), 1);
         assert_eq!(price_level.visible_quantity(), 0);
@@ -2509,7 +2515,7 @@ mod tests {
 
         // Verificar el resultado de matching
         assert_eq!(match_result.order_id(), taker_id);
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 10); // 25 - (140 - 50 - 75) = 10
         assert_eq!(price_level.order_count(), 1);
@@ -2538,8 +2544,8 @@ mod tests {
         let orders = price_level.snapshot_orders();
         assert_eq!(orders.len(), 1);
         assert_eq!(orders[0].id(), Id::from_u64(3));
-        assert_eq!(orders[0].visible_quantity(), 10);
-        assert_eq!(orders[0].hidden_quantity(), 0);
+        assert_eq!(orders[0].visible_quantity().as_u64(), 10);
+        assert_eq!(orders[0].hidden_quantity().as_u64(), 0);
     }
 
     #[test]
@@ -2554,9 +2560,9 @@ mod tests {
         let snapshot = price_level.snapshot();
 
         // Verify snapshot data
-        assert_eq!(snapshot.price(), 10000);
-        assert_eq!(snapshot.visible_quantity(), 150); // 100 + 50
-        assert_eq!(snapshot.hidden_quantity(), 0);
+        assert_eq!(snapshot.price().as_u128(), 10000);
+        assert_eq!(snapshot.visible_quantity().as_u64(), 150); // 100 + 50
+        assert_eq!(snapshot.hidden_quantity().as_u64(), 0);
         assert_eq!(snapshot.order_count(), 2);
         assert_eq!(snapshot.orders().len(), 2);
 
@@ -2634,7 +2640,7 @@ mod tests {
         assert!(result.is_ok());
         let updated_order = result.unwrap();
         assert!(updated_order.is_some());
-        assert_eq!(updated_order.unwrap().visible_quantity(), 150);
+        assert_eq!(updated_order.unwrap().visible_quantity().as_u64(), 150);
 
         // The price level should reflect the new quantity
         assert_eq!(price_level.visible_quantity(), 150);
@@ -2652,7 +2658,7 @@ mod tests {
         assert!(result.is_ok());
         let updated_order = result.unwrap();
         assert!(updated_order.is_some());
-        assert_eq!(updated_order.unwrap().visible_quantity(), 50);
+        assert_eq!(updated_order.unwrap().visible_quantity().as_u64(), 50);
 
         // The price level should reflect the new quantity
         assert_eq!(price_level.visible_quantity(), 50);
@@ -2686,7 +2692,7 @@ mod tests {
         assert!(result.is_ok());
         let updated = result.unwrap();
         assert!(updated.is_some());
-        assert_eq!(updated.unwrap().visible_quantity(), 40);
+        assert_eq!(updated.unwrap().visible_quantity().as_u64(), 40);
 
         // Match a quantity that only consumes the first resting order. A (id 1)
         // must be hit before B (id 2).
@@ -2727,7 +2733,7 @@ mod tests {
         assert!(result.is_ok());
         let updated = result.unwrap();
         assert!(updated.is_some());
-        assert_eq!(updated.unwrap().visible_quantity(), 150);
+        assert_eq!(updated.unwrap().visible_quantity().as_u64(), 150);
 
         // A subsequent match that only consumes the first resting order must
         // now hit B (id 2) before the resized A (id 1).
@@ -2785,8 +2791,8 @@ mod tests {
 
         // Atomic counters must equal the sum over the live queue contents.
         let snapshot = price_level.snapshot_orders();
-        let expected_visible: u64 = snapshot.iter().map(|o| o.visible_quantity()).sum();
-        let expected_hidden: u64 = snapshot.iter().map(|o| o.hidden_quantity()).sum();
+        let expected_visible: u64 = snapshot.iter().map(|o| o.visible_quantity().as_u64()).sum();
+        let expected_hidden: u64 = snapshot.iter().map(|o| o.hidden_quantity().as_u64()).sum();
 
         assert_eq!(price_level.order_count(), snapshot.len());
         assert_eq!(price_level.visible_quantity(), expected_visible);
@@ -2842,7 +2848,7 @@ mod tests {
         assert!(result.is_ok());
         let updated_order = result.unwrap();
         assert!(updated_order.is_some());
-        assert_eq!(updated_order.unwrap().visible_quantity(), 150);
+        assert_eq!(updated_order.unwrap().visible_quantity().as_u64(), 150);
 
         // The price level should reflect the new quantity
         assert_eq!(price_level.visible_quantity(), 150);
@@ -2894,7 +2900,7 @@ mod tests {
         assert!(result.is_ok());
         let updated_order = result.unwrap();
         assert!(updated_order.is_some());
-        assert_eq!(updated_order.unwrap().visible_quantity(), 150);
+        assert_eq!(updated_order.unwrap().visible_quantity().as_u64(), 150);
 
         // The price level should reflect the new quantity
         assert_eq!(price_level.visible_quantity(), 150);
@@ -3011,7 +3017,7 @@ mod tests {
         assert_eq!(orders.len(), 5);
         assert_eq!(orders[0].id(), Id::from_u64(1));
         assert_eq!(orders[0].price(), Price::new(10000));
-        assert_eq!(orders[0].visible_quantity(), 50);
+        assert_eq!(orders[0].visible_quantity().as_u64(), 50);
     }
 
     // Test serialization and deserialization for PriceLevel
@@ -3044,7 +3050,7 @@ mod tests {
         assert_eq!(orders.len(), 1);
         assert_eq!(orders[0].id(), Id::from_u64(1));
         assert_eq!(orders[0].price(), Price::new(10000));
-        assert_eq!(orders[0].visible_quantity(), 100);
+        assert_eq!(orders[0].visible_quantity().as_u64(), 100);
     }
 
     // `PriceLevelData` is a plain input/transfer DTO: with `deny_unknown_fields`
@@ -3122,7 +3128,7 @@ mod tests {
             &transaction_id_generator,
         );
 
-        assert_eq!(match_result.remaining_quantity(), 0);
+        assert_eq!(match_result.remaining_quantity().as_u64(), 0);
         assert!(match_result.is_complete());
         assert_eq!(price_level.visible_quantity(), 100); // 200 - 100 = 100
         assert_eq!(price_level.order_count(), 1);
@@ -3163,7 +3169,7 @@ mod tests {
 
         assert!(result.is_ok());
         let updated_order = result.unwrap().unwrap();
-        assert_eq!(updated_order.visible_quantity(), 150);
+        assert_eq!(updated_order.visible_quantity().as_u64(), 150);
         assert_eq!(price_level.visible_quantity(), 150);
         assert_eq!(price_level.order_count(), 1);
     }
@@ -3672,16 +3678,22 @@ mod tests {
     fn assert_snapshot_internally_consistent(snapshot: &crate::price_level::PriceLevelSnapshot) {
         let orders = snapshot.orders();
 
-        let visible_sum: u64 = orders.iter().map(|order| order.visible_quantity()).sum();
-        let hidden_sum: u64 = orders.iter().map(|order| order.hidden_quantity()).sum();
+        let visible_sum: u64 = orders
+            .iter()
+            .map(|order| order.visible_quantity().as_u64())
+            .sum();
+        let hidden_sum: u64 = orders
+            .iter()
+            .map(|order| order.hidden_quantity().as_u64())
+            .sum();
 
         assert_eq!(
-            snapshot.visible_quantity(),
+            snapshot.visible_quantity().as_u64(),
             visible_sum,
             "snapshot visible_quantity must equal the sum over its own orders"
         );
         assert_eq!(
-            snapshot.hidden_quantity(),
+            snapshot.hidden_quantity().as_u64(),
             hidden_sum,
             "snapshot hidden_quantity must equal the sum over its own orders"
         );
@@ -3812,7 +3824,7 @@ mod tests {
         // is_complete <=> remaining_quantity == 0
         assert_eq!(
             result.is_complete(),
-            result.remaining_quantity() == 0,
+            result.remaining_quantity().as_u64() == 0,
             "is_complete must agree with remaining_quantity == 0"
         );
 
@@ -3826,7 +3838,7 @@ mod tests {
             .try_fold(0u64, |acc, t| acc.checked_add(t.quantity().as_u64()))
             .expect("summing trade quantities must not overflow u64");
         let executed_qty = match result.executed_quantity() {
-            Ok(q) => q,
+            Ok(q) => q.as_u64(),
             Err(e) => panic!("executed_quantity must not error on real output: {e}"),
         };
         assert_eq!(
@@ -3933,7 +3945,7 @@ mod tests {
 
         // The taker (40) is exhausted against the maker (100): complete.
         assert!(result.is_complete());
-        assert_eq!(result.remaining_quantity(), 0);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
         assert_eq!(result.trades().len(), 1);
         // The maker is only partially filled and remains resting.
         assert_eq!(result.filled_order_ids().len(), 0);
@@ -3962,7 +3974,7 @@ mod tests {
         );
 
         assert!(result.is_complete());
-        assert_eq!(result.remaining_quantity(), 0);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
         assert_eq!(result.trades().len(), 2);
         assert_eq!(result.filled_order_ids().len(), 2);
         assert_match_result_consistent(&result, 10000, Side::Buy);
@@ -3989,7 +4001,7 @@ mod tests {
         );
 
         assert!(!result.is_complete());
-        assert_eq!(result.remaining_quantity(), 40);
+        assert_eq!(result.remaining_quantity().as_u64(), 40);
         assert_eq!(result.trades().len(), 2);
         assert_eq!(result.filled_order_ids().len(), 2);
         assert_eq!(price_level.order_count(), 0);
@@ -4018,7 +4030,7 @@ mod tests {
         );
 
         assert!(result.is_complete());
-        assert_eq!(result.remaining_quantity(), 0);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
         assert_eq!(result.trades().len(), 3);
         assert_eq!(result.filled_order_ids().len(), 2);
         assert_match_result_consistent(&result, 10000, Side::Buy);
@@ -4042,7 +4054,7 @@ mod tests {
         );
 
         assert!(!result.is_complete());
-        assert_eq!(result.remaining_quantity(), 50);
+        assert_eq!(result.remaining_quantity().as_u64(), 50);
         assert_eq!(result.trades().len(), 0);
         assert_eq!(result.filled_order_ids().len(), 0);
         assert_match_result_consistent(&result, 10000, Side::Buy);
@@ -4072,7 +4084,7 @@ mod tests {
         );
 
         assert!(result.is_complete());
-        assert_eq!(result.remaining_quantity(), 0);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
         assert!(!result.trades().as_vec().is_empty());
         assert_eq!(result.filled_order_ids().len(), 0);
         assert_match_result_consistent(&result, 10000, Side::Sell);
@@ -4100,7 +4112,7 @@ mod tests {
         );
 
         assert!(result.is_complete());
-        assert_eq!(result.remaining_quantity(), 0);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
         assert!(!result.trades().as_vec().is_empty());
         assert_match_result_consistent(&result, 10000, Side::Sell);
     }
@@ -4215,8 +4227,14 @@ mod tests {
         );
 
         assert!(result.is_complete());
-        assert_eq!(result.remaining_quantity(), 0);
-        assert_eq!(result.executed_quantity().expect("executed_quantity"), 70);
+        assert_eq!(result.remaining_quantity().as_u64(), 0);
+        assert_eq!(
+            result
+                .executed_quantity()
+                .expect("executed_quantity")
+                .as_u64(),
+            70
+        );
         // Both makers are fully consumed and removed.
         assert_eq!(price_level.order_count(), 0);
         assert_eq!(price_level.visible_quantity(), 0);
@@ -4246,7 +4264,13 @@ mod tests {
         assert!(result.is_complete());
         assert_eq!(result.outcome(), MatchOutcome::Filled);
         assert!(!result.was_killed());
-        assert_eq!(result.executed_quantity().expect("executed_quantity"), 70);
+        assert_eq!(
+            result
+                .executed_quantity()
+                .expect("executed_quantity")
+                .as_u64(),
+            70
+        );
         assert_eq!(price_level.order_count(), 0);
         assert_match_result_consistent(&result, 10000, Side::Sell);
     }
@@ -4271,7 +4295,7 @@ mod tests {
 
         assert!(result.was_killed());
         assert_eq!(result.outcome(), MatchOutcome::Killed);
-        assert_eq!(result.remaining_quantity(), 71);
+        assert_eq!(result.remaining_quantity().as_u64(), 71);
         assert_eq!(result.trades().len(), 0);
         // Queue untouched.
         assert_eq!(price_level.order_count(), 2);
@@ -4297,8 +4321,14 @@ mod tests {
             &trade_gen,
         );
 
-        assert_eq!(result.executed_quantity().expect("executed_quantity"), 70);
-        assert_eq!(result.remaining_quantity(), 130);
+        assert_eq!(
+            result
+                .executed_quantity()
+                .expect("executed_quantity")
+                .as_u64(),
+            70
+        );
+        assert_eq!(result.remaining_quantity().as_u64(), 130);
         assert!(!result.is_complete());
         assert_eq!(price_level.order_count(), 0);
         assert_eq!(price_level.visible_quantity(), 0);
@@ -4327,7 +4357,7 @@ mod tests {
 
         assert!(result.was_rejected());
         assert_eq!(result.outcome(), MatchOutcome::Rejected);
-        assert_eq!(result.remaining_quantity(), 10);
+        assert_eq!(result.remaining_quantity().as_u64(), 10);
         assert_eq!(result.trades().len(), 0);
         // Queue untouched by the rejection.
         assert_eq!(price_level.order_count(), 2);
@@ -4367,7 +4397,13 @@ mod tests {
             &trade_gen,
         );
         assert!(filled.is_complete());
-        assert_eq!(filled.executed_quantity().expect("executed_quantity"), 25);
+        assert_eq!(
+            filled
+                .executed_quantity()
+                .expect("executed_quantity")
+                .as_u64(),
+            25
+        );
         assert_eq!(price_level.order_count(), 0);
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.hidden_quantity(), 0);
@@ -4400,8 +4436,14 @@ mod tests {
 
         // 40 from the standard maker + 50 from the reserve (drained tranche by
         // tranche). Total available depth is 90.
-        assert_eq!(result.executed_quantity().expect("executed_quantity"), 90);
-        assert_eq!(result.remaining_quantity(), 110);
+        assert_eq!(
+            result
+                .executed_quantity()
+                .expect("executed_quantity")
+                .as_u64(),
+            90
+        );
+        assert_eq!(result.remaining_quantity().as_u64(), 110);
         assert_eq!(price_level.order_count(), 0);
         assert_eq!(price_level.visible_quantity(), 0);
         assert_eq!(price_level.hidden_quantity(), 0);
@@ -4429,7 +4471,13 @@ mod tests {
         assert!(result.is_complete());
         assert_eq!(result.outcome(), MatchOutcome::Filled);
         assert!(!result.was_killed());
-        assert_eq!(result.executed_quantity().expect("executed_quantity"), 90);
+        assert_eq!(
+            result
+                .executed_quantity()
+                .expect("executed_quantity")
+                .as_u64(),
+            90
+        );
         assert_eq!(price_level.order_count(), 0);
         assert_match_result_consistent(&result, 10000, Side::Sell);
 
@@ -4479,8 +4527,14 @@ mod tests {
 
         // Only the standard maker (40) is matchable; the non-replenishing,
         // zero-visible reserve is dropped without a trade.
-        assert_eq!(result.executed_quantity().expect("executed_quantity"), 40);
-        assert_eq!(result.remaining_quantity(), 60);
+        assert_eq!(
+            result
+                .executed_quantity()
+                .expect("executed_quantity")
+                .as_u64(),
+            40
+        );
+        assert_eq!(result.remaining_quantity().as_u64(), 60);
         // Both orders are gone from the queue (one filled, one dropped) and the
         // counters are consistent: hidden of the dropped reserve was removed.
         assert_eq!(price_level.order_count(), 0);
@@ -4511,7 +4565,7 @@ mod tests {
             &fok_gen,
         );
         assert!(fok.was_killed());
-        assert_eq!(fok.remaining_quantity(), 5);
+        assert_eq!(fok.remaining_quantity().as_u64(), 5);
         // FOK is a pre-check: the dead reserve is left resting, queue intact.
         assert_eq!(fok_level.order_count(), 1);
         assert_eq!(fok_level.hidden_quantity(), 50);
@@ -4534,7 +4588,13 @@ mod tests {
         );
         assert!(!post_only.was_rejected());
         assert_eq!(post_only.trades().len(), 0);
-        assert_eq!(post_only.executed_quantity().expect("executed_quantity"), 0);
+        assert_eq!(
+            post_only
+                .executed_quantity()
+                .expect("executed_quantity")
+                .as_u64(),
+            0
+        );
         // The non-matchable reserve is dropped by the fall-through sweep; the
         // hidden counter is decremented in lockstep with the queue removal.
         assert_eq!(po_level.order_count(), 0);
@@ -4574,7 +4634,13 @@ mod tests {
 
         // The standard maker (40) is matched regardless of how the zeroed
         // iceberg is resolved; the call terminates and counters stay consistent.
-        assert!(result.executed_quantity().expect("executed_quantity") >= 40);
+        assert!(
+            result
+                .executed_quantity()
+                .expect("executed_quantity")
+                .as_u64()
+                >= 40
+        );
         assert_eq!(price_level.visible_quantity(), 0);
         assert_match_result_consistent(&result, 10000, Side::Sell);
 

--- a/src/price_level/tests/order_queue.rs
+++ b/src/price_level/tests/order_queue.rs
@@ -75,10 +75,14 @@ mod tests {
 
         // Verify individual orders (order might not be preserved)
         let has_order1 = orders.iter().any(|o| {
-            o.id() == Id::from_u64(1) && o.price() == Price::new(1000) && o.visible_quantity() == 10
+            o.id() == Id::from_u64(1)
+                && o.price() == Price::new(1000)
+                && o.visible_quantity() == Quantity::new(10)
         });
         let has_order2 = orders.iter().any(|o| {
-            o.id() == Id::from_u64(2) && o.price() == Price::new(1100) && o.visible_quantity() == 20
+            o.id() == Id::from_u64(2)
+                && o.price() == Price::new(1100)
+                && o.visible_quantity() == Quantity::new(20)
         });
 
         assert!(has_order1, "First order not found or incorrect");
@@ -95,10 +99,14 @@ mod tests {
         );
 
         let round_trip_has_order1 = round_trip_orders.iter().any(|o| {
-            o.id() == Id::from_u64(1) && o.price() == Price::new(1000) && o.visible_quantity() == 10
+            o.id() == Id::from_u64(1)
+                && o.price() == Price::new(1000)
+                && o.visible_quantity() == Quantity::new(10)
         });
         let round_trip_has_order2 = round_trip_orders.iter().any(|o| {
-            o.id() == Id::from_u64(2) && o.price() == Price::new(1100) && o.visible_quantity() == 20
+            o.id() == Id::from_u64(2)
+                && o.price() == Price::new(1100)
+                && o.visible_quantity() == Quantity::new(20)
         });
 
         assert!(

--- a/src/price_level/tests/snapshot.rs
+++ b/src/price_level/tests/snapshot.rs
@@ -37,7 +37,7 @@ mod tests {
 
     #[test]
     fn test_snapshot_package_roundtrip() {
-        let snapshot = PriceLevelSnapshot::with_orders(42, create_sample_orders())
+        let snapshot = PriceLevelSnapshot::with_orders(Price::new(42), create_sample_orders())
             .expect("Failed to create snapshot with orders");
 
         let package =
@@ -58,22 +58,25 @@ mod tests {
             .into_snapshot()
             .expect("Snapshot extraction failed");
 
-        assert_eq!(restored_snapshot.price(), snapshot.price());
+        assert_eq!(
+            restored_snapshot.price().as_u128(),
+            snapshot.price().as_u128()
+        );
         assert_eq!(restored_snapshot.order_count(), snapshot.order_count());
         assert_eq!(
-            restored_snapshot.visible_quantity(),
-            snapshot.visible_quantity()
+            restored_snapshot.visible_quantity().as_u64(),
+            snapshot.visible_quantity().as_u64()
         );
         assert_eq!(
-            restored_snapshot.hidden_quantity(),
-            snapshot.hidden_quantity()
+            restored_snapshot.hidden_quantity().as_u64(),
+            snapshot.hidden_quantity().as_u64()
         );
         assert_eq!(restored_snapshot.orders().len(), snapshot.orders().len());
     }
 
     #[test]
     fn test_snapshot_package_checksum_mismatch() {
-        let snapshot = PriceLevelSnapshot::with_orders(99, create_sample_orders())
+        let snapshot = PriceLevelSnapshot::with_orders(Price::new(99), create_sample_orders())
             .expect("Failed to create snapshot with orders");
 
         let package = PriceLevelSnapshotPackage::new(snapshot).expect("Failed to create package");
@@ -117,8 +120,12 @@ mod tests {
             .record_execution(3, 1000, 2000, 5000)
             .expect("record_execution should succeed");
 
-        let snapshot = PriceLevelSnapshot::with_orders_and_stats(42, create_sample_orders(), stats)
-            .expect("Failed to create snapshot with stats");
+        let snapshot = PriceLevelSnapshot::with_orders_and_stats(
+            Price::new(42),
+            create_sample_orders(),
+            stats,
+        )
+        .expect("Failed to create snapshot with stats");
 
         let original = snapshot.statistics();
         let original_orders_added = original.orders_added();
@@ -156,7 +163,7 @@ mod tests {
         // A package carrying the previous format version must be rejected by
         // `validate()` with a version mismatch (InvalidOperation) rather than a
         // confusing checksum error, and never a panic.
-        let snapshot = PriceLevelSnapshot::with_orders(99, create_sample_orders())
+        let snapshot = PriceLevelSnapshot::with_orders(Price::new(99), create_sample_orders())
             .expect("Failed to create snapshot with orders");
         let package = PriceLevelSnapshotPackage::new(snapshot).expect("Failed to create package");
 
@@ -195,10 +202,10 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let snapshot = PriceLevelSnapshot::new(1000);
-        assert_eq!(snapshot.price(), 1000);
-        assert_eq!(snapshot.visible_quantity(), 0);
-        assert_eq!(snapshot.hidden_quantity(), 0);
+        let snapshot = PriceLevelSnapshot::new(Price::new(1000));
+        assert_eq!(snapshot.price().as_u128(), 1000);
+        assert_eq!(snapshot.visible_quantity().as_u64(), 0);
+        assert_eq!(snapshot.hidden_quantity().as_u64(), 0);
         assert_eq!(snapshot.order_count(), 0);
         assert!(snapshot.orders().is_empty());
     }
@@ -206,24 +213,36 @@ mod tests {
     #[test]
     fn test_default() {
         let snapshot = PriceLevelSnapshot::default();
-        assert_eq!(snapshot.price(), 0);
-        assert_eq!(snapshot.visible_quantity(), 0);
-        assert_eq!(snapshot.hidden_quantity(), 0);
+        assert_eq!(snapshot.price().as_u128(), 0);
+        assert_eq!(snapshot.visible_quantity().as_u64(), 0);
+        assert_eq!(snapshot.hidden_quantity().as_u64(), 0);
         assert_eq!(snapshot.order_count(), 0);
         assert!(snapshot.orders().is_empty());
     }
 
     #[test]
     fn test_total_quantity() {
-        let snapshot = PriceLevelSnapshot::from_raw_parts(1000, 50, 150, 0, Vec::new());
-        assert!(matches!(snapshot.total_quantity(), Ok(200)));
+        let snapshot = PriceLevelSnapshot::from_raw_parts(
+            Price::new(1000),
+            Quantity::new(50),
+            Quantity::new(150),
+            0,
+            Vec::new(),
+        );
+        assert!(matches!(snapshot.total_quantity(), Ok(q) if q.as_u64() == 200));
     }
 
     #[test]
     fn test_iter_orders() {
         let orders = create_sample_orders();
         let order_count = orders.len();
-        let snapshot = PriceLevelSnapshot::from_raw_parts(1000, 0, 0, order_count, orders);
+        let snapshot = PriceLevelSnapshot::from_raw_parts(
+            Price::new(1000),
+            Quantity::new(0),
+            Quantity::new(0),
+            order_count,
+            orders,
+        );
 
         let collected: Vec<_> = snapshot.iter_orders().collect();
         assert_eq!(collected.len(), 2);
@@ -245,19 +264,31 @@ mod tests {
 
     #[test]
     fn test_clone() {
-        let original = PriceLevelSnapshot::from_raw_parts(1000, 50, 150, 2, create_sample_orders());
+        let original = PriceLevelSnapshot::from_raw_parts(
+            Price::new(1000),
+            Quantity::new(50),
+            Quantity::new(150),
+            2,
+            create_sample_orders(),
+        );
 
         let cloned = original.clone();
-        assert_eq!(cloned.price(), 1000);
-        assert_eq!(cloned.visible_quantity(), 50);
-        assert_eq!(cloned.hidden_quantity(), 150);
+        assert_eq!(cloned.price().as_u128(), 1000);
+        assert_eq!(cloned.visible_quantity().as_u64(), 50);
+        assert_eq!(cloned.hidden_quantity().as_u64(), 150);
         assert_eq!(cloned.order_count(), 2);
         assert_eq!(cloned.orders().len(), 2);
     }
 
     #[test]
     fn test_display() {
-        let snapshot = PriceLevelSnapshot::from_raw_parts(1000, 50, 150, 2, Vec::new());
+        let snapshot = PriceLevelSnapshot::from_raw_parts(
+            Price::new(1000),
+            Quantity::new(50),
+            Quantity::new(150),
+            2,
+            Vec::new(),
+        );
 
         let display_str = snapshot.to_string();
         assert!(display_str.contains("price=1000"));
@@ -272,9 +303,9 @@ mod tests {
             "PriceLevelSnapshot:price=1000;visible_quantity=50;hidden_quantity=150;order_count=2";
         let snapshot = PriceLevelSnapshot::from_str(input).unwrap();
 
-        assert_eq!(snapshot.price(), 1000);
-        assert_eq!(snapshot.visible_quantity(), 50);
-        assert_eq!(snapshot.hidden_quantity(), 150);
+        assert_eq!(snapshot.price().as_u128(), 1000);
+        assert_eq!(snapshot.visible_quantity().as_u64(), 50);
+        assert_eq!(snapshot.hidden_quantity().as_u64(), 150);
         assert_eq!(snapshot.order_count(), 2);
         assert!(snapshot.orders().is_empty()); // Orders can't be parsed from string representation
     }
@@ -302,7 +333,13 @@ mod tests {
 
     #[test]
     fn test_roundtrip_display_fromstr() {
-        let original = PriceLevelSnapshot::from_raw_parts(1000, 50, 150, 2, Vec::new());
+        let original = PriceLevelSnapshot::from_raw_parts(
+            Price::new(1000),
+            Quantity::new(50),
+            Quantity::new(150),
+            2,
+            Vec::new(),
+        );
 
         let string_representation = original.to_string();
         let parsed = PriceLevelSnapshot::from_str(&string_representation).unwrap();
@@ -318,7 +355,13 @@ mod tests {
     #[test]
     fn test_snapshot_serialization_fields() {
         // Create a snapshot with specific field values
-        let snapshot = PriceLevelSnapshot::from_raw_parts(10000, 200, 300, 5, Vec::new());
+        let snapshot = PriceLevelSnapshot::from_raw_parts(
+            Price::new(10000),
+            Quantity::new(200),
+            Quantity::new(300),
+            5,
+            Vec::new(),
+        );
 
         // Add some orders (empty for now, we'll test orders separately)
 
@@ -367,9 +410,9 @@ mod tests {
 
         let snapshot: PriceLevelSnapshot = serde_json::from_str(json).unwrap();
 
-        assert_eq!(snapshot.price(), 10000);
-        assert_eq!(snapshot.visible_quantity(), 200);
-        assert_eq!(snapshot.hidden_quantity(), 300);
+        assert_eq!(snapshot.price().as_u128(), 10000);
+        assert_eq!(snapshot.visible_quantity().as_u64(), 200);
+        assert_eq!(snapshot.hidden_quantity().as_u64(), 300);
         assert_eq!(snapshot.order_count(), 5);
         assert!(snapshot.orders().is_empty());
     }
@@ -412,7 +455,13 @@ mod tests {
             Arc::new(create_standard_order(1, 10000u128, 100)),
             Arc::new(create_iceberg_order(2, 10000u128, 50, 250)),
         ];
-        let snapshot = PriceLevelSnapshot::from_raw_parts(10000, 150, 250, 2, orders);
+        let snapshot = PriceLevelSnapshot::from_raw_parts(
+            Price::new(10000),
+            Quantity::new(150),
+            Quantity::new(250),
+            2,
+            orders,
+        );
 
         // Serialize to JSON
         let serialized = serde_json::to_string(&snapshot).unwrap();
@@ -429,9 +478,9 @@ mod tests {
         // Deserialize back
         let deserialized: PriceLevelSnapshot = serde_json::from_str(&serialized).unwrap();
 
-        assert_eq!(deserialized.price(), 10000);
-        assert_eq!(deserialized.visible_quantity(), 150);
-        assert_eq!(deserialized.hidden_quantity(), 250);
+        assert_eq!(deserialized.price().as_u128(), 10000);
+        assert_eq!(deserialized.visible_quantity().as_u64(), 150);
+        assert_eq!(deserialized.hidden_quantity().as_u64(), 250);
         assert_eq!(deserialized.order_count(), 2);
         assert_eq!(deserialized.orders().len(), 2);
 
@@ -509,9 +558,9 @@ mod pricelevel_snapshot_serialization_tests {
     // Helper function to create a sample snapshot for testing
     fn create_sample_snapshot() -> PriceLevelSnapshot {
         PriceLevelSnapshot::from_raw_parts(
-            1000,
-            15, // 10 + 5 (first two orders)
-            15, // hidden quantity from iceberg order
+            Price::new(1000),
+            Quantity::new(15), // 10 + 5 (first two orders)
+            Quantity::new(15), // hidden quantity from iceberg order
             3,
             create_sample_orders(),
         )
@@ -556,9 +605,9 @@ mod pricelevel_snapshot_serialization_tests {
             .expect("Failed to deserialize PriceLevelSnapshot from JSON");
 
         // Verify basic fields
-        assert_eq!(deserialized.price(), 1000);
-        assert_eq!(deserialized.visible_quantity(), 15);
-        assert_eq!(deserialized.hidden_quantity(), 15);
+        assert_eq!(deserialized.price().as_u128(), 1000);
+        assert_eq!(deserialized.visible_quantity().as_u64(), 15);
+        assert_eq!(deserialized.hidden_quantity().as_u64(), 15);
         assert_eq!(deserialized.order_count(), 3);
 
         // Verify orders array length
@@ -640,9 +689,9 @@ mod pricelevel_snapshot_serialization_tests {
             PriceLevelSnapshot::from_str(input).expect("Failed to parse PriceLevelSnapshot");
 
         // Verify basic fields
-        assert_eq!(snapshot.price(), 1000);
-        assert_eq!(snapshot.visible_quantity(), 15);
-        assert_eq!(snapshot.hidden_quantity(), 15);
+        assert_eq!(snapshot.price().as_u128(), 1000);
+        assert_eq!(snapshot.visible_quantity().as_u64(), 15);
+        assert_eq!(snapshot.hidden_quantity().as_u64(), 15);
         assert_eq!(snapshot.order_count(), 3);
 
         // Orders array should be empty when deserialized from string format (per FromStr implementation)
@@ -683,7 +732,13 @@ mod pricelevel_snapshot_serialization_tests {
     #[test]
     fn test_snapshot_string_format_roundtrip() {
         // Create a snapshot with only basic fields (no orders)
-        let original = PriceLevelSnapshot::from_raw_parts(1000, 15, 15, 3, Vec::new());
+        let original = PriceLevelSnapshot::from_raw_parts(
+            Price::new(1000),
+            Quantity::new(15),
+            Quantity::new(15),
+            3,
+            Vec::new(),
+        );
 
         // Convert to string
         let string_representation = original.to_string();
@@ -702,22 +757,22 @@ mod pricelevel_snapshot_serialization_tests {
     #[test]
     fn test_snapshot_edge_cases() {
         // Test with zero values
-        let snapshot = PriceLevelSnapshot::new(0);
+        let snapshot = PriceLevelSnapshot::new(Price::new(0));
 
         let json = serde_json::to_string(&snapshot).expect("Failed to serialize");
         let deserialized: PriceLevelSnapshot =
             serde_json::from_str(&json).expect("Failed to deserialize");
 
-        assert_eq!(deserialized.price(), 0);
-        assert_eq!(deserialized.visible_quantity(), 0);
-        assert_eq!(deserialized.hidden_quantity(), 0);
+        assert_eq!(deserialized.price().as_u128(), 0);
+        assert_eq!(deserialized.visible_quantity().as_u64(), 0);
+        assert_eq!(deserialized.hidden_quantity().as_u64(), 0);
         assert_eq!(deserialized.order_count(), 0);
 
         // Test with maximum values
         let snapshot = PriceLevelSnapshot::from_raw_parts(
-            u128::MAX,
-            u64::MAX,
-            u64::MAX,
+            Price::new(u128::MAX),
+            Quantity::new(u64::MAX),
+            Quantity::new(u64::MAX),
             usize::MAX,
             Vec::new(),
         );
@@ -726,9 +781,9 @@ mod pricelevel_snapshot_serialization_tests {
         let deserialized: PriceLevelSnapshot =
             serde_json::from_str(&json).expect("Failed to deserialize max values");
 
-        assert_eq!(deserialized.price(), u128::MAX);
-        assert_eq!(deserialized.visible_quantity(), u64::MAX);
-        assert_eq!(deserialized.hidden_quantity(), u64::MAX);
+        assert_eq!(deserialized.price().as_u128(), u128::MAX);
+        assert_eq!(deserialized.visible_quantity().as_u64(), u64::MAX);
+        assert_eq!(deserialized.hidden_quantity().as_u64(), u64::MAX);
         assert_eq!(deserialized.order_count(), usize::MAX);
     }
 
@@ -767,13 +822,19 @@ mod pricelevel_snapshot_serialization_tests {
     #[test]
     fn test_snapshot_empty_orders() {
         // Test with an empty orders array
-        let snapshot = PriceLevelSnapshot::from_raw_parts(1000, 15, 15, 0, Vec::new());
+        let snapshot = PriceLevelSnapshot::from_raw_parts(
+            Price::new(1000),
+            Quantity::new(15),
+            Quantity::new(15),
+            0,
+            Vec::new(),
+        );
 
         let json = serde_json::to_string(&snapshot).expect("Failed to serialize");
         let deserialized: PriceLevelSnapshot =
             serde_json::from_str(&json).expect("Failed to deserialize");
 
-        assert_eq!(deserialized.price(), 1000);
+        assert_eq!(deserialized.price().as_u128(), 1000);
         assert_eq!(deserialized.orders().len(), 0);
     }
 
@@ -855,9 +916,9 @@ mod pricelevel_snapshot_serialization_tests {
         ];
 
         let snapshot = PriceLevelSnapshot::from_raw_parts(
-            1000,
-            45, // Sum of all visible quantities
-            27, // Sum of all hidden quantities
+            Price::new(1000),
+            Quantity::new(45), // Sum of all visible quantities
+            Quantity::new(27), // Sum of all hidden quantities
             many_orders.len(),
             many_orders,
         );
@@ -870,9 +931,9 @@ mod pricelevel_snapshot_serialization_tests {
             serde_json::from_str(&json).expect("Failed to deserialize complex snapshot");
 
         // Verify basic fields
-        assert_eq!(deserialized.price(), 1000);
-        assert_eq!(deserialized.visible_quantity(), 45);
-        assert_eq!(deserialized.hidden_quantity(), 27);
+        assert_eq!(deserialized.price().as_u128(), 1000);
+        assert_eq!(deserialized.visible_quantity().as_u64(), 45);
+        assert_eq!(deserialized.hidden_quantity().as_u64(), 27);
         assert_eq!(deserialized.order_count(), 6);
         assert_eq!(deserialized.orders().len(), 6);
 


### PR DESCRIPTION
## Summary

Return the crate's domain newtypes from accessors instead of raw `u64`/`u128`, so
raw primitives don't leak across the accessor boundary (the "newtypes at every
domain boundary" rule). User-approved breaking change for the 0.9 window.

## Changes

- **`OrderType`:** `visible_quantity()` / `hidden_quantity()` → `Quantity`,
  `timestamp()` → `TimestampMs` (already stored as newtypes internally).
- **`MatchResult`:** `new` / `with_capacity` / `finalize` take `Quantity`;
  `remaining_quantity()` → `Quantity`; `executed_quantity()` →
  `Result<Quantity, _>`. `executed_value()` / `total_value()` stay `u128` (no
  monetary newtype invented).
- **`PriceLevelSnapshot`:** `price` → `Price`, `visible_quantity` /
  `hidden_quantity` / `total_quantity` → `Quantity` (fields + accessors).

## Technical decisions

- **Snapshot wire format is byte-identical.** `Price`/`Quantity` are
  `#[serde(transparent)]`, so the hand-written `Serialize`/`Deserialize`/`FromStr`
  emit/parse the same numbers. No format-version bump. Proof: the checksum +
  round-trip tests (`test_snapshot_package_*`, `..._preserves_statistics`,
  `max_values`) pass unchanged.
- `match_order`'s `incoming_quantity` stays `u64` (converted to `Quantity` at the
  `MatchResult` boundary) to avoid re-churning the ~124 call sites just touched in
  #65. Documented in the migration note.

## Public API impact

Breaking (accessor/`MatchResult` return + param types). Migration-guide section
added to `src/lib.rs` (before/after table); `README.md` regenerated. Snapshot
wire unchanged. ~205 call sites updated.

## Testing

- [x] Snapshot round-trip + SHA-256 checksum tests pass unchanged (proves wire
      identical)
- [x] `make pre-push` clean

`cargo test`: 406 (unit) + 1 (integration) + 9 (doctests), 0 failed.
`cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all
--check`, `cargo build --release`: clean.

## Checklist

- [x] Accessors return domain newtypes; no raw `u64`/`u128` leak on the changed surface
- [x] Snapshot JSON wire + checksum unchanged (no version bump)
- [x] No behavior change (types only); determinism/round-trip intact
- [x] No new deps; no production `.unwrap()`; `# Errors`/`#[must_use]` retained
- [x] `src/lib.rs` migration guide + `README.md` updated

Closes #71
