### PR TITLE
Add PriceLevel::snapshot_by_insertion_seq; bump to 0.8.1 (#102)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pricelevel"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -243,6 +243,24 @@ impl PriceLevel {
         self.orders.snapshot_vec()
     }
 
+    /// Materializes the resting orders in the exact order [`Self::match_order`]
+    /// consumes them: ascending **insertion sequence** (the oldest order first).
+    ///
+    /// Use this to predict the sweep — e.g. a self-trade-prevention pre-scan that
+    /// must walk orders in consumption order to compute how much a taker may
+    /// safely fill. It differs from the other two views:
+    /// - [`Self::snapshot_orders`] sorts by `(timestamp, sequence)`, which equals
+    ///   the sweep order *only* when timestamps are monotonic with insertion
+    ///   (client-supplied or modify-restamped timestamps break that); and
+    /// - [`Self::iter_orders`] has no stable order.
+    ///
+    /// Like `snapshot_orders`, this is a point-in-time view: a concurrent
+    /// mutation after the call can change the queue.
+    #[must_use]
+    pub fn snapshot_by_insertion_seq(&self) -> Vec<Arc<OrderType<()>>> {
+        self.orders.snapshot_by_seq()
+    }
+
     /// Returns `true` if any resting order has matchable depth, i.e. a positive
     /// taker would cross at this level.
     ///

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -368,6 +368,26 @@ impl OrderQueue {
         self.snapshot_vec()
     }
 
+    /// Materialize the resting orders in ascending **insertion-sequence** order —
+    /// the exact order [`OrderQueue::match_front`] consumes them.
+    ///
+    /// Walks the `index` (`SkipMap<seq, Id>`, which iterates ascending) and
+    /// resolves each id in `orders`, skipping any transient index entry whose
+    /// order was already removed. Unlike [`OrderQueue::snapshot_vec`] (sorted by
+    /// `(timestamp, sequence)`), this reflects pure insertion order, so it equals
+    /// the sweep even when timestamps are not monotonic with insertion.
+    #[must_use]
+    pub(crate) fn snapshot_by_seq(&self) -> Vec<Arc<OrderType<()>>> {
+        self.index
+            .iter()
+            .filter_map(|index_entry| {
+                self.orders
+                    .get(index_entry.value())
+                    .map(|order_entry| order_entry.value().1.clone())
+            })
+            .collect()
+    }
+
     /// Creates a new `OrderQueue` instance and populates it with orders from the provided vector.
     ///
     /// This function takes ownership of a vector of order references (wrapped in `Arc`) and constructs
@@ -431,15 +451,7 @@ impl Serialize for OrderQueue {
         // where an order is in one structure but not yet the other.
         // Insertion-sequence order keeps the round-trip price-time priority
         // (the DashMap alone has no deterministic iteration order).
-        let ordered: Vec<Arc<OrderType<()>>> = self
-            .index
-            .iter()
-            .filter_map(|index_entry| {
-                self.orders
-                    .get(index_entry.value())
-                    .map(|order_entry| order_entry.value().1.clone())
-            })
-            .collect();
+        let ordered = self.snapshot_by_seq();
         let mut seq = serializer.serialize_seq(Some(ordered.len()))?;
         for order in &ordered {
             seq.serialize_element(order.as_ref())?;

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -4935,6 +4935,134 @@ mod tests {
             );
         }
     }
