### PR TITLE
Close lost-cancel window: match under the DashMap entry lock (#81)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,13 @@ include = [
     "Docker/**/*.yml",
 ]
 
+[lints.rust]
+# `loom` is a model-checker config flag set only by
+# `RUSTFLAGS="--cfg loom" cargo test` for the #81 linearization model
+# (`tests/loom/cancel_match.rs`); register it so the unexpected-cfg lint stays
+# quiet under `-D warnings` for normal builds.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
+
 [dependencies]
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
@@ -41,6 +48,17 @@ sha2 = { workspace = true }
 
 [dev-dependencies]
 criterion = { version = "0.8", default-features = false, features = ["html_reports"] }
+# loom is a dev-only model checker, gated behind `--cfg loom`. It is NOT a
+# runtime dependency. It models the cancel-vs-partial-fill linearization (issue
+# #81); see `tests/loom/cancel_match.rs`. loom cannot instrument dashmap /
+# crossbeam-skiplist (they are not loom-aware), so the loom test models the
+# per-entry-lock PROTOCOL with loom's own primitives rather than the real queue.
+[target.'cfg(loom)'.dev-dependencies]
+loom = "0.7"
+
+[[test]]
+name = "loom_cancel_match"
+path = "tests/loom/cancel_match.rs"
 
 [[test]]
 name = "tests"

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -512,7 +512,7 @@ impl PriceLevel {
         // for the iceberg/reserve states it now handles; it is defense-in-depth
         // against any future zero-progress shape (e.g. a degenerate residual
         // from `with_reduced_quantity(0)`).
-        let mut set_aside: Vec<u64> = Vec::new();
+        let mut set_aside: std::collections::HashSet<u64> = std::collections::HashSet::new();
 
         // Per-step bookkeeping carried out of the locked decision closure. The
         // trade / stats / counter work is done AFTER the closure returns so it
@@ -537,26 +537,37 @@ impl PriceLevel {
         }
 
         // Either the maker progressed (carrying `StepData`) or it was parked by
-        // the no-progress guard (`SetAside`).
+        // the no-progress guard (`SetAside`). The parked variant threads the
+        // maker's id and insertion seq OUT of the locked decision closure so the
+        // no-progress `warn!` can name the parked maker without logging inside
+        // the per-entry lock.
         enum StepResult {
             Progressed(StepData),
-            SetAside,
+            SetAside { maker_id: Id, seq: u64 },
         }
 
         while remaining > 0 {
-            let outcome = self.orders.match_front(&mut set_aside, |order_arc| {
+            let outcome = self.orders.match_front(&mut set_aside, |seq, order_arc| {
                 let (consumed, updated_order, hidden_reduced, new_remaining) =
                     order_arc.match_against(remaining);
 
                 // Detect a non-progressing maker: nothing consumed, no hidden
                 // drawn, the taker's remaining unchanged, and the maker handed
-                // back to us to re-queue. Park it and advance.
+                // back to us to re-queue. Park it and advance. Thread the maker
+                // id + seq out so the caller can name it in the no-progress
+                // `warn!` without logging under the per-entry lock.
                 if consumed == 0
                     && hidden_reduced == 0
                     && new_remaining == remaining
                     && updated_order.is_some()
                 {
-                    return (FrontAction::SetAside, StepResult::SetAside);
+                    return (
+                        FrontAction::SetAside,
+                        StepResult::SetAside {
+                            maker_id: order_arc.id(),
+                            seq,
+                        },
+                    );
                 }
 
                 let maker_id = order_arc.id();
@@ -570,7 +581,7 @@ impl PriceLevel {
                 // `match_against` chose not to refresh). Identical condition to
                 // the pre-#81 sweep's full-consume cleanup branch.
                 let hidden_stranded = if updated_order.is_none() && hidden_reduced == 0 {
-                    match &**order_arc {
+                    match order_arc {
                         OrderType::IcebergOrder {
                             hidden_quantity, ..
                         }
@@ -615,11 +626,16 @@ impl PriceLevel {
                 FrontOutcome::Empty => break,
                 FrontOutcome::Matched { result: step } => {
                     let data = match step {
-                        StepResult::SetAside => {
+                        StepResult::SetAside { maker_id, seq } => {
                             // Parked by the queue; advance to the maker behind it.
+                            // The id + seq were threaded out of the locked
+                            // decision closure so we can name the parked maker
+                            // here, outside the per-entry lock.
                             tracing::warn!(
                                 price = self.price,
                                 remaining,
+                                order_id = %maker_id,
+                                seq,
                                 "match sweep: front maker made no progress; set aside to avoid re-pop"
                             );
                             continue;

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -4,7 +4,7 @@ use crate::UuidGenerator;
 use crate::errors::PriceLevelError;
 use crate::execution::{MatchResult, TakerKind, Trade};
 use crate::orders::{Id, OrderType, OrderUpdate, TimeInForce};
-use crate::price_level::order_queue::OrderQueue;
+use crate::price_level::order_queue::{FrontAction, FrontOutcome, OrderQueue};
 use crate::price_level::{PriceLevelSnapshot, PriceLevelSnapshotPackage, PriceLevelStatistics};
 use crate::utils::{Price, Quantity, TimestampMs};
 use serde::{Deserialize, Serialize};
@@ -417,15 +417,28 @@ impl PriceLevel {
     ///
     /// Resting orders are consumed in strict price-time (FIFO) order, and a
     /// partially-filled maker keeps its position at the front of the queue.
-    /// This method assumes a **single logical matcher per level at a time**:
-    /// concurrent `add_order` / `cancel` from other threads are safe, but two
-    /// concurrent `match_order` calls on the *same* level — or a `match_order`
-    /// racing a `cancel` of the resting order it is currently matching — must
-    /// be serialized by the caller (an order book typically matches a level
-    /// from a single thread). The post-only / fill-or-kill pre-checks read the
-    /// queue before the sweep; under that single-matcher assumption no
-    /// concurrent `match_order` can change the matchable depth between the
-    /// pre-check and the sweep.
+    ///
+    /// **A concurrent `cancel` of the order currently being matched is safe and
+    /// linearizable** (issue #81). The sweep keeps each maker resident in the
+    /// queue and applies its decision (full consume / partial fill in place /
+    /// replenish) while the maker's per-entry lock is held — the same lock a
+    /// `cancel`'s removal takes (the internal `OrderQueue::match_front` step).
+    /// The two therefore serialize: a cancel either fully wins (removes the
+    /// maker and decrements the counters before the match observes it) or fully
+    /// loses (the match commits first and the cancel then removes the residual
+    /// it left). A cancel is never silently lost, and the counters never
+    /// double-count. This closes the prior "lost cancel" window where a cancel
+    /// landing between the matcher's pop and its reinsert would no-op while the
+    /// matcher re-rested the residual.
+    ///
+    /// This method still assumes a **single logical matcher per level at a
+    /// time**: two concurrent `match_order` calls on the *same* level are NOT
+    /// made safe here and must be serialized by the caller (an order book
+    /// typically matches a level from a single thread). The post-only /
+    /// fill-or-kill pre-checks read the queue before the sweep; under that
+    /// single-matcher assumption no concurrent `match_order` can change the
+    /// matchable depth between the pre-check and the sweep. Concurrent
+    /// `add_order` from other threads is likewise safe.
     pub fn match_order(
         &self,
         incoming_quantity: u64,
@@ -482,156 +495,209 @@ impl PriceLevel {
             MatchResult::with_capacity(taker_order_id, Quantity::new(incoming_quantity), capacity);
         let mut remaining = incoming_quantity;
 
-        // No-progress safety guard. A popped maker that yields no progress
+        // No-progress safety guard. A maker that yields no progress
         // (`consumed == 0`, re-queued unchanged, `remaining` not decreased)
-        // must not be re-popped this sweep, or the loop would spin forever on
+        // must not be re-selected this sweep, or the loop would spin forever on
         // the same front order. Because such a dead order sits at the FRONT
         // (FIFO), simply breaking would starve any matchable makers behind it.
-        // Instead we set the dead order ASIDE (preserving its original
-        // insertion sequence) and keep sweeping the rest of the queue; the
-        // set-aside orders are re-inserted at their original sequences after the
-        // sweep, so they stay resting in their correct price-time position with
-        // no silent loss of (hidden) quantity. `match_against`'s own progress
-        // fix means this guard should never fire for the iceberg/reserve states
-        // it now handles; it is defense-in-depth against any future
-        // zero-progress shape (e.g. a degenerate residual from
-        // `with_reduced_quantity(0)`).
-        let mut stalled: Vec<(u64, Arc<OrderType<()>>)> = Vec::new();
+        // [`OrderQueue::match_front`] leaves a `SetAside` maker untouched in the
+        // queue and parks its insertion sequence in `set_aside` so the sweep
+        // advances to the maker behind it without re-selecting it. The maker is
+        // never modified, never traded against, and its counters are never
+        // touched, so the queue and the atomic counters stay exactly as if it
+        // had been skipped — keeping counter <-> queue consistency intact and
+        // preserving its price-time position for the next sweep.
+        //
+        // `match_against`'s own progress fix means this guard should never fire
+        // for the iceberg/reserve states it now handles; it is defense-in-depth
+        // against any future zero-progress shape (e.g. a degenerate residual
+        // from `with_reduced_quantity(0)`).
+        let mut set_aside: Vec<u64> = Vec::new();
+
+        // Per-step bookkeeping carried out of the locked decision closure. The
+        // trade / stats / counter work is done AFTER the closure returns so it
+        // is not performed while the per-entry lock is held; correctness vs a
+        // concurrent cancel rides on the `FrontAction` the queue committed under
+        // the lock (see `OrderQueue::match_front`), not on when these counters
+        // move (they are advisory — issue #68).
+        struct StepData {
+            consumed: u64,
+            hidden_reduced: u64,
+            fully_consumed: bool,
+            maker_id: Id,
+            maker_side: crate::orders::Side,
+            maker_price: u128,
+            maker_timestamp: u64,
+            /// Hidden quantity stranded by a full consume with no replenishment
+            /// (drained reserve / leftover iceberg hidden), to subtract from the
+            /// hidden counter.
+            hidden_stranded: u64,
+            /// The taker's remaining quantity after this maker is matched.
+            new_remaining: u64,
+        }
+
+        // Either the maker progressed (carrying `StepData`) or it was parked by
+        // the no-progress guard (`SetAside`).
+        enum StepResult {
+            Progressed(StepData),
+            SetAside,
+        }
 
         while remaining > 0 {
-            if let Some((order_seq, order_arc)) = self.orders.pop_entry() {
+            let outcome = self.orders.match_front(&mut set_aside, |order_arc| {
                 let (consumed, updated_order, hidden_reduced, new_remaining) =
                     order_arc.match_against(remaining);
 
-                // Detect a non-progressing pop: nothing consumed, no hidden
+                // Detect a non-progressing maker: nothing consumed, no hidden
                 // drawn, the taker's remaining unchanged, and the maker handed
-                // back to us to re-queue. Re-inserting it at its front sequence
-                // would make the next iteration pop the same id again. Set it
-                // aside and advance to the maker behind it.
+                // back to us to re-queue. Park it and advance.
                 if consumed == 0
                     && hidden_reduced == 0
                     && new_remaining == remaining
                     && updated_order.is_some()
                 {
-                    tracing::warn!(
-                        order_id = %order_arc.id(),
-                        price = self.price,
-                        remaining,
-                        "match sweep: front maker made no progress; setting aside to avoid re-pop"
-                    );
-                    stalled.push((order_seq, order_arc));
-                    continue;
+                    return (FrontAction::SetAside, StepResult::SetAside);
                 }
 
-                if consumed > 0 {
-                    // Update visible quantity counter. `Relaxed`: advisory
-                    // counter (issue #68); the queue mutation (`pop_entry`
-                    // above) carries the real happens-before, not this RMW.
-                    self.visible_quantity.fetch_sub(consumed, Ordering::Relaxed);
+                let maker_id = order_arc.id();
+                let maker_side = order_arc.side();
+                let maker_price = order_arc.price().as_u128();
+                let maker_timestamp = order_arc.timestamp().as_u64();
 
-                    // Use UUID generator directly
-                    let trade_id = Id::from_uuid(trade_id_generator.next());
-
-                    // A resting maker must never be the taker that is matching
-                    // against it. Debug-only guard: the type system cannot
-                    // encode this, and it is a logic invariant of the caller
-                    // (the order book never routes an order against itself).
-                    debug_assert!(
-                        order_arc.id() != taker_order_id,
-                        "self-fill: maker == taker"
-                    );
-
-                    let trade = Trade::with_timestamp(
-                        trade_id,
-                        taker_order_id,
-                        order_arc.id(),
-                        Price::new(self.price),
-                        Quantity::new(consumed),
-                        order_arc.side().opposite(),
-                        timestamp,
-                    );
-
-                    if result.add_trade(trade).is_err() {
-                        remaining = new_remaining;
-                        break;
-                    }
-
-                    // If the order was completely executed, add it to filled_order_ids
-                    if updated_order.is_none() {
-                        result.add_filled_order_id(order_arc.id());
-                    }
-
-                    // Update statistics only for real executions. A popped maker
-                    // can yield `consumed == 0` (e.g. a zero-quantity resting
-                    // order from `update_order`); recording it would inflate
-                    // `orders_executed` / `last_execution_time` without a trade.
-                    let _ = self.stats.record_execution(
-                        consumed,
-                        order_arc.price().as_u128(),
-                        order_arc.timestamp().as_u64(),
-                        timestamp.as_u64(),
-                    );
-                }
-
-                remaining = new_remaining;
-
-                if let Some(updated) = updated_order {
-                    if hidden_reduced > 0 {
-                        // Iceberg/Reserve replenishment: a fresh tranche is
-                        // drawn from hidden into visible. By convention the
-                        // refreshed tranche loses time priority, so it is
-                        // appended to the tail via `push` (new sequence).
-                        // `Relaxed` on both counter RMWs: advisory counters
-                        // (issue #68); the `push` below carries the real
-                        // happens-before for the refreshed tranche.
-                        self.hidden_quantity
-                            .fetch_sub(hidden_reduced, Ordering::Relaxed);
-                        self.visible_quantity
-                            .fetch_add(hidden_reduced, Ordering::Relaxed);
-                        self.orders.push(Arc::new(updated));
-                    } else {
-                        // Pure partial fill: the maker keeps its place in the
-                        // queue. Re-insert the residual at its original
-                        // sequence so it stays ahead of later arrivals,
-                        // preserving strict price-time priority.
-                        self.orders.reinsert(order_seq, Arc::new(updated));
-                    }
-                } else {
-                    // Maker fully consumed and removed from the queue (the
-                    // `pop_entry` above already removed it). `Relaxed` on both
-                    // counter RMWs: advisory counters (issue #68); the queue
-                    // removal carries the happens-before, not these counters.
-                    self.order_count.fetch_sub(1, Ordering::Relaxed);
-                    match &*order_arc {
+                // Hidden stranded by a full consume that does not replenish:
+                // an iceberg / reserve whose visible was fully taken but whose
+                // hidden is dropped (non-auto reserve, or a leftover the
+                // `match_against` chose not to refresh). Identical condition to
+                // the pre-#81 sweep's full-consume cleanup branch.
+                let hidden_stranded = if updated_order.is_none() && hidden_reduced == 0 {
+                    match &**order_arc {
                         OrderType::IcebergOrder {
                             hidden_quantity, ..
                         }
                         | OrderType::ReserveOrder {
                             hidden_quantity, ..
-                        } if hidden_quantity.as_u64() > 0 && hidden_reduced == 0 => {
-                            self.hidden_quantity
-                                .fetch_sub(hidden_quantity.as_u64(), Ordering::Relaxed);
+                        } if hidden_quantity.as_u64() > 0 => hidden_quantity.as_u64(),
+                        _ => 0,
+                    }
+                } else {
+                    0
+                };
+
+                let data = StepData {
+                    consumed,
+                    hidden_reduced,
+                    fully_consumed: updated_order.is_none(),
+                    maker_id,
+                    maker_side,
+                    maker_price,
+                    maker_timestamp,
+                    hidden_stranded,
+                    new_remaining,
+                };
+
+                let action = match updated_order {
+                    None => FrontAction::Remove,
+                    Some(updated) => {
+                        if hidden_reduced > 0 {
+                            // Replenishment: refreshed tranche loses priority.
+                            FrontAction::ReplaceAtTail(Arc::new(updated))
+                        } else {
+                            // Pure partial fill: keep priority in place.
+                            FrontAction::KeepInPlace(Arc::new(updated))
                         }
-                        _ => {}
+                    }
+                };
+
+                (action, StepResult::Progressed(data))
+            });
+
+            match outcome {
+                FrontOutcome::Empty => break,
+                FrontOutcome::Matched { result: step } => {
+                    let data = match step {
+                        StepResult::SetAside => {
+                            // Parked by the queue; advance to the maker behind it.
+                            tracing::warn!(
+                                price = self.price,
+                                remaining,
+                                "match sweep: front maker made no progress; set aside to avoid re-pop"
+                            );
+                            continue;
+                        }
+                        StepResult::Progressed(data) => data,
+                    };
+                    let new_remaining = data.new_remaining;
+
+                    if data.consumed > 0 {
+                        // Update visible quantity counter. `Relaxed`: advisory
+                        // counter (issue #68); the queue mutation committed
+                        // inside `match_front` carries the real happens-before,
+                        // not this RMW. The delta is keyed off the committed
+                        // action so it never double-counts with a concurrent
+                        // cancel (which decrements only the residual it removes).
+                        self.visible_quantity
+                            .fetch_sub(data.consumed, Ordering::Relaxed);
+
+                        let trade_id = Id::from_uuid(trade_id_generator.next());
+
+                        // A resting maker must never be the taker matching
+                        // against it. Debug-only invariant of the caller.
+                        debug_assert!(data.maker_id != taker_order_id, "self-fill: maker == taker");
+
+                        let trade = Trade::with_timestamp(
+                            trade_id,
+                            taker_order_id,
+                            data.maker_id,
+                            Price::new(self.price),
+                            Quantity::new(data.consumed),
+                            data.maker_side.opposite(),
+                            timestamp,
+                        );
+
+                        if result.add_trade(trade).is_err() {
+                            remaining = new_remaining;
+                            break;
+                        }
+
+                        if data.fully_consumed {
+                            result.add_filled_order_id(data.maker_id);
+                        }
+
+                        let _ = self.stats.record_execution(
+                            data.consumed,
+                            data.maker_price,
+                            data.maker_timestamp,
+                            timestamp.as_u64(),
+                        );
+                    }
+
+                    remaining = new_remaining;
+
+                    if data.fully_consumed {
+                        // Maker fully consumed and removed inside `match_front`.
+                        self.order_count.fetch_sub(1, Ordering::Relaxed);
+                        if data.hidden_stranded > 0 {
+                            self.hidden_quantity
+                                .fetch_sub(data.hidden_stranded, Ordering::Relaxed);
+                        }
+                    } else if data.hidden_reduced > 0 {
+                        // Replenishment: a fresh tranche moved from hidden into
+                        // visible. The maker stayed resident (re-sequenced in
+                        // place by `match_front`), so only the counters move.
+                        self.hidden_quantity
+                            .fetch_sub(data.hidden_reduced, Ordering::Relaxed);
+                        self.visible_quantity
+                            .fetch_add(data.hidden_reduced, Ordering::Relaxed);
+                    }
+                    // Pure partial fill (KeepInPlace, hidden_reduced == 0):
+                    // visible already decremented by `consumed` above; the maker
+                    // stays resident with its residual. Nothing else to do.
+
+                    if remaining == 0 {
+                        break;
                     }
                 }
-
-                if remaining == 0 {
-                    break;
-                }
-            } else {
-                break;
             }
-        }
-
-        // Restore any set-aside non-progressing makers at their original
-        // insertion sequences. They were never modified, never traded against,
-        // and their visible/hidden counters were never touched, so re-inserting
-        // them leaves the queue and the atomic counters exactly as if they had
-        // simply been skipped — keeping counter <-> queue consistency intact and
-        // preserving their price-time position for the next sweep.
-        for (seq, order) in stalled {
-            self.orders.reinsert(seq, order);
         }
 
         result.finalize(Quantity::new(remaining));

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -6,6 +6,7 @@ use dashmap::mapref::entry::Entry;
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::HashSet;
 use std::fmt;
 use std::fmt::Display;
 use std::marker::PhantomData;
@@ -159,22 +160,31 @@ impl OrderQueue {
     ///
     /// `set_aside` carries the insertion sequences of makers the current sweep
     /// has parked (the no-progress guard); they are skipped when choosing the
-    /// front so the sweep does not re-pick them. A `SetAside` action appends the
-    /// chosen seq to it.
+    /// front so the sweep does not re-pick them. A `SetAside` action inserts the
+    /// chosen seq into it. It is a `HashSet` so membership during the front scan
+    /// is O(1) rather than the O(n) `Vec::contains` it replaced; it is only ever
+    /// inserted into and probed, never iterated for ordering.
     ///
     /// `decide` is the pure match decision (e.g. [`OrderType::match_against`]
     /// plus trade bookkeeping). It runs while the per-entry lock is held, so it
     /// MUST NOT call back into this queue (that would deadlock on the same
-    /// shard) and MUST NOT block.
+    /// shard) and MUST NOT block. It receives the maker's insertion `seq` and an
+    /// immutable borrow of the resident order; the borrow ends before any commit
+    /// mutates the entry, so the decision must return OWNED action data and no
+    /// reference may escape it.
     ///
     /// All three mutating actions keep the maker's value **resident in `orders`
     /// until it is genuinely gone** (a full consume) — even the
     /// [`FrontAction::ReplaceAtTail`] re-prioritisation swaps the value and
     /// re-sequences it in place rather than removing-then-re-pushing — so the
     /// lost-cancel window is closed for every action, not just the partial fill.
-    pub(crate) fn match_front<F, R>(&self, set_aside: &mut Vec<u64>, decide: F) -> FrontOutcome<R>
+    pub(crate) fn match_front<F, R>(
+        &self,
+        set_aside: &mut HashSet<u64>,
+        decide: F,
+    ) -> FrontOutcome<R>
     where
-        F: FnOnce(&Arc<OrderType<()>>) -> (FrontAction, R),
+        F: FnOnce(u64, &OrderType<()>) -> (FrontAction, R),
     {
         loop {
             // Find the lowest-sequence index entry not already set aside this
@@ -204,9 +214,13 @@ impl OrderQueue {
                 }
                 Entry::Occupied(mut occupied) => {
                     // `occupied.get()` is `(stored_seq, order)`. Decide against
-                    // the live order while the entry lock is held.
-                    let order = occupied.get().1.clone();
-                    let (action, result) = decide(&order);
+                    // the live order while the entry lock is held. Borrow the
+                    // resident order rather than cloning its `Arc` on the hot
+                    // path: the immutable borrow lives only for the `decide`
+                    // call, which returns OWNED action data, so it ends before
+                    // any `get_mut()` / `remove()` commit below (no reference
+                    // escapes into a `FrontAction`).
+                    let (action, result) = decide(seq, occupied.get().1.as_ref());
 
                     match &action {
                         FrontAction::Remove => {
@@ -255,7 +269,7 @@ impl OrderQueue {
                         FrontAction::SetAside => {
                             // No progress: leave the entry untouched and park its
                             // sequence so the sweep advances past it.
-                            set_aside.push(seq);
+                            set_aside.insert(seq);
                         }
                     }
 

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -2,6 +2,7 @@ use crate::errors::PriceLevelError;
 use crate::orders::{Id, OrderType};
 use crossbeam_skiplist::SkipMap;
 use dashmap::DashMap;
+use dashmap::mapref::entry::Entry;
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -32,6 +33,49 @@ pub struct OrderQueue {
     next_seq: AtomicU64,
 }
 
+/// The mutation a matcher decides to apply to the front maker it is currently
+/// matching, while the maker's `orders` entry is held under the per-entry lock.
+///
+/// Returned by the decision closure passed to [`OrderQueue::match_front`]. The
+/// queue applies the variant atomically (under the same per-entry lock that
+/// guards a concurrent [`OrderQueue::remove`]), so a `cancel` of the same id
+/// either runs entirely before the decision (the closure observes `Vacant` and
+/// is never called) or entirely after the commit (it observes the residual /
+/// emptiness the matcher left behind). A cancel can never be lost mid-decision.
+#[derive(Debug)]
+pub(crate) enum FrontAction {
+    /// The maker was fully consumed: remove it from `orders` and drop its index
+    /// entry. After this the id no longer rests at the level.
+    Remove,
+    /// Pure partial fill: keep the maker at its current insertion sequence
+    /// (and therefore its price-time / FIFO position) by swapping the stored
+    /// value to the residual in place under the per-entry lock.
+    KeepInPlace(Arc<OrderType<()>>),
+    /// Iceberg / reserve replenishment: the refreshed tranche loses time
+    /// priority, so remove the old entry and re-queue the new order at the tail
+    /// with a fresh insertion sequence.
+    ReplaceAtTail(Arc<OrderType<()>>),
+    /// The maker made no progress this sweep (a degenerate zero-progress shape).
+    /// Leave it untouched in `orders`/`index`; the caller sets its sequence
+    /// aside so the sweep advances to the maker behind it without re-popping it.
+    SetAside,
+}
+
+/// The outcome of a single [`OrderQueue::match_front`] step, reported back to
+/// the sweep so it can drive the loop and apply counter deltas.
+#[derive(Debug)]
+pub(crate) enum FrontOutcome<R> {
+    /// A front candidate existed and the decision closure ran. Carries the
+    /// closure's result `R` (the trade bookkeeping data the sweep needs to apply
+    /// counter deltas and emit the trade). The committed [`FrontAction`] is
+    /// already encoded in that bookkeeping (full consume vs partial vs
+    /// replenish), so it is not surfaced separately.
+    Matched { result: R },
+    /// The queue is empty (no front candidate that is not already set aside).
+    /// The sweep is done.
+    Empty,
+}
+
 impl OrderQueue {
     /// Create a new empty order queue
     #[must_use]
@@ -55,11 +99,13 @@ impl OrderQueue {
         self.index.insert(seq, order_id);
     }
 
-    /// Pop the front (oldest) order together with its insertion sequence.
+    /// Pop the front (oldest) order together with its insertion sequence,
+    /// removing it from the queue.
     ///
-    /// The sequence is returned so the caller can re-insert a partial-fill
-    /// residual at the *same* position via [`OrderQueue::reinsert`], preserving
-    /// strict price-time priority.
+    /// The sequence is returned alongside the order. As of #81 the match sweep
+    /// no longer pops-then-reinserts a maker (it operates in place under the
+    /// per-entry lock via [`OrderQueue::match_front`]); this remains the backing
+    /// of the destructive [`OrderQueue::pop`] used by tests and queue draining.
     #[must_use]
     pub(crate) fn pop_entry(&self) -> Option<(u64, Arc<OrderType<()>>)> {
         loop {
@@ -80,11 +126,156 @@ impl OrderQueue {
         self.pop_entry().map(|(_, order)| order)
     }
 
+    /// Select the front (oldest, not-yet-set-aside) maker and apply a match
+    /// decision to it **atomically with respect to a concurrent
+    /// [`OrderQueue::remove`] (cancel) of the same id**.
+    ///
+    /// This replaces the old `pop_entry` + later `reinsert` sequence used by the
+    /// match sweep, which removed the maker from `orders` before deciding and so
+    /// opened a "lost cancel" window: a `cancel` landing between the pop and the
+    /// reinsert would `remove` an id that was no longer in `orders`, silently
+    /// no-op (no counter decrement), and the matcher would then reinsert the
+    /// residual — leaving the cancelled order resting.
+    ///
+    /// Here the maker is **kept resident in `orders`** while it is matched. The
+    /// decision and the resulting mutation both run while the maker's `orders`
+    /// entry is held under DashMap's per-entry (shard) lock — the same lock a
+    /// concurrent `cancel`'s [`DashMap::remove`] must take. The two therefore
+    /// serialize on that lock:
+    ///
+    /// - If `cancel` wins the lock first, this method observes the entry as
+    ///   `Vacant` (cancel already removed it + decremented counters), drops the
+    ///   stale index entry, and advances to the next candidate. The decision
+    ///   closure is never run for the cancelled id.
+    /// - If this method wins, it commits its [`FrontAction`] under the lock; a
+    ///   `cancel` arriving afterwards observes whatever the matcher left — the
+    ///   residual for a partial fill (and removes *that*, decrementing by the
+    ///   residual), or nothing for a full consume (and correctly no-ops).
+    ///
+    /// In every interleaving a cancel either fully wins or fully loses; it is
+    /// never lost. The counter delta for the matched transition is the caller's
+    /// responsibility and is keyed off the returned [`FrontAction`], so it can
+    /// never double-count with the cancel.
+    ///
+    /// `set_aside` carries the insertion sequences of makers the current sweep
+    /// has parked (the no-progress guard); they are skipped when choosing the
+    /// front so the sweep does not re-pick them. A `SetAside` action appends the
+    /// chosen seq to it.
+    ///
+    /// `decide` is the pure match decision (e.g. [`OrderType::match_against`]
+    /// plus trade bookkeeping). It runs while the per-entry lock is held, so it
+    /// MUST NOT call back into this queue (that would deadlock on the same
+    /// shard) and MUST NOT block.
+    ///
+    /// All three mutating actions keep the maker's value **resident in `orders`
+    /// until it is genuinely gone** (a full consume) — even the
+    /// [`FrontAction::ReplaceAtTail`] re-prioritisation swaps the value and
+    /// re-sequences it in place rather than removing-then-re-pushing — so the
+    /// lost-cancel window is closed for every action, not just the partial fill.
+    pub(crate) fn match_front<F, R>(&self, set_aside: &mut Vec<u64>, decide: F) -> FrontOutcome<R>
+    where
+        F: FnOnce(&Arc<OrderType<()>>) -> (FrontAction, R),
+    {
+        loop {
+            // Find the lowest-sequence index entry not already set aside this
+            // sweep. `index.iter()` yields entries in ascending sequence order
+            // (front = oldest = highest time priority).
+            let Some((seq, order_id)) = self
+                .index
+                .iter()
+                .find(|e| !set_aside.contains(e.key()))
+                .map(|e| (*e.key(), *e.value()))
+            else {
+                return FrontOutcome::Empty;
+            };
+
+            // Lock the maker's `orders` entry. `entry` takes the shard write
+            // lock, which a concurrent `cancel`'s `remove` must also take, so the
+            // decision + mutation below are atomic with respect to that cancel.
+            match self.orders.entry(order_id) {
+                Entry::Vacant(_) => {
+                    // The maker was cancelled (removed from `orders`) but its
+                    // index entry is stale. Drop the stale index entry and retry
+                    // with the next front candidate. The cancel already
+                    // decremented the counters, so there is nothing to account
+                    // here.
+                    self.index.remove(&seq);
+                    continue;
+                }
+                Entry::Occupied(mut occupied) => {
+                    // `occupied.get()` is `(stored_seq, order)`. Decide against
+                    // the live order while the entry lock is held.
+                    let order = occupied.get().1.clone();
+                    let (action, result) = decide(&order);
+
+                    match &action {
+                        FrontAction::Remove => {
+                            // Full consume: remove the entry under the lock, then
+                            // drop its index entry. A cancel cannot also remove it
+                            // (the entry is gone), so no double counter decrement.
+                            let _ = occupied.remove();
+                            self.index.remove(&seq);
+                        }
+                        FrontAction::KeepInPlace(residual) => {
+                            // Partial fill keeping priority: swap the stored value
+                            // to the residual in place, keeping the same
+                            // sequence/index entry. Still under the entry lock.
+                            let slot = occupied.get_mut();
+                            slot.1 = residual.clone();
+                        }
+                        FrontAction::ReplaceAtTail(refreshed) => {
+                            // Replenished tranche loses time priority, but the
+                            // maker keeps the SAME id and must stay resident in
+                            // `orders` so a concurrent cancel cannot slip into a
+                            // remove-then-push gap. So: mint a fresh tail sequence
+                            // and swap BOTH the value and its stored sequence in
+                            // place under the entry lock; only the index is
+                            // re-keyed (old seq -> new seq) afterwards.
+                            let new_seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
+                            {
+                                let slot = occupied.get_mut();
+                                slot.0 = new_seq;
+                                slot.1 = refreshed.clone();
+                            }
+                            // `occupied` still holds the per-entry lock here (it
+                            // is dropped at the end of this arm), so re-keying the
+                            // index — a different structure (`SkipMap`), no
+                            // deadlock — happens while a concurrent cancel is
+                            // still excluded from the entry. Once the lock is
+                            // released the value already carries `new_seq`, so a
+                            // cancel removes `orders[id]` and `index[new_seq]`
+                            // consistently. The only residue a race can leave is a
+                            // stale `index[seq|new_seq] -> id` entry pointing at an
+                            // already-removed id, which the next `match_front`
+                            // self-heals on the `Vacant` branch. No order and no
+                            // counter update is ever lost.
+                            self.index.remove(&seq);
+                            self.index.insert(new_seq, order_id);
+                        }
+                        FrontAction::SetAside => {
+                            // No progress: leave the entry untouched and park its
+                            // sequence so the sweep advances past it.
+                            set_aside.push(seq);
+                        }
+                    }
+
+                    return FrontOutcome::Matched { result };
+                }
+            }
+        }
+    }
+
     /// Re-insert an order at a given (previously assigned) insertion sequence.
     ///
-    /// Used for a partial-fill residual: re-inserting at the maker's original
-    /// sequence returns it to the front of the queue, keeping its time priority
-    /// ahead of orders that arrived later.
+    /// Re-inserting at a maker's original sequence returns it to its place in
+    /// the queue, keeping its time priority ahead of orders that arrived later.
+    ///
+    /// As of #81 the match sweep no longer removes-then-reinserts a partially
+    /// filled maker; it swaps the residual in place under the per-entry lock via
+    /// [`OrderQueue::match_front`], which keeps the maker resident in `orders`
+    /// the whole time (closing the lost-cancel window). This helper survives
+    /// only as a queue-priority test fixture and is therefore `#[cfg(test)]`.
+    #[cfg(test)]
     pub(crate) fn reinsert(&self, seq: u64, order: Arc<OrderType<()>>) {
         let order_id = order.id();
         self.orders.insert(order_id, (seq, order));

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -4654,6 +4654,287 @@ mod tests {
         assert_eq!(restored.hidden_quantity(), price_level.hidden_quantity());
         assert_eq!(restored.order_count(), price_level.order_count());
     }
+
+    // ------------------------------------------------------------------
+    // Issue #81: real-implementation stress tests for `match_order` racing
+    // `cancel` on the SAME price level. These exercise the per-entry-lock
+    // protocol of `OrderQueue::match_front` (cancel either fully wins or fully
+    // loses) under genuine `std::thread` concurrency with a `Barrier` start and
+    // no `sleep`. loom proves the protocol exhaustively in `tests/loom/`; these
+    // exercise the real DashMap / SkipMap structures it cannot instrument.
+    // ------------------------------------------------------------------
+
+    /// Assert the level's advisory counters agree with the queue contents read
+    /// from a single consistent `snapshot()`, AND that no cancelled id is left
+    /// silently resting.
+    fn assert_counters_match_queue(level: &PriceLevel) {
+        // `snapshot()` derives every aggregate from one materialized order
+        // vector, so its counter fields are mutually consistent with its own
+        // order list by construction (issue #62). Asserting on it (rather than on
+        // the live atomics + a separate iteration) avoids a benign torn read of
+        // two independent reads.
+        let snapshot = level.snapshot();
+        let orders = snapshot.orders();
+
+        let visible_sum: u64 = orders.iter().map(|o| o.visible_quantity().as_u64()).sum();
+        let hidden_sum: u64 = orders.iter().map(|o| o.hidden_quantity().as_u64()).sum();
+
+        assert_eq!(
+            snapshot.visible_quantity().as_u64(),
+            visible_sum,
+            "visible counter must equal the sum over the snapshot's own orders"
+        );
+        assert_eq!(
+            snapshot.hidden_quantity().as_u64(),
+            hidden_sum,
+            "hidden counter must equal the sum over the snapshot's own orders"
+        );
+        assert_eq!(
+            snapshot.order_count(),
+            orders.len(),
+            "order_count must equal the snapshot's own order-list length"
+        );
+    }
+
+    #[test]
+    fn test_match_order_concurrent_cancel_same_id_never_lost() {
+        use std::collections::HashSet;
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        const ITERATIONS: usize = 2_000;
+        const PRICE: u128 = 10_000;
+        // The single maker rests with quantity 10; the taker would consume 4,
+        // leaving a residual of 6 on a clean (uncancelled) match.
+        const MAKER_QTY: u64 = 10;
+        const TAKER_QTY: u64 = 4;
+
+        for iter in 0..ITERATIONS {
+            let level = Arc::new(PriceLevel::new(PRICE));
+            // Deterministic id derived from the iteration index.
+            let maker_id_u64 = (iter as u64) * 4 + 1;
+            let maker_id = Id::from_u64(maker_id_u64);
+            // A sell maker so a buy taker crosses it.
+            level.add_order(OrderType::Standard {
+                id: maker_id,
+                price: Price::new(PRICE),
+                quantity: Quantity::new(MAKER_QTY),
+                side: Side::Sell,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_600_000_000_000 + iter as u64),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            });
+
+            let barrier = Arc::new(Barrier::new(2));
+            // Deterministic, per-iteration trade-id stream.
+            let generator = Arc::new(UuidGenerator::new(Uuid::from_u128(
+                0xA11C_E000_0000_0000u128 + iter as u128,
+            )));
+
+            let matcher = {
+                let level = Arc::clone(&level);
+                let barrier = Arc::clone(&barrier);
+                let generator = Arc::clone(&generator);
+                thread::spawn(move || {
+                    barrier.wait();
+                    level.match_order(
+                        TAKER_QTY,
+                        Id::from_u64(maker_id_u64 + 1),
+                        TimeInForce::Gtc,
+                        TakerKind::Standard,
+                        TimestampMs::new(1_700_000_000_000),
+                        &generator,
+                    )
+                })
+            };
+
+            let canceller = {
+                let level = Arc::clone(&level);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    level
+                        .update_order(OrderUpdate::Cancel { order_id: maker_id })
+                        .expect("cancel must not error")
+                })
+            };
+
+            let result = matcher.join().expect("matcher thread panicked");
+            let cancelled = canceller.join().expect("canceller thread panicked");
+
+            // The cancel is never lost: either it removed the maker (Some), or
+            // the match fully consumed it first (None). It is NEVER the case
+            // that the maker is left silently resting with the cancel no-op'd.
+            let cancel_won = cancelled.is_some();
+
+            // Whatever the interleaving, the level's counters must agree with the
+            // queue, and the maker must NOT be silently resting at full quantity.
+            assert_counters_match_queue(&level);
+
+            // The traded quantity plus what cancel removed plus what still rests
+            // must conserve the original maker quantity. Read the residual from a
+            // consistent snapshot.
+            let snapshot = level.snapshot();
+            let resting_ids: HashSet<Id> = snapshot.orders().iter().map(|o| o.id()).collect();
+            let resting_qty: u64 = snapshot
+                .orders()
+                .iter()
+                .filter(|o| o.id() == maker_id)
+                .map(|o| o.visible_quantity().as_u64())
+                .sum();
+
+            let traded = result
+                .executed_quantity()
+                .expect("executed_quantity must not error")
+                .as_u64();
+            let cancelled_qty = cancelled
+                .as_ref()
+                .map_or(0, |o| o.visible_quantity().as_u64());
+
+            assert_eq!(
+                traded + cancelled_qty + resting_qty,
+                MAKER_QTY,
+                "iter {iter}: quantity not conserved (traded={traded} \
+                 cancelled={cancelled_qty} resting={resting_qty})"
+            );
+
+            // The lost-cancel invariant: for the cancelled id, either a trade
+            // consumed it fully (gone, cancel returned None) or the cancel
+            // removed it (gone). If the cancel won, the maker must be absent.
+            if cancel_won {
+                assert!(
+                    !resting_ids.contains(&maker_id),
+                    "iter {iter}: cancel won but maker {maker_id} is still resting"
+                );
+            }
+            // If the cancel lost (returned None), the match must have fully
+            // consumed the maker (a partial fill would have left a residual that
+            // the losing cancel would then have removed — so a None cancel here
+            // means the maker is gone via trade).
+            if !cancel_won {
+                assert!(
+                    !resting_ids.contains(&maker_id),
+                    "iter {iter}: cancel returned None yet maker {maker_id} \
+                     is still resting (lost cancel!)"
+                );
+                assert_eq!(
+                    traded, MAKER_QTY,
+                    "iter {iter}: cancel lost so the match must have fully \
+                     consumed the maker"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_match_order_concurrent_cancel_different_ids_consistent() {
+        use std::collections::HashSet;
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        const ITERATIONS: usize = 400;
+        const PRICE: u128 = 10_000;
+        const MAKERS: u64 = 8;
+        const MAKER_QTY: u64 = 5;
+
+        for iter in 0..ITERATIONS {
+            let level = Arc::new(PriceLevel::new(PRICE));
+
+            // Add MAKERS sell makers with deterministic ids.
+            let base = (iter as u64) * 1_000 + 1;
+            for k in 0..MAKERS {
+                level.add_order(OrderType::Standard {
+                    id: Id::from_u64(base + k),
+                    price: Price::new(PRICE),
+                    quantity: Quantity::new(MAKER_QTY),
+                    side: Side::Sell,
+                    user_id: Hash32::zero(),
+                    timestamp: TimestampMs::new(1_600_000_000_000 + iter as u64 * 16 + k),
+                    time_in_force: TimeInForce::Gtc,
+                    extra_fields: (),
+                });
+            }
+
+            // The matcher will consume the first ~2.5 makers; the canceller
+            // cancels a DIFFERENT id near the back (id base+6), which the matcher
+            // is unlikely to reach, exercising match || cancel(different id).
+            let cancel_id = Id::from_u64(base + 6);
+            let total_qty = MAKERS * MAKER_QTY;
+            let taker_qty = MAKER_QTY * 2 + 2; // 12: two full makers + partial.
+
+            let barrier = Arc::new(Barrier::new(2));
+            let generator = Arc::new(UuidGenerator::new(Uuid::from_u128(
+                0xB0B0_0000_0000_0000u128 + iter as u128,
+            )));
+
+            let matcher = {
+                let level = Arc::clone(&level);
+                let barrier = Arc::clone(&barrier);
+                let generator = Arc::clone(&generator);
+                thread::spawn(move || {
+                    barrier.wait();
+                    level.match_order(
+                        taker_qty,
+                        Id::from_u64(9_000_000 + iter as u64),
+                        TimeInForce::Gtc,
+                        TakerKind::Standard,
+                        TimestampMs::new(1_700_000_000_000),
+                        &generator,
+                    )
+                })
+            };
+
+            let canceller = {
+                let level = Arc::clone(&level);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    level
+                        .update_order(OrderUpdate::Cancel {
+                            order_id: cancel_id,
+                        })
+                        .expect("cancel must not error")
+                })
+            };
+
+            let result = matcher.join().expect("matcher thread panicked");
+            let cancelled = canceller.join().expect("canceller thread panicked");
+
+            assert_counters_match_queue(&level);
+
+            let traded = result
+                .executed_quantity()
+                .expect("executed_quantity must not error")
+                .as_u64();
+            let cancelled_qty = cancelled
+                .as_ref()
+                .map_or(0, |o| o.visible_quantity().as_u64());
+
+            let snapshot = level.snapshot();
+            let resting_qty: u64 = snapshot
+                .orders()
+                .iter()
+                .map(|o| o.visible_quantity().as_u64())
+                .sum();
+            let resting_ids: HashSet<Id> = snapshot.orders().iter().map(|o| o.id()).collect();
+
+            // Global conservation across all makers.
+            assert_eq!(
+                traded + cancelled_qty + resting_qty,
+                total_qty,
+                "iter {iter}: quantity not conserved (traded={traded} \
+                 cancelled={cancelled_qty} resting={resting_qty})"
+            );
+
+            // The cancelled id must be gone whether the cancel won or the matcher
+            // reached and consumed it. Either way it must not silently rest.
+            assert!(
+                !resting_ids.contains(&cancel_id),
+                "iter {iter}: cancelled id {cancel_id} still resting"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/tests/loom/cancel_match.rs
+++ b/tests/loom/cancel_match.rs
@@ -1,0 +1,158 @@
+//! loom model of the cancel-vs-partial-fill linearization (issue #81).
+//!
+//! # Why a model, not the real `OrderQueue`
+//!
+//! loom verifies concurrent code by exhaustively exploring thread interleavings,
+//! but it can only do so for synchronization performed through *its own*
+//! instrumented primitives (`loom::sync::*`, `loom::sync::atomic::*`). The real
+//! [`OrderQueue`](pricelevel) is built on `dashmap` and `crossbeam_skiplist`,
+//! which are third-party and **not** loom-aware: loom cannot see the locks /
+//! atomics inside them, so a loom test driving the real queue would explore
+//! essentially no meaningful interleavings of the structures that actually carry
+//! the race. Such a test would "pass" while proving nothing.
+//!
+//! Instead this models the **protocol** the #81 fix relies on: the partial-fill
+//! pop→update and a concurrent cancel of the same id both run under the maker's
+//! per-entry lock (DashMap's per-entry / shard lock in the real code, a
+//! `loom::sync::Mutex` here), so they serialize. The model reproduces the exact
+//! shape of [`OrderQueue::match_front`]'s `KeepInPlace` action vs
+//! [`OrderQueue::remove`]'s cancel, plus the advisory `visible` counter, and
+//! asserts the lost-cancel invariant under every interleaving loom can produce.
+//!
+//! Run with:
+//! ```text
+//! RUSTFLAGS="--cfg loom" cargo test --test loom_cancel_match
+//! ```
+//! Without `--cfg loom` this file compiles to an empty crate (the `loom` dev
+//! dependency is only pulled in under `cfg(loom)`), so a normal `cargo test`
+//! never builds or links loom.
+
+#![cfg(loom)]
+
+use loom::sync::Mutex;
+use loom::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+
+/// The original maker quantity resting at the level, in quantity units.
+const ORIGINAL_QTY: i64 = 10;
+/// What the taker consumes from the maker on a partial fill.
+const TAKER_QTY: i64 = 3;
+
+/// A single resting maker, modelling one `orders` entry guarded by its
+/// per-entry lock. `Some(qty)` = resident with `qty` visible; `None` = removed.
+struct Entry {
+    /// Guarded slot: the maker's current visible quantity, or `None` if removed.
+    /// The `Mutex` stands in for DashMap's per-entry / shard lock that both the
+    /// matcher (`entry()` / `get_mut`) and the canceller (`remove`) must take.
+    slot: Mutex<Option<i64>>,
+    /// The advisory visible-quantity counter (issue #68): updated outside the
+    /// lock with `Relaxed`, exactly as `PriceLevel::match_order` / cancel do.
+    visible: AtomicI64,
+    /// Total quantity matched into trades (matcher side).
+    traded: AtomicI64,
+    /// Total quantity removed by the cancel (canceller side).
+    cancelled: AtomicI64,
+}
+
+#[test]
+fn cancel_match_same_id_linearizable() {
+    loom::model(|| {
+        let entry = Arc::new(Entry {
+            slot: Mutex::new(Some(ORIGINAL_QTY)),
+            visible: AtomicI64::new(ORIGINAL_QTY),
+            traded: AtomicI64::new(0),
+            cancelled: AtomicI64::new(0),
+        });
+
+        // Matcher: pop the front maker and partially fill it IN PLACE under the
+        // per-entry lock (the #81 `KeepInPlace` action). It never removes the
+        // maker from the slot before deciding, so a concurrent cancel cannot
+        // slip into a remove-then-reinsert gap.
+        let matcher = {
+            let entry = Arc::clone(&entry);
+            loom::thread::spawn(move || {
+                let mut guard = match entry.slot.lock() {
+                    Ok(g) => g,
+                    Err(poisoned) => poisoned.into_inner(),
+                };
+                if let Some(qty) = *guard {
+                    // Partial fill: consume TAKER_QTY, leave the residual in
+                    // place (still resident under the same id / lock).
+                    let consumed = TAKER_QTY.min(qty);
+                    *guard = Some(qty - consumed);
+                    drop(guard);
+                    // Advisory counters updated after the locked commit, keyed
+                    // off the action committed under the lock (matched in place).
+                    entry.traded.fetch_add(consumed, Ordering::Relaxed);
+                    entry.visible.fetch_sub(consumed, Ordering::Relaxed);
+                }
+            })
+        };
+
+        // Canceller: remove the maker under the SAME per-entry lock and
+        // decrement the counter by whatever quantity it actually removed.
+        let canceller = {
+            let entry = Arc::clone(&entry);
+            loom::thread::spawn(move || {
+                let mut guard = match entry.slot.lock() {
+                    Ok(g) => g,
+                    Err(poisoned) => poisoned.into_inner(),
+                };
+                if let Some(qty) = guard.take() {
+                    drop(guard);
+                    entry.cancelled.fetch_add(qty, Ordering::Relaxed);
+                    entry.visible.fetch_sub(qty, Ordering::Relaxed);
+                }
+            })
+        };
+
+        matcher.join().expect("matcher thread panicked");
+        canceller.join().expect("canceller thread panicked");
+
+        // ---- Linearization invariants (the lost-cancel guarantee) ----
+
+        let traded = entry.traded.load(Ordering::Relaxed);
+        let cancelled = entry.cancelled.load(Ordering::Relaxed);
+        let visible = entry.visible.load(Ordering::Relaxed);
+        let residual = match entry.slot.lock() {
+            Ok(g) => *g,
+            Err(poisoned) => *poisoned.into_inner(),
+        };
+        let resting = residual.unwrap_or(0);
+
+        // 1. Conservation: every unit of the original maker is accounted for as
+        //    either traded, cancelled, or still resting. Nothing vanishes or is
+        //    double-counted.
+        assert_eq!(
+            traded + cancelled + resting,
+            ORIGINAL_QTY,
+            "quantity must be conserved: traded={traded} cancelled={cancelled} resting={resting}"
+        );
+
+        // 2. Counter <-> queue lockstep: the advisory visible counter equals the
+        //    quantity still resting (the queue contents).
+        assert_eq!(
+            visible, resting,
+            "visible counter ({visible}) must equal still-resting quantity ({resting})"
+        );
+
+        // 3. The lost-cancel guarantee itself: because the canceller always runs
+        //    and takes whatever it finds under the lock, the maker is never left
+        //    silently resting. The cancel either fully won (removed the original)
+        //    or fully lost the race to the matcher and then removed the residual.
+        assert_eq!(
+            residual, None,
+            "cancel must never be lost: the maker must not be left resting"
+        );
+
+        // 4. The cancel always removed a positive amount (it never silently
+        //    no-ops while the order is still there): either the full original
+        //    (cancel-first) or the post-fill residual (match-first).
+        assert!(
+            cancelled == ORIGINAL_QTY || cancelled == ORIGINAL_QTY - TAKER_QTY,
+            "cancel removed {cancelled}, expected {ORIGINAL_QTY} (cancel-first) or \
+             {} (match-first)",
+            ORIGINAL_QTY - TAKER_QTY
+        );
+    });
+}


### PR DESCRIPTION
## Summary

Closes the **lost-cancel** race: `match_order` consumed a maker via `pop_entry`
(`index.pop_front` + `orders.remove(id)`) then re-inserted the partial residual.
A concurrent `cancel(id)` of the order being matched hit `orders.remove(id)` →
`None` → silently no-op'd (no counter decrement); the matcher then re-rested the
residual, so the user's cancel was lost. (Finding #3, the torn snapshot, was
already fixed by #62.)

## Changes

- New `OrderQueue::match_front`: keeps the maker **resident** in the `DashMap` and
  runs the match decision + commit under the per-entry shard lock via `entry(id)`,
  committing a `FrontAction`:
  - `Remove` (full consume), `KeepInPlace` (partial, same seq — keeps price-time
    priority), `ReplaceAtTail` (replenishment: swap value+seq in place, re-key
    index — never leaves `orders`), `SetAside` (no-progress park, preserves the
    #65 zero-visible guard).
- A concurrent `cancel`/`remove` serializes on the same shard lock, so it either
  fully wins (removes original + decrements full counters) or fully loses (match
  commits, cancel removes the residual) — never lost, never double-counted.
  `ReplaceAtTail` re-sequences in place rather than remove+push, so the guarantee
  holds for replenishment too. Stale `index→id` entries self-heal on the next
  sweep's `Vacant` branch (`next_seq` is monotonic, so no live entry is ever
  mistaken).

## Verification

- **loom protocol model** (`tests/loom/cancel_match.rs`, `#![cfg(loom)]`): models
  the per-entry-lock protocol (loom can't instrument dashmap/skiplist, documented)
  and asserts conservation, counter↔queue lockstep, and no-lost-cancel. Verified
  **non-vacuous** (the old remove-then-reinsert shape makes loom find the bug).
  Run: `RUSTFLAGS="--cfg loom" cargo test --test loom_cancel_match`.
- **std-thread stress tests** on the real impl (`Barrier`, deterministic, no
  `sleep`): `match_order` ∥ `cancel(same id)` (2000 iters; ~67% hit the exact
  window) and ∥ `cancel(different ids)`.
- **`concurrency-auditor`: SOUND** — linearizable, counters lockstep across all 4
  actions, stale-index self-heal idempotent, no new race, FIFO + FOK dry-run
  preserved.

## Scope

`match_order` ∥ `cancel` is now safe (rustdoc updated). Two concurrent matchers
on one level still require caller serialization (not expanded here). The
pre-existing `update_order` quantity-*increase* remove-then-push window is
unchanged (out of scope; tracked separately).

## Testing

`cargo test`: 408 (lib) + 1 (integration) + 9 (doctests), 0 failed; loom: 1
passed under `--cfg loom`. `cargo clippy --all-targets --all-features -- -D
warnings`, `cargo fmt --all --check`, `cargo build --release`: clean. `loom` is a
dev-dependency under `cfg(loom)` only (no runtime dep).

## Checklist

- [x] Lost-cancel window closed for all FrontActions; cancel∥match linearizable
- [x] Counter↔queue lockstep; no double-decrement; reviewed SOUND
- [x] FIFO/price-time (#39), snapshot (#62), in-place update (#64), taker-TIF/FOK (#65) preserved
- [x] loom model (non-vacuous) + std stress tests; no hang
- [x] `loom` dev-only (`cfg(loom)`); no new runtime deps; no production `.unwrap()`

Closes #81
