### PR TITLE
docs: Gtd payload is Unix milliseconds, not seconds (release 0.8.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.4] - 2026-07-10
+
+Patch release: a **documentation fix** to `TimeInForce::Gtd`'s payload unit. No
+API, behavior, or wire-format change.
+
+### Fixed
+
+- **`TimeInForce::Gtd`'s doc no longer claims the payload is seconds — it is
+  Unix MILLISECONDS since the epoch.** Every other timestamp in this crate is
+  milliseconds (`TimestampMs`, trade timestamps, statistics), this crate's own
+  tests always used 13-digit millisecond epochs for GTD, and `orderbook-rs`
+  compares the payload against `Clock::now_millis`. A caller following the old
+  doc and passing seconds got orders that appeared expired immediately. The
+  contract is now pinned by the `gtd_payload_unit_is_milliseconds` test
+  (found via joaquinbejar/OrderBook-rs#187).
+
 ## [0.8.3] - 2026-06-25
 
 Patch release: a **performance fix** to `match_order`'s transient allocation. No

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pricelevel"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
  - **Good Till Canceled (GTC)**: Order remains active until explicitly canceled
  - **Immediate Or Cancel (IOC)**: Order must be filled immediately (partially or completely) or canceled
  - **Fill Or Kill (FOK)**: Order must be filled completely immediately or canceled entirely
- - **Good Till Date (GTD)**: Order remains active until a specified date/time
+ - **Good Till Date (GTD)**: Order remains active until a specified date/time (Unix milliseconds)
  - **Day Order**: Order valid only for the current trading day
 
  ## Implementation Details

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //!  - **Good Till Canceled (GTC)**: Order remains active until explicitly canceled
 //!  - **Immediate Or Cancel (IOC)**: Order must be filled immediately (partially or completely) or canceled
 //!  - **Fill Or Kill (FOK)**: Order must be filled completely immediately or canceled entirely
-//!  - **Good Till Date (GTD)**: Order remains active until a specified date/time
+//!  - **Good Till Date (GTD)**: Order remains active until a specified date/time (Unix milliseconds)
 //!  - **Day Order**: Order valid only for the current trading day
 //!
 //!  ## Implementation Details

--- a/src/orders/tests/order_type.rs
+++ b/src/orders/tests/order_type.rs
@@ -218,7 +218,6 @@ mod tests {
         // Test with IOC time-in-force
         if let OrderType::<()>::Standard {
             ref mut time_in_force,
-            extra_fields: _,
             ..
         } = order
         {
@@ -235,7 +234,6 @@ mod tests {
         // Test with FOK time-in-force
         if let OrderType::<()>::Standard {
             ref mut time_in_force,
-            extra_fields: _,
             ..
         } = order
         {

--- a/src/orders/tests/time_in_force.rs
+++ b/src/orders/tests/time_in_force.rs
@@ -23,6 +23,24 @@ mod tests {
     }
 
     #[test]
+    fn gtd_payload_unit_is_milliseconds() {
+        // Issue joaquinbejar/OrderBook-rs#187: the Gtd payload is Unix
+        // MILLISECONDS (the doc previously said seconds). Pin the contract:
+        // against a milliseconds "now", a deadline 60s ahead in ms is live
+        // and the same deadline expressed in SECONDS reads as long-expired.
+        let now_ms: u64 = 1_700_000_000_000; // a 13-digit ms epoch
+        let deadline_ms = now_ms + 60_000;
+
+        assert!(!TimeInForce::Gtd(deadline_ms).is_expired(now_ms, None));
+        assert!(TimeInForce::Gtd(deadline_ms).is_expired(deadline_ms, None));
+
+        // A caller who follows the OLD (wrong) doc and passes seconds gets an
+        // instantly-expired order — the exact failure the doc fix prevents.
+        let deadline_secs = deadline_ms / 1000;
+        assert!(TimeInForce::Gtd(deadline_secs).is_expired(now_ms, None));
+    }
+
+    #[test]
     fn test_is_expired_gtd() {
         let expiry_time = 1000;
         let tif = TimeInForce::Gtd(expiry_time);

--- a/src/orders/time_in_force.rs
+++ b/src/orders/time_in_force.rs
@@ -24,7 +24,16 @@ pub enum TimeInForce {
     #[serde(alias = "fok", alias = "FOK")]
     Fok,
 
-    /// Good 'Til Date - The order remains active until a specified date and time, expressed as a Unix timestamp (seconds since epoch).
+    /// Good 'Til Date - The order remains active until a specified date and
+    /// time, expressed as a Unix timestamp in MILLISECONDS since the epoch.
+    ///
+    /// The payload unit is milliseconds — the same unit as every other
+    /// timestamp in this crate ([`TimestampMs`](crate::TimestampMs), trade
+    /// timestamps, statistics) and the unit `orderbook-rs` compares against
+    /// (`Clock::now_millis`). Earlier docs incorrectly said seconds; passing
+    /// seconds makes the order appear expired immediately against a
+    /// milliseconds clock. Pinned by `gtd_payload_unit_is_milliseconds` in
+    /// the tests.
     #[serde(rename(serialize = "GTD"))]
     #[serde(alias = "gtd", alias = "GTD")]
     Gtd(u64),


### PR DESCRIPTION
## Summary

Fixes the `TimeInForce::Gtd` payload-unit documentation (found via joaquinbejar/OrderBook-rs#187). The doc claimed "**seconds** since epoch" — the outlier inside this crate:

- `TimestampMs`, trade timestamps and statistics are all **milliseconds**;
- this crate's own tests always used 13-digit millisecond epochs for GTD (`order_type.rs`, `time_in_force.rs`);
- `orderbook-rs::OrderBook::has_expired` compares the payload against `Clock::now_millis()`.

A caller following the old doc and passing seconds got orders that appeared **expired immediately** against a milliseconds clock (this nearly caused a 1000× "fix" in the wrong direction downstream — see Option-Chain-OrderBook-Backend#98).

## Changes (doc-only — no API, behavior, or wire change)

- `Gtd` doc rewritten: milliseconds, rationale, cross-references.
- GTD bullet in `lib.rs`/README carries the unit; README regenerated via `make readme`.
- **`gtd_payload_unit_is_milliseconds`** pins the contract: an ms deadline is live against an ms clock; the same deadline expressed in seconds reads as long-expired.
- Version **0.8.3 → 0.8.4** + CHANGELOG (bump needed only to republish; cargo-semver-checks passes — API shape unchanged).

Closes the pricelevel half of joaquinbejar/OrderBook-rs#187.