### PR TITLE
Release 0.8.2: expose matchable_quantity + add snapshot_by_seq_into (buffer reuse)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.8.2] - 2026-06-24
+
+Small, **non-breaking** release exposing two primitives an order book needs to
+compose this level without re-deriving its internal sweep order.
+
+### Added
+
+- **`PriceLevel::matchable_quantity(incoming_quantity: u64) -> u64`** is now
+  `pub`. It was already the deterministic fill-or-kill dry run — a no-mutation
+  replay of the FIFO sweep (including iceberg / reserve replenishment) that
+  returns exactly what `match_order` would consume. Making it public lets a
+  composing order book delegate per-level all-or-nothing feasibility to this
+  single upstream source of truth instead of re-implementing the sweep and
+  risking drift.
+- **`PriceLevel::snapshot_by_seq_into(&self, out: &mut Vec<Arc<OrderType<()>>>)`**
+  — buffer-reuse variant of `snapshot_by_insertion_seq()`. Clears `out` and
+  refills it in ascending insertion sequence (the order `match_order` consumes
+  orders), so a consumer that walks every level repeatedly (e.g. a
+  self-trade-prevention pre-scan) can reuse one pooled scratch buffer and avoid
+  the per-call allocation the owned-`Vec` variant pays.
+
+No breaking changes, no new dependencies, no change to matching semantics or the
+snapshot wire format.
+
+## [0.8.1] - 2026-06-24
+
+### Added
+
+- **`PriceLevel::snapshot_by_insertion_seq() -> Vec<Arc<OrderType<()>>>`** —
+  returns the resting orders in ascending insertion sequence, i.e. the exact
+  order `match_order` consumes them. Unlike `snapshot_orders()` (sorted by
+  `(timestamp, sequence)`, which equals the sweep only when timestamps are
+  monotonic with insertion) and `iter_orders()` (no stable order), this faithfully
+  predicts the sweep, giving a downstream consumer a public primitive to walk
+  orders in consumption order.
+
+No breaking changes, no new dependencies, snapshot wire format unchanged.
+
+## [0.8.0] - 2026-06-23
+
+Roadmap hardening release: a sweep of correctness, robustness, and tooling
+improvements across the price level. Highlights:
+
+### Added
+
+- Taker time-in-force handling inside `match_order` (`Gtc` / `Ioc` / `Fok` /
+  `Gtd` / `Day`), with a `TakerKind` (`Standard` / `PostOnly` / `MarketToLimit`)
+  and a `MatchOutcome` (`Filled` / `PartiallyFilled` / `NotFilled` / `Killed` /
+  `Rejected`).
+- A property-test harness (`proptest`) covering the nine price-level invariants.
+- A `loom` linearization model for the cancel-vs-partial-fill protocol.
+
+### Changed
+
+- Unified order matchability behind `OrderType::is_matchable`, shared by the
+  post-only pre-check and the fill-or-kill dry run so they can never disagree.
+- Bumped `sha2` to `0.11`.
+
+### Fixed
+
+- A zero-visible iceberg / auto-replenishing reserve backed by hidden quantity is
+  now correctly treated as matchable depth, closing a fill-or-kill no-progress
+  loop.
+- Lost-cancel race on the order queue.
+
+[0.8.2]: https://github.com/joaquinbejar/PriceLevel/compare/v0.8.1...v0.8.2
+[0.8.1]: https://github.com/joaquinbejar/PriceLevel/compare/v0.8.0...v0.8.1
+[0.8.0]: https://github.com/joaquinbejar/PriceLevel/releases/tag/v0.8.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pricelevel"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -261,6 +261,22 @@ impl PriceLevel {
         self.orders.snapshot_by_seq()
     }
 
+    /// Fill `out` with the resting orders in ascending **insertion sequence** —
+    /// the buffer-reuse variant of [`Self::snapshot_by_insertion_seq`].
+    ///
+    /// `out` is cleared and then extended in place, yielding the exact same
+    /// sequence [`Self::snapshot_by_insertion_seq`] returns — the order
+    /// [`Self::match_order`] consumes resting orders. Reusing one scratch
+    /// buffer across calls avoids the per-call allocation the owned-`Vec`
+    /// variant pays, which matters for a downstream consumer that walks every
+    /// level repeatedly (e.g. a self-trade-prevention pre-scan).
+    ///
+    /// Like `snapshot_by_insertion_seq`, this is a point-in-time view: a
+    /// concurrent mutation after the call can change the queue.
+    pub fn snapshot_by_seq_into(&self, out: &mut Vec<Arc<OrderType<()>>>) {
+        self.orders.snapshot_by_seq_into(out);
+    }
+
     /// Returns `true` if any resting order has matchable depth, i.e. a positive
     /// taker would cross at this level.
     ///