+
+    // ------------------------------------------------------------------
+    // Issue #102 — snapshot_by_insertion_seq (predicts match_order order)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_snapshot_by_insertion_seq_matches_match_order_consumption() {
+        // Build a Buy maker with an explicit (non-counter) timestamp so we can
+        // make timestamps NON-monotonic with insertion order.
+        let mk_buy = |id: u64, ts: u64, qty: u64| OrderType::Standard {
+            id: Id::from_u64(id),
+            price: Price::new(10_000),
+            quantity: Quantity::new(qty),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(ts),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        };
+
+        let level = PriceLevel::new(10_000);
+        // Insert id 1 FIRST but with a LATER timestamp than id 2 (added second).
+        level.add_order(mk_buy(1, 2_000, 50));
+        level.add_order(mk_buy(2, 1_000, 50));
+
+        let by_seq: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+        let by_ts: Vec<Id> = level.snapshot_orders().iter().map(|o| o.id()).collect();
+
+        // Insertion-sequence order is the order they were added: 1, 2.
+        assert_eq!(by_seq, vec![Id::from_u64(1), Id::from_u64(2)]);
+        // Timestamp order is 2, 1 (id 2 has the earlier timestamp) — different.
+        assert_eq!(by_ts, vec![Id::from_u64(2), Id::from_u64(1)]);
+        assert_ne!(
+            by_seq, by_ts,
+            "the two views must differ under non-monotonic timestamps"
+        );
+
+        // The sweep consumes in insertion-sequence order: id 1 then id 2.
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let generator = UuidGenerator::new(namespace);
+        let result = level.match_order(
+            100,
+            Id::from_u64(999),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(3_000),
+            &generator,
+        );
+        let consumed: Vec<Id> = result
+            .trades()
+            .as_vec()
+            .iter()
+            .map(|t| t.maker_order_id())
+            .collect();
+        assert_eq!(
+            consumed, by_seq,
+            "match_order consumes makers in snapshot_by_insertion_seq order"
+        );
+    }
+
+    #[test]
+    fn test_snapshot_by_insertion_seq_empty_level() {
+        let level = PriceLevel::new(10_000);
+        assert!(level.snapshot_by_insertion_seq().is_empty());
+    }
+
+    #[test]
+    fn test_snapshot_by_insertion_seq_partial_fill_keeps_front() {
+        let level = PriceLevel::new(10_000);
+        level.add_order(create_standard_order(1, 10_000, 100));
+        level.add_order(create_standard_order(2, 10_000, 50));
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let generator = UuidGenerator::new(namespace);
+        // Small taker partially fills the front maker (id 1): KeepInPlace, same seq.
+        let _ = level.match_order(
+            30,
+            Id::from_u64(999),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(1_700_000_000_000),
+            &generator,
+        );
+        let by_seq: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+        assert_eq!(
+            by_seq,
+            vec![Id::from_u64(1), Id::from_u64(2)],
+            "a partially-filled front maker keeps the front"
+        );
+    }
+
+    #[test]
+    fn test_snapshot_by_insertion_seq_replenished_maker_moves_to_tail() {
+        let level = PriceLevel::new(10_000);
+        // Iceberg (id 1, Sell) added first: visible 10 over hidden 40.
+        level.add_order(create_iceberg_order(1, 10_000, 10, 40));
+        // A plain Sell maker (id 2) rests behind it.
+        level.add_order(create_sell_standard_order(2, 10_000, 100));
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let generator = UuidGenerator::new(namespace);
+        // Fully consume the iceberg's visible tranche (10): it replenishes from
+        // hidden and is re-queued at the TAIL (ReplaceAtTail, new sequence).
+        let _ = level.match_order(
+            10,
+            Id::from_u64(999),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(1_700_000_000_000),
+            &generator,
+        );
+        let by_seq: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+        assert_eq!(
+            by_seq,
+            vec![Id::from_u64(2), Id::from_u64(1)],
+            "a replenished maker moves to the tail"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`PriceLevel` exposed two order views, neither of which matches the order
`match_order` actually consumes liquidity:
- `iter_orders()` — `DashMap`-backed, non-stable order.
- `snapshot_orders()` — sorted by `(timestamp, sequence)`.
- `match_order` → `OrderQueue::match_front()` — consumes by **pure insertion
  sequence**.

`snapshot_orders()` equals the sweep order *only* when timestamps are monotonic
with insertion (client-supplied / modify-restamped timestamps break that), so a
downstream self-trade-prevention pre-scan had no public primitive to predict the
sweep (issue #102). This adds one.

## Changes

- **`PriceLevel::snapshot_by_insertion_seq() -> Vec<Arc<OrderType<()>>>`**
  (`#[must_use]`) — resting orders in ascending insertion sequence, i.e. the exact
  order `match_order` consumes them. Doc contrasts it with `snapshot_orders()`
  (timestamp order) and `iter_orders()` (unordered), and notes the same
  point-in-time caveat as `snapshot_orders()`.
- **`OrderQueue::snapshot_by_seq()`** (`pub(crate)`) — the ascending `index`
  (`SkipMap<seq, Id>`) walk that `match_front` uses; factored out of the existing
  `impl Serialize for OrderQueue` (which now calls it — no duplication).
- **Version bump 0.8.0 → 0.8.1** (additive, non-breaking).

No new exported type, no `lib.rs`/`prelude.rs` change, no migration guide, no
snapshot-format change, no `match_order` semantics change.

## Testing

- `test_snapshot_by_insertion_seq_matches_match_order_consumption` — with
  **non-monotonic** timestamps (id 1 inserted first but timestamped later than id
  2): asserts the accessor yields insertion order `[1, 2]`, equals the maker-id
  order `match_order` actually emits, and **differs** from `snapshot_orders()`
  (`[2, 1]`) — proving it predicts the sweep where `snapshot_orders()` does not.
- `_empty_level`, `_partial_fill_keeps_front` (KeepInPlace, same seq),
  `_replenished_maker_moves_to_tail` (ReplaceAtTail → new seq → last).

`cargo test`: 412 (lib) + 9 proptest + 1 integration + 9 doc, 0 failed.
`cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all
--check`, `cargo build --release`, `make doc` (rustdoc `-D warnings`): all clean.

## Checklist

- [x] Additive, non-breaking; reuses the existing `Serialize` index-walk
- [x] No `# Errors` (returns `Vec`); `#[must_use]`; doc'd vs the other two views
- [x] Headline test proves equivalence to the real sweep under non-monotonic timestamps
- [x] Version bumped to 0.8.1; no new deps; no behavior change

Closes #102
