### PR TITLE
Preserve queue-priority demotion across snapshot restore (#109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.5] - 2026-07-14
+
+Patch release: a **bug fix** to the snapshot round-trip's queue-priority
+preservation. The snapshot JSON *shape* is unchanged, but the `orders` array
+order — and therefore the package checksum — changes for levels whose
+consumption order diverges from timestamp order (a demoted or
+non-monotonically-timestamped maker).
+
+### Fixed
+
+- **A snapshot round-trip no longer undoes a queue-priority demotion.**
+  `PriceLevel::snapshot()` sorted its orders by `(timestamp, sequence)` and
+  did not serialize the insertion sequence, while `from_snapshot` re-enqueues
+  in vector order. An order demoted to the back of the queue with its original
+  admission timestamp intact — a quantity *increase* via `update_order`, or an
+  iceberg / reserve replenishment — therefore sorted back to its old timestamp
+  position on restore and wrongly regained front priority. The snapshot now
+  materializes orders in **queue-consumption order** (ascending insertion
+  sequence, exactly as `match_order` sweeps), so a restore reproduces the live
+  queue's price-time priority in all cases, demotions included. Found via the
+  queue-priority contract review in joaquinbejar/OrderBook-rs#204 (#109).
+
+### Notes
+
+- `PriceLevelSnapshot::orders()` / `iter_orders()` / `into_orders()` now
+  yield consumption order, not timestamp order. A consumer that wants
+  admission-time order should sort by `order.timestamp()` itself (or read
+  `PriceLevel::snapshot_orders()` on a live level, which keeps the
+  `(timestamp, sequence)` view).
+- A snapshot serialized by ≤ 0.8.4 that captured a demotion restores with the
+  old (wrong) front priority — the fix cannot repair data already persisted
+  in timestamp order. Re-snapshot with 0.8.5 to pin the correct order.
+
 ## [0.8.4] - 2026-07-10
 
 Patch release: a **documentation fix** to `TimeInForce::Gtd`'s payload unit. No

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pricelevel"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -267,9 +267,11 @@ impl PriceLevel {
     /// `out` is cleared and then extended in place, yielding the exact same
     /// sequence [`Self::snapshot_by_insertion_seq`] returns — the order
     /// [`Self::match_order`] consumes resting orders. Reusing one scratch
-    /// buffer across calls avoids the per-call allocation the owned-`Vec`
-    /// variant pays, which matters for a downstream consumer that walks every
-    /// level repeatedly (e.g. a self-trade-prevention pre-scan).
+    /// buffer across calls avoids the per-call allocation of the returned
+    /// `Vec`, which matters for a downstream consumer that walks every level
+    /// repeatedly (e.g. a self-trade-prevention pre-scan). Note that an
+    /// internal `(sequence, order)` pairs buffer plus its sort is still paid
+    /// per call, so the reuse saves only the output `Vec` allocation.
     ///
     /// Like `snapshot_by_insertion_seq`, this is a point-in-time view: a
     /// concurrent mutation after the call can change the queue.

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -775,11 +775,24 @@ impl PriceLevel {
     /// fold the vector instead of reading the live atomic counters separately,
     /// which would be a torn read (the atomics could advance between the counter
     /// load and the order materialization).
+    ///
+    /// The `orders` vector is materialized in **queue-consumption order**
+    /// (ascending insertion sequence — the exact order [`Self::match_order`]
+    /// consumes resting orders), not the `(timestamp, sequence)` display order
+    /// of [`Self::snapshot_orders`]. Because [`Self::from_snapshot`] re-enqueues
+    /// in vector order, a restore reproduces the live queue's priority exactly —
+    /// including the "sizing an order up loses time priority" demotion, where an
+    /// order that was moved to the back of the queue keeps its original
+    /// admission timestamp. Using the timestamp view here would let such an
+    /// order sort back to its old position and wrongly regain front priority on
+    /// restore.
     #[must_use]
     pub fn snapshot(&self) -> PriceLevelSnapshot {
-        // Materialize the orders exactly once; every aggregate is derived from
-        // this snapshot so they are mutually consistent by construction.
-        let orders = self.snapshot_orders();
+        // Materialize the orders exactly once, in queue-consumption (insertion
+        // sequence) order so a snapshot round-trip re-enqueues them in identical
+        // priority order; every aggregate is derived from this same snapshot so
+        // they are mutually consistent by construction.
+        let orders = self.snapshot_by_insertion_seq();
 
         let order_count = orders.len();
 

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -372,11 +372,23 @@ impl OrderQueue {
     /// Materialize the resting orders in ascending **insertion-sequence** order —
     /// the exact order [`OrderQueue::match_front`] consumes them.
     ///
-    /// Walks the `index` (`SkipMap<seq, Id>`, which iterates ascending) and
-    /// resolves each id in `orders`, skipping any transient index entry whose
-    /// order was already removed. Unlike [`OrderQueue::snapshot_vec`] (sorted by
-    /// `(timestamp, sequence)`), this reflects pure insertion order, so it equals
-    /// the sweep even when timestamps are not monotonic with insertion.
+    /// Derived from the authoritative `orders` map (keyed by `Id`) rather than
+    /// the `index`: we collect the `(stored_seq, order)` pairs and sort by the
+    /// stored sequence. Because the map holds exactly one entry per order, a
+    /// duplicate id is impossible by construction, and because each
+    /// `(seq, order)` pair is swapped atomically under the `DashMap` per-entry
+    /// lock (both [`FrontAction::ReplaceAtTail`] and
+    /// [`OrderQueue::update_in_place`] mutate value and sequence together under
+    /// it), every emitted pair is a real committed state — an order caught
+    /// mid-re-sequencing appears at either its old or its new sequence, never
+    /// both and never as a mixed `(old_seq, new_order)` pair. Walking the
+    /// `index` instead could pin a stale `seq -> id` entry during a
+    /// re-sequencing and emit the same order twice (or at the wrong priority),
+    /// which corrupts a snapshot fold.
+    ///
+    /// Unlike [`OrderQueue::snapshot_vec`] (sorted by `(timestamp, sequence)`),
+    /// this reflects pure insertion order, so it equals the sweep even when
+    /// timestamps are not monotonic with insertion.
     ///
     /// This view also backs [`crate::price_level::PriceLevel::snapshot`]: the
     /// snapshot round-trip re-enqueues in this consumption order, so exact
@@ -393,17 +405,28 @@ impl OrderQueue {
     /// order — the buffer-reuse variant of [`OrderQueue::snapshot_by_seq`].
     ///
     /// `out` is cleared first, then extended in place, so a caller can reuse one
-    /// scratch buffer across many calls and avoid a per-call allocation (e.g. a
-    /// pooled buffer in a per-level pre-scan). The walk and skip-removed-entry
-    /// semantics are identical to [`OrderQueue::snapshot_by_seq`]; the only
-    /// difference is where the result lands.
+    /// scratch buffer across calls and avoid the per-call allocation of the
+    /// returned `Vec`. Note the internal `(seq, order)` pairs buffer plus its
+    /// sort is still paid on every call — the reuse saves only the output `Vec`
+    /// allocation, not the collect-and-sort. The duplicate-free,
+    /// committed-pair guarantees are identical to
+    /// [`OrderQueue::snapshot_by_seq`]; the only difference is where the result
+    /// lands.
     pub(crate) fn snapshot_by_seq_into(&self, out: &mut Vec<Arc<OrderType<()>>>) {
+        // Build from the `orders` map (one entry per id) so a concurrent
+        // re-sequencing can never surface an order twice or at a mixed
+        // priority; see `snapshot_by_seq` for the full rationale.
+        let mut pairs: Vec<(u64, Arc<OrderType<()>>)> = self
+            .orders
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect();
+        // Unstable sort is deterministic here because sequences are unique
+        // across live orders (`push` / `ReplaceAtTail` mint distinct seqs via
+        // `fetch_add`; `update_in_place` keeps the order's own seq).
+        pairs.sort_unstable_by_key(|(seq, _)| *seq);
         out.clear();
-        out.extend(self.index.iter().filter_map(|index_entry| {
-            self.orders
-                .get(index_entry.value())
-                .map(|order_entry| order_entry.value().1.clone())
-        }));
+        out.extend(pairs.into_iter().map(|(_, order)| order));
     }
 
     /// Creates a new `OrderQueue` instance and populates it with orders from the provided vector.
@@ -464,11 +487,12 @@ impl Serialize for OrderQueue {
         S: Serializer,
     {
         // Materialize the ordered view first so the length hint always matches
-        // the number of elements emitted. Iterating `index` while hinting
-        // `self.len()` (from `orders`) could disagree in a transient state
-        // where an order is in one structure but not yet the other.
-        // Insertion-sequence order keeps the round-trip price-time priority
-        // (the DashMap alone has no deterministic iteration order).
+        // the number of elements emitted. `snapshot_by_seq` derives its pairs
+        // from the `orders` map (one entry per id) and sorts by insertion
+        // sequence, so it can neither duplicate an order nor disagree with its
+        // own length during a concurrent re-sequencing. Insertion-sequence
+        // order keeps the round-trip price-time priority (the DashMap alone has
+        // no deterministic iteration order).
         let ordered = self.snapshot_by_seq();
         let mut seq = serializer.serialize_seq(Some(ordered.len()))?;
         for order in &ordered {

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -350,10 +350,11 @@ impl OrderQueue {
     ///
     /// The insertion sequence is used as a deterministic tiebreak so orders
     /// sharing a millisecond timestamp are still ordered exactly as matching
-    /// would consume them. Note the sequence itself is not serialized: a
-    /// snapshot round-trip reconstructs queue order from `(timestamp,
-    /// sequence)`, so exact price-time priority survives a round-trip only when
-    /// timestamps are monotonic with insertion order (the normal case).
+    /// would consume them. This is the timestamp-sorted display / reporting
+    /// view; it is not what a snapshot round-trip uses. Snapshot round-trips
+    /// materialize via `snapshot_by_seq` (ascending insertion sequence), so the
+    /// live queue order — including the "sizing up loses time priority"
+    /// demotion — survives a restore.
     #[must_use]
     pub fn snapshot_vec(&self) -> Vec<Arc<OrderType<()>>> {
         let mut orders: Vec<(u64, Arc<OrderType<()>>)> =
@@ -376,6 +377,11 @@ impl OrderQueue {
     /// order was already removed. Unlike [`OrderQueue::snapshot_vec`] (sorted by
     /// `(timestamp, sequence)`), this reflects pure insertion order, so it equals
     /// the sweep even when timestamps are not monotonic with insertion.
+    ///
+    /// This view also backs [`crate::price_level::PriceLevel::snapshot`]: the
+    /// snapshot round-trip re-enqueues in this consumption order, so exact
+    /// price-time priority — including the "sizing up loses time priority"
+    /// demotion — is preserved across a restore.
     #[must_use]
     pub(crate) fn snapshot_by_seq(&self) -> Vec<Arc<OrderType<()>>> {
         let mut out = Vec::new();

--- a/src/price_level/snapshot.rs
+++ b/src/price_level/snapshot.rs
@@ -54,6 +54,12 @@ impl PriceLevelSnapshot {
     /// The statistics are initialized empty; use [`Self::with_orders_and_stats`]
     /// to carry recorded execution statistics into the snapshot.
     ///
+    /// The `orders` vector order is significant: it is the queue-consumption
+    /// order a restore reproduces, since
+    /// [`crate::price_level::PriceLevel::from_snapshot`] re-enqueues in vector
+    /// order. Pass orders in ascending insertion-sequence (sweep) order to
+    /// preserve price-time priority across a round-trip.
+    ///
     /// # Errors
     ///
     /// Returns [`PriceLevelError::InvalidOperation`] if summing the per-order
@@ -120,6 +126,10 @@ impl PriceLevelSnapshot {
     }
 
     /// Returns a reference to the orders in this snapshot.
+    ///
+    /// The vector order is significant: it is the queue-consumption order a
+    /// restore reproduces, since [`crate::price_level::PriceLevel::from_snapshot`]
+    /// re-enqueues the orders in vector order.
     #[must_use]
     pub fn orders(&self) -> &[Arc<OrderType<()>>] {
         &self.orders

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -5180,6 +5180,127 @@ mod tests {
     }
 
     #[test]
+    fn test_snapshot_concurrent_resequencing_no_duplicates() {
+        // Issue #110 (PR review): while a maker is re-sequenced (an upsize's
+        // remove+push demotion), a concurrent reader must never observe the
+        // same order twice — or a torn (order_count, orders) pair — in a
+        // snapshot. The old `snapshot_by_seq` walked the SkipMap `index` and
+        // could pin a stale `seq -> id` entry mid-re-sequencing, emit the
+        // refreshed order at BOTH its old and new sequence, and hand
+        // `snapshot()` a vector with a duplicate id whose fold corrupts the
+        // restore. Deriving the view from the id-keyed `orders` map makes a
+        // duplicate impossible by construction; this test guards that.
+        use std::collections::HashSet;
+        use std::sync::atomic::AtomicBool;
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        const N: usize = 8;
+        const WRITER_ITERS: usize = 300;
+        const READERS: usize = 2;
+
+        let level = Arc::new(PriceLevel::new(10_000));
+        // N resting standard makers with known ids 1..=N and initial quantity
+        // 100 (monotonic timestamps via the shared counter).
+        for id in 1..=N as u64 {
+            level.add_order(create_standard_order(id, 10_000, 100));
+        }
+
+        // Barrier aligns the single writer with the readers so the resequencing
+        // churn and the snapshots genuinely overlap (global_rules requires a
+        // Barrier start for concurrency tests).
+        let barrier = Arc::new(Barrier::new(READERS + 1));
+        let writer_done = Arc::new(AtomicBool::new(false));
+
+        let writer = {
+            let level = Arc::clone(&level);
+            let barrier = Arc::clone(&barrier);
+            let writer_done = Arc::clone(&writer_done);
+            thread::spawn(move || {
+                barrier.wait();
+                for k in 0..WRITER_ITERS {
+                    // Rotate through the ids; the target quantity strictly
+                    // increases every time (1000 + k > any prior value assigned
+                    // to this id, and > the initial 100), so each update takes
+                    // the quantity-increase branch and demotes via remove+push.
+                    let id = Id::from_u64((k % N) as u64 + 1);
+                    let new_quantity = Quantity::new(1_000 + k as u64);
+                    let _ = level
+                        .update_order(OrderUpdate::UpdateQuantity {
+                            order_id: id,
+                            new_quantity,
+                        })
+                        .expect("upsize update must not error");
+                }
+                writer_done.store(true, Ordering::Release);
+            })
+        };
+
+        let readers: Vec<_> = (0..READERS)
+            .map(|_| {
+                let level = Arc::clone(&level);
+                let barrier = Arc::clone(&barrier);
+                let writer_done = Arc::clone(&writer_done);
+                thread::spawn(move || {
+                    barrier.wait();
+                    loop {
+                        // Observe the flag BEFORE taking the snapshot, then run
+                        // one more check after it flips, so a final post-writer
+                        // snapshot is always validated too.
+                        let finished = writer_done.load(Ordering::Acquire);
+
+                        let snap = level.snapshot();
+                        let ids: HashSet<Id> = snap.orders().iter().map(|o| o.id()).collect();
+                        assert_eq!(
+                            ids.len(),
+                            snap.orders().len(),
+                            "snapshot contains a duplicate order id under concurrent resequencing"
+                        );
+                        assert_eq!(
+                            snap.orders().len(),
+                            snap.order_count(),
+                            "snapshot order_count disagrees with its own orders vector"
+                        );
+
+                        // The snapshot must also round-trip into a level whose
+                        // rebuilt queue length matches its order_count.
+                        let restored =
+                            PriceLevel::from_snapshot(snap).expect("from_snapshot must succeed");
+                        assert_eq!(
+                            restored.order_count(),
+                            restored.snapshot_by_insertion_seq().len(),
+                            "restored order_count disagrees with rebuilt queue length"
+                        );
+
+                        if finished {
+                            break;
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        writer.join().expect("writer thread panicked");
+        for reader in readers {
+            reader.join().expect("reader thread panicked");
+        }
+
+        // After the churn settles the level still holds exactly the N makers,
+        // with no duplicates and counters consistent with the queue.
+        assert_counters_match_queue(&level);
+        let final_ids: HashSet<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+        assert_eq!(
+            final_ids.len(),
+            N,
+            "the level must still hold exactly N distinct makers"
+        );
+    }
+
+    #[test]
     fn test_snapshot_by_insertion_seq_empty_level() {
         let level = PriceLevel::new(10_000);
         assert!(level.snapshot_by_insertion_seq().is_empty());

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -5000,6 +5000,186 @@ mod tests {
     }
 
     #[test]
+    fn test_snapshot_restore_preserves_upsize_demotion() {
+        // Issue #109: sizing an order up demotes it to the back of the queue
+        // (remove+push mints a fresh insertion sequence) while keeping its
+        // original admission timestamp. A snapshot round-trip must reproduce
+        // that demotion, not let the order sort back to its timestamp position
+        // and wrongly regain front priority.
+        let level = PriceLevel::new(10_000);
+        // Three standard makers with monotonic timestamps (TIMESTAMP_COUNTER),
+        // so insertion sequence and timestamp order initially agree.
+        level.add_order(create_standard_order(1, 10_000, 100));
+        level.add_order(create_standard_order(2, 10_000, 100));
+        level.add_order(create_standard_order(3, 10_000, 100));
+
+        // Upsize maker 1 (Standard orders resize): total increases 100 -> 150,
+        // so update_order takes the quantity-increase branch and demotes it to
+        // the back, behind 2 and 3.
+        let updated = level
+            .update_order(OrderUpdate::UpdateQuantity {
+                order_id: Id::from_u64(1),
+                new_quantity: Quantity::new(150),
+            })
+            .expect("upsize update should succeed")
+            .expect("maker 1 must still be present");
+        assert_eq!(updated.visible_quantity().as_u64(), 150);
+
+        // Pre-snapshot consumption order reflects the demotion: 2, 3, then 1.
+        let pre_ids: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+        assert_eq!(
+            pre_ids,
+            vec![Id::from_u64(2), Id::from_u64(3), Id::from_u64(1)],
+            "upsized maker 1 must sit at the back of the live queue"
+        );
+        let original_visible = level.visible_quantity();
+
+        // Full JSON round-trip through the checksum-protected package.
+        let json = level
+            .snapshot_to_json()
+            .expect("snapshot_to_json should succeed");
+        let restored =
+            PriceLevel::from_snapshot_json(&json).expect("from_snapshot_json should succeed");
+
+        // The restored level reproduces the demoted consumption order exactly.
+        let restored_ids: Vec<Id> = restored
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+        assert_eq!(
+            restored_ids,
+            vec![Id::from_u64(2), Id::from_u64(3), Id::from_u64(1)],
+            "restore must preserve the upsize demotion, not regain front priority"
+        );
+
+        // Counters survive the round-trip: 100 + 100 + 150 = 350 visible.
+        assert_eq!(
+            restored.visible_quantity(),
+            original_visible,
+            "restored visible quantity must equal the original"
+        );
+        assert_eq!(restored.visible_quantity(), 350);
+
+        // Draining the restored level to completion must emit trades in the
+        // demoted maker order: 2, 3, then the upsized 1.
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let generator = UuidGenerator::new(namespace);
+        let result = restored.match_order(
+            1_000,
+            Id::from_u64(999),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(9_000),
+            &generator,
+        );
+        let makers: Vec<Id> = result
+            .trades()
+            .as_vec()
+            .iter()
+            .map(|t| t.maker_order_id())
+            .collect();
+        assert_eq!(
+            makers,
+            vec![Id::from_u64(2), Id::from_u64(3), Id::from_u64(1)],
+            "restored match_order must consume makers in the demoted order"
+        );
+    }
+
+    #[test]
+    fn test_snapshot_restore_preserves_iceberg_replenish_demotion() {
+        // Issue #109 (same bug class as the upsize): an iceberg/reserve
+        // replenishment re-queues the refreshed tranche at the TAIL
+        // (ReplaceAtTail, fresh sequence) while keeping its ORIGINAL timestamp.
+        // A snapshot round-trip must reproduce that demotion, not let the
+        // refreshed tranche sort back to its timestamp position and regain
+        // front priority.
+        let level = PriceLevel::new(10_000);
+        // Iceberg maker (id 1, Sell) added first: visible 50 over hidden 100.
+        level.add_order(create_iceberg_order(1, 10_000, 50, 100));
+        // A plain Sell maker (id 2) rests behind it.
+        level.add_order(create_sell_standard_order(2, 10_000, 100));
+
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let generator = UuidGenerator::new(namespace);
+        // Fully consume the iceberg's visible tranche (50): it replenishes from
+        // hidden and is re-queued at the TAIL, behind maker 2.
+        let _ = level.match_order(
+            50,
+            Id::from_u64(901),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(1_700_000_000_000),
+            &generator,
+        );
+
+        // Live consumption order reflects the replenish demotion: 2, then 1.
+        let pre_ids: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+        assert_eq!(
+            pre_ids,
+            vec![Id::from_u64(2), Id::from_u64(1)],
+            "replenished iceberg must sit at the back of the live queue"
+        );
+        let original_visible = level.visible_quantity();
+
+        // Full JSON round-trip through the checksum-protected package.
+        let json = level
+            .snapshot_to_json()
+            .expect("snapshot_to_json should succeed");
+        let restored =
+            PriceLevel::from_snapshot_json(&json).expect("from_snapshot_json should succeed");
+
+        // The restored level reproduces the demoted consumption order exactly.
+        let restored_ids: Vec<Id> = restored
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+        assert_eq!(
+            restored_ids,
+            vec![Id::from_u64(2), Id::from_u64(1)],
+            "restore must preserve the replenish demotion, not regain front priority"
+        );
+        assert_eq!(
+            restored.visible_quantity(),
+            original_visible,
+            "restored visible quantity must equal the original"
+        );
+
+        // Draining the restored level to completion must emit trades with
+        // maker 2 before maker 1. The iceberg may emit several trades as it
+        // replenishes, so compare the order-preserving de-duplicated makers.
+        let drain = restored.match_order(
+            1_000,
+            Id::from_u64(902),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(1_700_000_000_001),
+            &generator,
+        );
+        let mut deduped: Vec<Id> = Vec::new();
+        for trade in drain.trades().as_vec() {
+            let maker = trade.maker_order_id();
+            if deduped.last() != Some(&maker) {
+                deduped.push(maker);
+            }
+        }
+        assert_eq!(
+            deduped,
+            vec![Id::from_u64(2), Id::from_u64(1)],
+            "restored match_order must consume maker 2 fully before the demoted iceberg 1"
+        );
+    }
+
+    #[test]
     fn test_snapshot_by_insertion_seq_empty_level() {
         let level = PriceLevel::new(10_000);
         assert!(level.snapshot_by_insertion_seq().is_empty());


### PR DESCRIPTION
## Summary

A snapshot round-trip could undo the queue-priority demotion applied by a
quantity increase (and by iceberg / reserve replenishment): the demoted order
keeps its original admission timestamp and the demotion lives only in the
insertion sequence, which `PriceLevel::snapshot()` sorted away and never
serialized. On restore the order sorted back to its old timestamp position and
wrongly regained front priority. The snapshot now materializes its orders in
queue-consumption order, so a restore reproduces the live queue's price-time
priority exactly — demotions included.

## Changes

- `PriceLevel::snapshot()` materializes orders via
  `snapshot_by_insertion_seq()` (ascending insertion sequence — the exact
  order `match_order` consumes) instead of the `(timestamp, sequence)`-sorted
  `snapshot_orders()`. Since `from_snapshot` re-enqueues in vector order, the
  restored queue's consumption order now equals the original's in all cases.
- `snapshot_orders()` keeps its public `(timestamp, sequence)`-sorted view;
  only the snapshot payload ordering changes.
- Docs: dropped the now-obsolete monotonic-timestamp round-trip caveat on
  `OrderQueue::snapshot_vec()`; noted on `snapshot_by_seq`,
  `PriceLevelSnapshot::orders()`, and `with_orders` that vector order is the
  queue order a restore reproduces.
- Regression tests for both demotion sources with full JSON round-trips
  (upsize via `update_order`, iceberg replenishment), asserting restored
  consumption order and post-restore `match_order` trade emission.
- Release 0.8.5 + CHANGELOG entry, including a forward-compat note:
  pre-0.8.5 snapshots that captured a demotion restore with the old (wrong)
  front priority — re-snapshot to pin the correct order.

## Technical decisions

- **No snapshot format change / no version bump of the package format.** The
  orders were always a plain JSON array; only the element order changes (and
  therefore the SHA-256 checksum for levels whose consumption order diverges
  from timestamp order). Checksums are computed fresh at package creation, so
  round-trips are unaffected.
- **Consumption order is the right serialization order**: timestamp order
  actively misrepresents priority for a demoted maker, while insertion-seq
  order is by construction what `match_order` sweeps. This also fixes the
  latent case of client-supplied non-monotonic timestamps without any resize.
- Reviewed by `microstructure-critic`: fix confirmed correct for upsize,
  iceberg/reserve replenishment (same bug class — refreshed tranche keeps its
  original timestamp), partially filled makers (in-place, seq unchanged), and
  non-monotonic timestamps. The iceberg round-trip regression test was added
  at its recommendation.

## Testing

- [x] Unit tests added or updated (co-located under `src/<module>/tests/`)
- [x] Snapshot round-trip covered via `PriceLevelSnapshotPackage` (full
  `snapshot_to_json()` → `from_snapshot_json()` in both regression tests)
- [x] Matching coverage: post-restore full-drain `match_order` asserts trade
  emission order for both demotion sources
- [x] `make pre-push` run locally and clean

439 tests passed; 0 failed (420 lib + 9 unit-integration + 1 proptest harness + 9 doctests). `cargo clippy --all-targets --all-features -- -D
warnings`, `cargo fmt --all --check`, and `cargo build --release` all clean.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic on quantity / value / counters — no `saturating_*` / `wrapping_*`
- [x] No new production `unsafe` introduced
- [x] Module boundaries respected (`errors` / `utils` are leaves; `orders` → `execution` → `price_level`; nothing imports from `prelude`)
- [x] No new dependencies added without explicit approval (no `thiserror` / `anyhow`)
- [x] `tracing` only for logging — no `println!` / `eprintln!` / `dbg!` / `log` crate
- [x] `src/lib.rs` docs + `README.md` unchanged — no public surface change

Closes #109