@@ -292,7 +308,13 @@ impl PriceLevel {
     ///
     /// It allocates a working snapshot and is only used on the cold
     /// fill-or-kill path, not on the hot `Gtc` sweep.
-    fn matchable_quantity(&self, incoming_quantity: u64) -> u64 {
+    ///
+    /// Public so an order book composing this level can reuse the single
+    /// upstream source of truth for per-level fill-or-kill (all-or-nothing)
+    /// feasibility instead of re-deriving the sweep, which would risk drifting
+    /// from the real `match_order` behavior.
+    #[must_use]
+    pub fn matchable_quantity(&self, incoming_quantity: u64) -> u64 {
         if incoming_quantity == 0 {
             return 0;
         }

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -378,14 +378,26 @@ impl OrderQueue {
     /// the sweep even when timestamps are not monotonic with insertion.
     #[must_use]
     pub(crate) fn snapshot_by_seq(&self) -> Vec<Arc<OrderType<()>>> {
-        self.index
-            .iter()
-            .filter_map(|index_entry| {
-                self.orders
-                    .get(index_entry.value())
-                    .map(|order_entry| order_entry.value().1.clone())
-            })
-            .collect()
+        let mut out = Vec::new();
+        self.snapshot_by_seq_into(&mut out);
+        out
+    }
+
+    /// Fill `out` with the resting orders in ascending **insertion-sequence**
+    /// order — the buffer-reuse variant of [`OrderQueue::snapshot_by_seq`].
+    ///
+    /// `out` is cleared first, then extended in place, so a caller can reuse one
+    /// scratch buffer across many calls and avoid a per-call allocation (e.g. a
+    /// pooled buffer in a per-level pre-scan). The walk and skip-removed-entry
+    /// semantics are identical to [`OrderQueue::snapshot_by_seq`]; the only
+    /// difference is where the result lands.
+    pub(crate) fn snapshot_by_seq_into(&self, out: &mut Vec<Arc<OrderType<()>>>) {
+        out.clear();
+        out.extend(self.index.iter().filter_map(|index_entry| {
+            self.orders
+                .get(index_entry.value())
+                .map(|order_entry| order_entry.value().1.clone())
+        }));
     }
 
     /// Creates a new `OrderQueue` instance and populates it with orders from the provided vector.

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -5063,6 +5063,141 @@ mod tests {
             "a replenished maker moves to the tail"
         );
     }
+
+    // ------------------------------------------------------------------
+    // Issue #104 — snapshot_by_seq_into (buffer-reuse) + public
+    // matchable_quantity
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_snapshot_by_seq_into_matches_snapshot_by_insertion_seq() {
+        let level = PriceLevel::new(10_000);
+        level.add_order(create_standard_order(1, 10_000, 100));
+        level.add_order(create_standard_order(2, 10_000, 50));
+        level.add_order(create_iceberg_order(3, 10_000, 20, 30));
+
+        let owned: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+
+        let mut buf = Vec::new();
+        level.snapshot_by_seq_into(&mut buf);
+        let into: Vec<Id> = buf.iter().map(|o| o.id()).collect();
+
+        assert_eq!(
+            into, owned,
+            "snapshot_by_seq_into must yield the same sequence as \
+             snapshot_by_insertion_seq"
+        );
+        assert_eq!(
+            into,
+            vec![Id::from_u64(1), Id::from_u64(2), Id::from_u64(3)],
+            "the sequence is ascending insertion order"
+        );
+    }
+
+    #[test]
+    fn test_snapshot_by_seq_into_reuses_buffer() {
+        // Seed the scratch buffer from a level with THREE orders so the buffer
+        // starts non-empty (proving `clear()` discards the prior contents
+        // rather than appending to them).
+        let big = PriceLevel::new(10_000);
+        big.add_order(create_standard_order(1, 10_000, 100));
+        big.add_order(create_standard_order(2, 10_000, 100));
+        big.add_order(create_standard_order(3, 10_000, 100));
+        let mut buf = big.snapshot_by_insertion_seq();
+        assert_eq!(buf.len(), 3);
+
+        // Reuse the same buffer on a SMALLER level: it must shrink to one entry
+        // with no stale tail left over from the previous three.
+        let small = PriceLevel::new(10_000);
+        small.add_order(create_standard_order(10, 10_000, 100));
+        small.snapshot_by_seq_into(&mut buf);
+        let ids: Vec<Id> = buf.iter().map(|o| o.id()).collect();
+        assert_eq!(
+            ids,
+            vec![Id::from_u64(10)],
+            "buffer must be cleared, not appended to"
+        );
+
+        // Reuse the same buffer again on a LARGER level: it must grow and hold
+        // exactly the new contents in insertion order.
+        let bigger = PriceLevel::new(10_000);
+        for id in [20_u64, 21, 22, 23] {
+            bigger.add_order(create_standard_order(id, 10_000, 100));
+        }
+        bigger.snapshot_by_seq_into(&mut buf);
+        let ids: Vec<Id> = buf.iter().map(|o| o.id()).collect();
+        assert_eq!(
+            ids,
+            vec![
+                Id::from_u64(20),
+                Id::from_u64(21),
+                Id::from_u64(22),
+                Id::from_u64(23)
+            ],
+            "buffer must hold exactly the new contents, in insertion order"
+        );
+    }
+
+    #[test]
+    fn test_matchable_quantity_public_predicts_sweep() {
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+
+        // Plain makers: 100 + 50 = 150 of depth.
+        let level = PriceLevel::new(10_000);
+        level.add_order(create_standard_order(1, 10_000, 100));
+        level.add_order(create_standard_order(2, 10_000, 50));
+
+        assert_eq!(level.matchable_quantity(0), 0, "zero taker fills nothing");
+        assert_eq!(level.matchable_quantity(120), 120, "taker below depth");
+        // A taker above the available depth is capped at the depth.
+        let predicted = level.matchable_quantity(200);
+        assert_eq!(predicted, 150, "taker above depth is capped at depth");
+
+        // The dry run does not mutate, so the real sweep on the same level must
+        // consume exactly what was predicted.
+        let generator = UuidGenerator::new(namespace);
+        let result = level.match_order(
+            200,
+            Id::from_u64(999),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(1_700_000_000_000),
+            &generator,
+        );
+        assert_eq!(
+            result.executed_quantity().unwrap_or_default().as_u64(),
+            predicted,
+            "match_order consumes exactly matchable_quantity"
+        );
+
+        // Iceberg replenish: visible 10 over hidden 40 = 50 of total depth, all
+        // reachable across replenishment.
+        let ice = PriceLevel::new(10_000);
+        ice.add_order(create_iceberg_order(1, 10_000, 10, 40));
+        let predicted_ice = ice.matchable_quantity(100);
+        assert_eq!(
+            predicted_ice, 50,
+            "matchable_quantity reaches hidden depth via replenishment"
+        );
+        let generator = UuidGenerator::new(namespace);
+        let result = ice.match_order(
+            100,
+            Id::from_u64(998),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(1_700_000_000_000),
+            &generator,
+        );
+        assert_eq!(
+            result.executed_quantity().unwrap_or_default().as_u64(),
+            predicted_ice,
+            "match_order consumes exactly matchable_quantity for an iceberg"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #104.

Two small, **additive, non-breaking** API changes, shipped as **0.8.2**. Neither changes existing behavior, dependencies, matching semantics, or the snapshot wire format.

## Changes

### 1. `PriceLevel::matchable_quantity` is now `pub`
It was already the deterministic fill-or-kill dry run — a no-mutation replay of the FIFO sweep (including iceberg / reserve replenishment) that returns *exactly* what `match_order` would consume. Making it public lets a composing order book delegate per-level all-or-nothing feasibility to this single upstream source of truth instead of re-implementing the sweep and risking drift. Now `#[must_use]`, logic unchanged.

### 2. `snapshot_by_seq_into(&self, out: &mut Vec<Arc<OrderType<()>>>)` (buffer reuse)
A buffer-reuse variant of `snapshot_by_insertion_seq()`: clears `out` and refills it in ascending insertion sequence (the order `match_order` consumes orders), so a consumer that walks every level repeatedly (e.g. a self-trade-prevention pre-scan) can reuse one pooled scratch buffer and avoid the per-call allocation. Added on both `PriceLevel` (pub) and `OrderQueue` (pub(crate)); the existing `snapshot_by_seq()` now delegates to the `_into` form (single walk definition).

### Housekeeping
- Bump `Cargo.toml` `0.8.1` → `0.8.2`.
- New `CHANGELOG.md` (Keep a Changelog style) with the 0.8.2 entry plus back-fill for 0.8.1 / 0.8.0.

## Tests (`src/price_level/tests/level.rs`)
- `test_snapshot_by_seq_into_matches_snapshot_by_insertion_seq` — same sequence as the owned-`Vec` variant.
- `test_snapshot_by_seq_into_reuses_buffer` — seeds the buffer non-empty, then reuses it across a smaller and a larger level; asserts `clear()` (no stale tail) and correct grow/shrink contents.
- `test_matchable_quantity_public_predicts_sweep` — the now-public method equals what `match_order` actually consumes (depth cap + iceberg replenishment parity).

## Verification
- `make pre-push` clean: 415 lib tests (412 + 3 new), 9 proptests, 1 integration, 9 doctests; clippy + fmt + rustdoc `-D warnings` all green.
- No `README.md` diff (item docs only).

No new exported type → no `lib.rs` / `prelude.rs` re-export change and no migration-guide entry.