### PR TITLE
Parse malformed UTF-8 in MatchResult::from_str without panicking (#114)

### DIFF
--- a/src/execution/match_result.rs
+++ b/src/execution/match_result.rs
@@ -379,22 +379,26 @@ impl FromStr for MatchResult {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         fn find_next_field(s: &str, start_pos: usize) -> Result<(&str, usize), PriceLevelError> {
+            // Scan raw bytes for the ASCII ';' delimiter rather than advancing a
+            // `&str` slice one byte at a time. Every byte of a multibyte scalar
+            // is >= 0x80, so it can never equal `b';'` (0x3B): a byte comparison
+            // never mistakes an interior byte for the delimiter, and we only
+            // ever form a `&str` slice at a `;` position or the end of the
+            // string — both guaranteed char boundaries — so slicing cannot panic
+            // on malformed UTF-8. `start_pos` is always the boundary just after
+            // an ASCII `=`.
+            let bytes = s.as_bytes();
             let mut pos = start_pos;
 
-            while pos < s.len() {
-                if s[pos..].starts_with(';') {
-                    let value = &s[start_pos..pos];
-                    return Ok((value, pos + 1));
+            while pos < bytes.len() {
+                if bytes[pos] == b';' {
+                    return Ok((&s[start_pos..pos], pos + 1));
                 }
                 pos += 1;
             }
 
-            if pos == s.len() {
-                let value = &s[start_pos..pos];
-                return Ok((value, pos));
-            }
-
-            Err(PriceLevelError::InvalidFormat)
+            // No ';' before the end: the value runs to the end of the string.
+            Ok((&s[start_pos..], bytes.len()))
         }
         if !s.starts_with("MatchResult:") {
             return Err(PriceLevelError::InvalidFormat);
@@ -406,10 +410,18 @@ impl FromStr for MatchResult {
         let mut trades_str = None;
         let mut filled_order_ids_str = None;
 
+        // Scan over the raw bytes. Every structural delimiter in the format
+        // (`=`, `;`, `[`, `]`) and every literal prefix (`Trades:[`) is ASCII,
+        // so a byte comparison locates them without ever splitting a multibyte
+        // scalar, and every `&str` slice below is taken at an ASCII delimiter
+        // position (or the string end) — all guaranteed char boundaries — so a
+        // field carrying malformed / multibyte text yields a deterministic
+        // `Err`, never a slice-on-non-boundary panic.
+        let bytes = s.as_bytes();
         let mut pos = "MatchResult:".len();
 
-        while pos < s.len() {
-            let field_end = match s[pos..].find('=') {
+        while pos < bytes.len() {
+            let field_end = match bytes[pos..].iter().position(|&b| b == b'=') {
                 Some(idx) => pos + idx,
                 None => return Err(PriceLevelError::InvalidFormat),
             };
@@ -433,25 +445,29 @@ impl FromStr for MatchResult {
                     pos = next_pos;
                 }
                 "trades" => {
-                    if !s[pos..].starts_with("Trades:[") {
+                    if !bytes[pos..].starts_with(b"Trades:[") {
                         return Err(PriceLevelError::InvalidFormat);
                     }
 
                     let mut bracket_depth = 1;
                     let mut i = pos + "Trades:[".len();
 
-                    while i < s.len() && bracket_depth > 0 {
-                        if s[i..].starts_with(']') {
-                            bracket_depth -= 1;
-                            if bracket_depth == 0 {
-                                break;
+                    while i < bytes.len() && bracket_depth > 0 {
+                        match bytes[i] {
+                            b']' => {
+                                bracket_depth -= 1;
+                                if bracket_depth == 0 {
+                                    break;
+                                }
+                                i += 1;
                             }
-                            i += 1;
-                        } else if s[i..].starts_with('[') {
-                            bracket_depth += 1;
-                            i += 1;
-                        } else {
-                            i += 1;
+                            b'[' => {
+                                bracket_depth += 1;
+                                i += 1;
+                            }
+                            _ => {
+                                i += 1;
+                            }
                         }
                     }
 
@@ -459,34 +475,40 @@ impl FromStr for MatchResult {
                         return Err(PriceLevelError::InvalidFormat);
                     }
 
+                    // `i` is the byte index of the closing ASCII `]`, so the
+                    // inclusive slice ends on a char boundary.
                     trades_str = Some(&s[pos..=i]);
                     pos = i + 1;
-                    if pos < s.len() && s[pos..].starts_with(';') {
+                    if pos < bytes.len() && bytes[pos] == b';' {
                         pos += 1;
-                    } else if pos < s.len() {
+                    } else if pos < bytes.len() {
                         return Err(PriceLevelError::InvalidFormat);
                     }
                 }
                 "filled_order_ids" => {
-                    if !s[pos..].starts_with('[') {
+                    if bytes.get(pos) != Some(&b'[') {
                         return Err(PriceLevelError::InvalidFormat);
                     }
 
                     let mut bracket_depth = 1;
                     let mut i = pos + 1;
 
-                    while i < s.len() && bracket_depth > 0 {
-                        if s[i..].starts_with(']') {
-                            bracket_depth -= 1;
-                            if bracket_depth == 0 {
-                                break;
+                    while i < bytes.len() && bracket_depth > 0 {
+                        match bytes[i] {
+                            b']' => {
+                                bracket_depth -= 1;
+                                if bracket_depth == 0 {
+                                    break;
+                                }
+                                i += 1;
                             }
-                            i += 1;
-                        } else if s[i..].starts_with('[') {
-                            bracket_depth += 1;
-                            i += 1;
-                        } else {
-                            i += 1;
+                            b'[' => {
+                                bracket_depth += 1;
+                                i += 1;
+                            }
+                            _ => {
+                                i += 1;
+                            }
                         }
                     }
 
@@ -494,10 +516,12 @@ impl FromStr for MatchResult {
                         return Err(PriceLevelError::InvalidFormat);
                     }
 
+                    // `i` is the byte index of the closing ASCII `]`, so the
+                    // inclusive slice ends on a char boundary.
                     filled_order_ids_str = Some(&s[pos..=i]);
 
                     pos = i + 1;
-                    if pos < s.len() && s[pos..].starts_with(';') {
+                    if pos < bytes.len() && bytes[pos] == b';' {
                         pos += 1;
                     }
                 }

--- a/src/execution/match_result.rs
+++ b/src/execution/match_result.rs
@@ -390,15 +390,19 @@ impl FromStr for MatchResult {
             let bytes = s.as_bytes();
             let mut pos = start_pos;
 
-            while pos < bytes.len() {
-                if bytes[pos] == b';' {
-                    return Ok((&s[start_pos..pos], pos + 1));
+            while let Some(&byte) = bytes.get(pos) {
+                if byte == b';' {
+                    let value = s
+                        .get(start_pos..pos)
+                        .ok_or(PriceLevelError::InvalidFormat)?;
+                    return Ok((value, pos + 1));
                 }
                 pos += 1;
             }
 
             // No ';' before the end: the value runs to the end of the string.
-            Ok((&s[start_pos..], bytes.len()))
+            let value = s.get(start_pos..).ok_or(PriceLevelError::InvalidFormat)?;
+            Ok((value, bytes.len()))
         }
         if !s.starts_with("MatchResult:") {
             return Err(PriceLevelError::InvalidFormat);
@@ -421,12 +425,17 @@ impl FromStr for MatchResult {
         let mut pos = "MatchResult:".len();
 
         while pos < bytes.len() {
-            let field_end = match bytes[pos..].iter().position(|&b| b == b'=') {
+            let field_end = match bytes
+                .get(pos..)
+                .and_then(|rest| rest.iter().position(|&b| b == b'='))
+            {
                 Some(idx) => pos + idx,
                 None => return Err(PriceLevelError::InvalidFormat),
             };
 
-            let field_name = &s[pos..field_end];
+            let field_name = s
+                .get(pos..field_end)
+                .ok_or(PriceLevelError::InvalidFormat)?;
             pos = field_end + 1;
             match field_name {
                 "order_id" => {
@@ -445,29 +454,33 @@ impl FromStr for MatchResult {
                     pos = next_pos;
                 }
                 "trades" => {
-                    if !bytes[pos..].starts_with(b"Trades:[") {
+                    if !bytes
+                        .get(pos..)
+                        .is_some_and(|rest| rest.starts_with(b"Trades:["))
+                    {
                         return Err(PriceLevelError::InvalidFormat);
                     }
 
                     let mut bracket_depth = 1;
                     let mut i = pos + "Trades:[".len();
 
-                    while i < bytes.len() && bracket_depth > 0 {
-                        match bytes[i] {
-                            b']' => {
+                    while bracket_depth > 0 {
+                        match bytes.get(i) {
+                            Some(b']') => {
                                 bracket_depth -= 1;
                                 if bracket_depth == 0 {
                                     break;
                                 }
                                 i += 1;
                             }
-                            b'[' => {
+                            Some(b'[') => {
                                 bracket_depth += 1;
                                 i += 1;
                             }
-                            _ => {
+                            Some(_) => {
                                 i += 1;
                             }
+                            None => break,
                         }
                     }
 
@@ -477,9 +490,9 @@ impl FromStr for MatchResult {
 
                     // `i` is the byte index of the closing ASCII `]`, so the
                     // inclusive slice ends on a char boundary.
-                    trades_str = Some(&s[pos..=i]);
+                    trades_str = Some(s.get(pos..=i).ok_or(PriceLevelError::InvalidFormat)?);
                     pos = i + 1;
-                    if pos < bytes.len() && bytes[pos] == b';' {
+                    if bytes.get(pos) == Some(&b';') {
                         pos += 1;
                     } else if pos < bytes.len() {
                         return Err(PriceLevelError::InvalidFormat);
@@ -493,22 +506,23 @@ impl FromStr for MatchResult {
                     let mut bracket_depth = 1;
                     let mut i = pos + 1;
 
-                    while i < bytes.len() && bracket_depth > 0 {
-                        match bytes[i] {
-                            b']' => {
+                    while bracket_depth > 0 {
+                        match bytes.get(i) {
+                            Some(b']') => {
                                 bracket_depth -= 1;
                                 if bracket_depth == 0 {
                                     break;
                                 }
                                 i += 1;
                             }
-                            b'[' => {
+                            Some(b'[') => {
                                 bracket_depth += 1;
                                 i += 1;
                             }
-                            _ => {
+                            Some(_) => {
                                 i += 1;
                             }
+                            None => break,
                         }
                     }
 
@@ -518,10 +532,11 @@ impl FromStr for MatchResult {
 
                     // `i` is the byte index of the closing ASCII `]`, so the
                     // inclusive slice ends on a char boundary.
-                    filled_order_ids_str = Some(&s[pos..=i]);
+                    filled_order_ids_str =
+                        Some(s.get(pos..=i).ok_or(PriceLevelError::InvalidFormat)?);
 
                     pos = i + 1;
-                    if pos < bytes.len() && bytes[pos] == b';' {
+                    if bytes.get(pos) == Some(&b';') {
                         pos += 1;
                     }
                 }

--- a/src/execution/tests/match_result_trade.rs
+++ b/src/execution/tests/match_result_trade.rs
@@ -278,4 +278,159 @@ mod tests {
             }
         }
     }
+
+    // ----- issue #114: malformed UTF-8 must parse to Err, never panic -----
+    //
+    // `MatchResult::from_str` accepts untrusted text and must return a
+    // `Result`, so a multibyte Unicode scalar sitting before the next ASCII
+    // delimiter must not make an internal byte offset land inside the scalar
+    // and panic on a non-char-boundary slice. Each case below simply calls
+    // `from_str` and asserts `Err`: a plain call is enough to prove no panic,
+    // because a panic would unwind the test rather than reach the assertion.
+
+    /// Every field position that the byte scanners walk — a plain field value,
+    /// a value that runs to the end of the string with no trailing `;`, a
+    /// field name, the `trades` bracket body, and the `filled_order_ids`
+    /// bracket body — must reject 2-, 3-, and 4-byte scalars deterministically.
+    #[test]
+    fn from_str_rejects_multibyte_without_panicking() {
+        // 'é' = 2 bytes, '→' = 3 bytes, '😀' = 4 bytes: cover every UTF-8 width
+        // and a scalar straddling each delimiter position.
+        let malformed = [
+            // Multibyte in a field value immediately before the ';' delimiter.
+            "MatchResult:order_id=é;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[];filled_order_ids=[]",
+            "MatchResult:order_id=→;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[];filled_order_ids=[]",
+            // Multibyte in the LAST-scanned value that runs to end-of-string
+            // (no trailing ';'): exercises the find-to-end branch.
+            "MatchResult:order_id=10😀",
+            // Multibyte in a field NAME (before the '=').
+            "MatchResult:é=10;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[];filled_order_ids=[]",
+            // Multibyte inside the trades bracket body.
+            "MatchResult:order_id=10;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[é];filled_order_ids=[]",
+            "MatchResult:order_id=10;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[😀];filled_order_ids=[]",
+            // Multibyte inside the filled_order_ids bracket list.
+            "MatchResult:order_id=10;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[];filled_order_ids=[é]",
+            "MatchResult:order_id=10;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[];filled_order_ids=[1,→,2]",
+            // Multibyte right where the '=' after a field name is expected.
+            "MatchResult:order_idé=10;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[];filled_order_ids=[]",
+        ];
+
+        for input in malformed {
+            let parsed = MatchResult::from_str(input);
+            assert!(
+                parsed.is_err(),
+                "malformed multibyte input must parse to Err, got Ok for {input:?}"
+            );
+        }
+    }
+
+    /// A multibyte scalar that lands exactly on the byte offset where the
+    /// scanner probes for the closing `]` of each bracket must not panic — the
+    /// bracket depth stays unbalanced and the parse fails cleanly.
+    #[test]
+    fn from_str_rejects_unterminated_multibyte_bracket() {
+        let inputs = [
+            // trades bracket opened, then a multibyte scalar, then end.
+            "MatchResult:order_id=10;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[é",
+            // filled_order_ids bracket opened, then a multibyte scalar, then end.
+            "MatchResult:order_id=10;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[];filled_order_ids=[😀",
+        ];
+        for input in inputs {
+            assert!(
+                MatchResult::from_str(input).is_err(),
+                "unterminated multibyte bracket must parse to Err for {input:?}"
+            );
+        }
+    }
+
+    /// Canonical ASCII output from `Display` — including a populated
+    /// `filled_order_ids` list and multiple trades — must keep round-tripping
+    /// unchanged through `FromStr`.
+    #[test]
+    fn display_round_trips_with_filled_ids_and_trades() {
+        let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(result.add_trade(sample_trade(30)).is_ok());
+        assert!(result.add_trade(sample_trade(20)).is_ok());
+        result.add_filled_order_id(Id::from_u64(20));
+        result.add_filled_order_id(Id::from_u64(21));
+
+        let rendered = result.to_string();
+        let parsed = match MatchResult::from_str(&rendered) {
+            Ok(value) => value,
+            Err(error) => panic!("valid canonical output must round-trip: {error:?}"),
+        };
+
+        assert_eq!(parsed.order_id(), Id::from_u64(10));
+        assert_eq!(parsed.remaining_quantity().as_u64(), 50);
+        assert!(!parsed.is_complete());
+        assert_eq!(parsed.trades().len(), 2);
+        assert_eq!(
+            parsed.filled_order_ids(),
+            &[Id::from_u64(20), Id::from_u64(21)]
+        );
+        // Rendering the parsed result reproduces the exact canonical text.
+        assert_eq!(parsed.to_string(), rendered);
+    }
+
+    // ----- property: from_str never panics on arbitrary UTF-8 -----
+    //
+    // A co-located `proptest` block (the `tests/proptest/` harness is reserved
+    // for the nine matching invariants and drives `PriceLevel`, not the
+    // parser, so a parser-robustness property does not fit there). `proptest`
+    // reports any panic in the closure as a failing, shrinking case, so the
+    // bodies just call `from_str` and drop the result.
+    use proptest::prelude::*;
+
+    /// Concatenate the format's structural delimiters with arbitrary Unicode
+    /// scalars so multibyte characters land adjacent to (and straddling) every
+    /// delimiter the byte scanners probe — the worst case for boundary safety.
+    fn structural_fuzz() -> impl Strategy<Value = String> {
+        let token = prop_oneof![
+            Just("=".to_string()),
+            Just(";".to_string()),
+            Just("[".to_string()),
+            Just("]".to_string()),
+            Just("Trades:".to_string()),
+            Just("order_id".to_string()),
+            Just("remaining_quantity".to_string()),
+            Just("is_complete".to_string()),
+            Just("trades".to_string()),
+            Just("filled_order_ids".to_string()),
+            any::<char>().prop_map(|c| c.to_string()),
+        ];
+        prop::collection::vec(token, 0..24)
+            .prop_map(|parts| format!("MatchResult:{}", parts.concat()))
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 1024, ..ProptestConfig::default() })]
+
+        /// Arbitrary UTF-8 strings (with the required prefix and bare) never
+        /// panic; they either parse or return `Err`.
+        #[test]
+        fn from_str_never_panics_on_arbitrary_utf8(suffix in any::<String>()) {
+            let with_prefix = format!("MatchResult:{suffix}");
+            // The result is deliberately ignored — a panic (not an Err) is the
+            // only way this can fail.
+            let _ = MatchResult::from_str(&with_prefix);
+            let _ = MatchResult::from_str(&suffix);
+        }
+
+        /// Delimiter-dense fuzz: multibyte scalars adjacent to every structural
+        /// delimiter still never panic.
+        #[test]
+        fn from_str_never_panics_on_structural_fuzz(input in structural_fuzz()) {
+            let _ = MatchResult::from_str(&input);
+        }
+    }
 }

--- a/src/orders/order_type.rs
+++ b/src/orders/order_type.rs
@@ -381,7 +381,23 @@ impl<T: Clone> OrderType<T> {
         matches!(self, Self::PostOnly { .. })
     }
 
-    /// Create a new standard order with reduced quantity
+    /// Return a clone of this order with its resting (visible / main) quantity
+    /// reset to `new_quantity`, in quantity units.
+    ///
+    /// Every variant is rewritten explicitly so a partial fill (via
+    /// [`Self::match_against`]) or an `OrderUpdate::UpdateQuantity` leaves the
+    /// residual maker at exactly `new_quantity` rather than its original size.
+    /// For the single-quantity variants (`Standard`, `PostOnly`,
+    /// `TrailingStop`, `PeggedOrder`, `MarketToLimit`) this rewrites the
+    /// `quantity` field; for the two-tranche variants (`IcebergOrder`,
+    /// `ReserveOrder`) it rewrites the *visible* quantity and preserves the
+    /// hidden tranche together with every order-type-specific field (trail /
+    /// peg parameters, replenishment policy).
+    ///
+    /// The match is exhaustive by design: a new variant must supply its own arm
+    /// rather than silently retaining its original quantity, which would let a
+    /// later taker execute the same depth twice and break quantity
+    /// conservation.
     #[must_use]
     pub fn with_reduced_quantity(&self, new_quantity: u64) -> Self {
         let new_quantity = Quantity::new(new_quantity);
@@ -448,8 +464,100 @@ impl<T: Clone> OrderType<T> {
                 time_in_force: *time_in_force,
                 extra_fields: extra_fields.clone(),
             },
-            // For other order types, similar pattern...
-            _ => self.clone(), // Default fallback, though this should be implemented for all types
+            Self::TrailingStop {
+                id,
+                price,
+                side,
+                user_id,
+                timestamp,
+                time_in_force,
+                trail_amount,
+                last_reference_price,
+                extra_fields,
+                ..
+            } => Self::TrailingStop {
+                id: *id,
+                price: *price,
+                quantity: new_quantity,
+                side: *side,
+                user_id: *user_id,
+                timestamp: *timestamp,
+                time_in_force: *time_in_force,
+                trail_amount: *trail_amount,
+                last_reference_price: *last_reference_price,
+                extra_fields: extra_fields.clone(),
+            },
+            Self::PeggedOrder {
+                id,
+                price,
+                side,
+                user_id,
+                timestamp,
+                time_in_force,
+                reference_price_offset,
+                reference_price_type,
+                extra_fields,
+                ..
+            } => Self::PeggedOrder {
+                id: *id,
+                price: *price,
+                quantity: new_quantity,
+                side: *side,
+                user_id: *user_id,
+                timestamp: *timestamp,
+                time_in_force: *time_in_force,
+                reference_price_offset: *reference_price_offset,
+                reference_price_type: *reference_price_type,
+                extra_fields: extra_fields.clone(),
+            },
+            Self::MarketToLimit {
+                id,
+                price,
+                side,
+                user_id,
+                timestamp,
+                time_in_force,
+                extra_fields,
+                ..
+            } => Self::MarketToLimit {
+                id: *id,
+                price: *price,
+                quantity: new_quantity,
+                side: *side,
+                user_id: *user_id,
+                timestamp: *timestamp,
+                time_in_force: *time_in_force,
+                extra_fields: extra_fields.clone(),
+            },
+            // Reserve rewrites the visible tranche (mirroring `IcebergOrder`),
+            // preserving the hidden quantity and the replenishment policy.
+            Self::ReserveOrder {
+                id,
+                price,
+                hidden_quantity,
+                side,
+                user_id,
+                timestamp,
+                time_in_force,
+                replenish_threshold,
+                replenish_amount,
+                auto_replenish,
+                extra_fields,
+                ..
+            } => Self::ReserveOrder {
+                id: *id,
+                price: *price,
+                visible_quantity: new_quantity,
+                hidden_quantity: *hidden_quantity,
+                side: *side,
+                user_id: *user_id,
+                timestamp: *timestamp,
+                time_in_force: *time_in_force,
+                replenish_threshold: *replenish_threshold,
+                replenish_amount: *replenish_amount,
+                auto_replenish: *auto_replenish,
+                extra_fields: extra_fields.clone(),
+            },
         }
     }
 
@@ -531,7 +639,15 @@ impl<T: Clone> OrderType<T> {
                     used_hidden,
                 )
             }
-            _ => (self.clone(), 0), // Non-iceberg orders don't refresh
+            // Single-tranche variants have no hidden reserve to draw from, so a
+            // refresh is a no-op that draws `0`. Listed explicitly (rather than
+            // via a `_` fallback) so a future variant with a hidden tranche is a
+            // compile error here until it defines its own refresh behaviour.
+            Self::Standard { .. }
+            | Self::PostOnly { .. }
+            | Self::TrailingStop { .. }
+            | Self::PeggedOrder { .. }
+            | Self::MarketToLimit { .. } => (self.clone(), 0),
         }
     }
 }
@@ -784,8 +900,18 @@ impl<T: Clone> OrderType<T> {
                 }
             }
 
-            // For all other order types, use standard matching logic
-            _ => {
+            // Single-quantity variants with no hidden tranche: match against
+            // the whole (visible) quantity and, on a partial fill, rewrite the
+            // residual to exactly the untaken remainder via
+            // `with_reduced_quantity`. Listed explicitly rather than via a `_`
+            // fallback so a future variant must decide its own matching path
+            // instead of silently inheriting this single-quantity logic (which
+            // would keep its full size after a partial fill and let a later
+            // taker execute the same depth twice).
+            Self::PostOnly { .. }
+            | Self::TrailingStop { .. }
+            | Self::PeggedOrder { .. }
+            | Self::MarketToLimit { .. } => {
                 let visible_qty = self.visible_quantity().as_u64();
 
                 if visible_qty <= incoming_quantity {

--- a/src/orders/tests/order_type.rs
+++ b/src/orders/tests/order_type.rs
@@ -291,40 +291,57 @@ mod tests {
             panic!("Expected PostOnly order");
         }
 
-        // NEW TEST: Test trailing stop order with reduced quantity
+        // TrailingStop is now resized to exactly the new quantity (issue #118).
         let order = create_trailing_stop_order();
         let reduced = order.with_reduced_quantity(3);
 
         match reduced {
-            OrderType::<()>::TrailingStop { quantity, .. } => {
-                assert_eq!(quantity, Quantity::new(5));
+            OrderType::<()>::TrailingStop {
+                quantity,
+                trail_amount,
+                last_reference_price,
+                ..
+            } => {
+                assert_eq!(quantity, Quantity::new(3));
+                // Trail parameters are preserved by the resize.
+                assert_eq!(trail_amount, Quantity::new(100));
+                assert_eq!(last_reference_price, Price::new(10100));
             }
             _ => panic!("Expected TrailingStop order"),
         }
 
-        // NEW TEST: Test pegged order with reduced quantity
+        // PeggedOrder is now resized to exactly the new quantity (issue #118).
         let order = create_pegged_order();
         let reduced = order.with_reduced_quantity(1);
 
         match reduced {
-            OrderType::<()>::PeggedOrder { quantity, .. } => {
-                assert_eq!(quantity, Quantity::new(5));
+            OrderType::<()>::PeggedOrder {
+                quantity,
+                reference_price_offset,
+                reference_price_type,
+                ..
+            } => {
+                assert_eq!(quantity, Quantity::new(1));
+                // Peg parameters are preserved by the resize.
+                assert_eq!(reference_price_offset, -50);
+                assert_eq!(reference_price_type, PegReferenceType::BestAsk);
             }
             _ => panic!("Expected PeggedOrder"),
         }
 
-        // NEW TEST: Test market-to-limit order with reduced quantity
+        // MarketToLimit is now resized to exactly the new quantity (issue #118).
         let order = create_market_to_limit_order();
         let reduced = order.with_reduced_quantity(4);
 
         match reduced {
             OrderType::<()>::MarketToLimit { quantity, .. } => {
-                assert_eq!(quantity, Quantity::new(5));
+                assert_eq!(quantity, Quantity::new(4));
             }
             _ => panic!("Expected MarketToLimit order"),
         }
 
-        // NEW TEST: Test reserve order with reduced quantity
+        // ReserveOrder rewrites the visible tranche to the new quantity and
+        // keeps the hidden tranche (mirrors IcebergOrder; issue #118).
         let order = create_reserve_order();
         let reduced = order.with_reduced_quantity(0);
 
@@ -334,7 +351,7 @@ mod tests {
                 hidden_quantity,
                 ..
             } => {
-                assert_eq!(visible_quantity, Quantity::new(1));
+                assert_eq!(visible_quantity, Quantity::new(0));
                 assert_eq!(hidden_quantity, Quantity::new(4)); // Hidden should remain unchanged
             }
             _ => panic!("Expected ReserveOrder"),
@@ -717,10 +734,10 @@ mod tests {
 
         let reduced = order.with_reduced_quantity(5);
 
-        // Verify the quantity is not changed (market to limit orders don't support
-        // reduced quantity in the current implementation)
+        // The residual must carry exactly the reduced quantity so a later taker
+        // can only execute the remainder (issue #118).
         if let OrderType::MarketToLimit { quantity, .. } = reduced {
-            assert_eq!(quantity, Quantity::new(10)); // Original quantity, not reduced
+            assert_eq!(quantity, Quantity::new(5));
         } else {
             panic!("Expected MarketToLimit order");
         }
@@ -744,10 +761,18 @@ mod tests {
 
         let reduced = order.with_reduced_quantity(5);
 
-        // Verify the quantity is not changed (pegged orders don't support
-        // reduced quantity in the current implementation)
-        if let OrderType::PeggedOrder { quantity, .. } = reduced {
-            assert_eq!(quantity, Quantity::new(10)); // Original quantity, not reduced
+        // The residual must carry exactly the reduced quantity, and the peg
+        // parameters must be preserved (issue #118).
+        if let OrderType::PeggedOrder {
+            quantity,
+            reference_price_offset,
+            reference_price_type,
+            ..
+        } = reduced
+        {
+            assert_eq!(quantity, Quantity::new(5));
+            assert_eq!(reference_price_offset, -50);
+            assert_eq!(reference_price_type, PegReferenceType::BestAsk);
         } else {
             panic!("Expected PeggedOrder order");
         }
@@ -771,10 +796,18 @@ mod tests {
 
         let reduced = order.with_reduced_quantity(5);
 
-        // Verify the quantity is not changed (trailing stop orders don't support
-        // reduced quantity in the current implementation)
-        if let OrderType::TrailingStop { quantity, .. } = reduced {
-            assert_eq!(quantity, Quantity::new(10)); // Original quantity, not reduced
+        // The residual must carry exactly the reduced quantity, and the trail
+        // parameters must be preserved (issue #118).
+        if let OrderType::TrailingStop {
+            quantity,
+            trail_amount,
+            last_reference_price,
+            ..
+        } = reduced
+        {
+            assert_eq!(quantity, Quantity::new(5));
+            assert_eq!(trail_amount, Quantity::new(100));
+            assert_eq!(last_reference_price, Price::new(1100));
         } else {
             panic!("Expected TrailingStop order");
         }

--- a/src/orders/update.rs
+++ b/src/orders/update.rs
@@ -16,10 +16,17 @@ pub enum OrderUpdate {
     },
 
     /// Update the quantity of an order
+    ///
+    /// For two-tranche orders (iceberg / reserve) `new_quantity` applies to the
+    /// **visible** tranche only; the hidden tranche is left untouched, so the
+    /// order's new total is `new_quantity + hidden`. Reducing hidden depth is
+    /// not reachable through this update — cancel and re-submit instead. The
+    /// increase-vs-decrease priority policy (documented on the price level's
+    /// `update_order`) is likewise driven by the visible delta.
     UpdateQuantity {
         /// ID of the order to update
         order_id: Id,
-        /// New quantity for the order
+        /// New quantity for the order (visible tranche for iceberg / reserve)
         new_quantity: Quantity,
     },
 

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -887,9 +887,11 @@ impl PriceLevel {
     ///   loses time priority, matching standard exchange behaviour.
     ///
     /// Total quantity is `visible + hidden`; the branch is chosen by comparing
-    /// the order's total before and after the update. Order types that cannot
-    /// be resized fall back to an unchanged order and therefore take the
-    /// in-place (position-preserving) branch.
+    /// the order's total before and after the update. Every order variant is
+    /// resized by [`OrderType::with_reduced_quantity`] (single-quantity
+    /// variants rewrite their `quantity`; two-tranche variants rewrite the
+    /// visible tranche and keep hidden), so the branch reflects the real size
+    /// change rather than a silent no-op.
     ///
     /// # Errors
     ///
@@ -962,10 +964,10 @@ impl PriceLevel {
                     })?;
 
                 // Build the updated order. `with_reduced_quantity` sets the
-                // (visible/main) quantity to exactly `new_quantity` for order
-                // types that support resizing; types it cannot resize fall back
-                // to an unchanged clone, so `new_total` equals the old total for
-                // them and they take the position-preserving in-place branch.
+                // (visible/main) quantity to exactly `new_quantity` for every
+                // order variant, so `new_total` reflects the real post-update
+                // size and the increase/decrease branch below is chosen
+                // correctly for all types.
                 let new_order = order.with_reduced_quantity(new_quantity.as_u64());
                 let new_visible = new_order.visible_quantity().as_u64();
                 let new_hidden = new_order.hidden_quantity().as_u64();

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -1928,6 +1928,256 @@ mod tests {
         assert_eq!(result.filled_order_ids().len(), 0);
     }
 
+    // --------------------------------- RESIDUAL CONSERVATION (#118) ---------------------------------
+    //
+    // `OrderType::with_reduced_quantity` used to no-op on TrailingStop /
+    // PeggedOrder / MarketToLimit, so a partially-filled maker of one of those
+    // types kept its ORIGINAL quantity: a later taker could execute the same
+    // depth again, and repeated fills could drive the advisory visible counter
+    // below zero. These drivers rest a single maker, partially fill it, then
+    // prove the residual is the ONLY thing left — in the advisory counter, the
+    // live queue, and a snapshot round-trip — and that a second, over-large
+    // taker can take only that residual. The `empty / partial / full` matrix and
+    // FIFO-position checks for these types live in the ORDER-TYPE MATRIX block
+    // above; here we specifically pin quantity conservation across two takers.
+
+    /// Rest `maker` (original size `original_qty`, known resting `side`),
+    /// partially fill it with a taker of `first_take` (`< original_qty`), then
+    /// assert the residual is exposed identically by the advisory
+    /// `visible_quantity()` counter, the live `snapshot_by_insertion_seq()`
+    /// queue, and a `snapshot_to_json` -> `from_snapshot_json` round-trip. A
+    /// second, over-large taker must then execute ONLY the residual, so the
+    /// total executed across both takers equals `original_qty` exactly — never
+    /// more (quantity conservation, issue #118).
+    fn assert_two_takers_conserve_quantity(
+        maker: OrderType<()>,
+        original_qty: u64,
+        first_take: u64,
+        side: Side,
+    ) {
+        let level_price = maker.price().as_u128();
+        let maker_id = maker.id();
+        let price_level = PriceLevel::new(level_price);
+        price_level.add_order(maker);
+
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let trade_id_generator = UuidGenerator::new(namespace);
+
+        // First taker: strictly partial fill of the maker.
+        let first = price_level.match_order(
+            first_take,
+            Id::from_u64(901),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(1_716_000_000_000),
+            &trade_id_generator,
+        );
+        assert_eq!(
+            first.executed_quantity().unwrap_or_default().as_u64(),
+            first_take
+        );
+        assert_match_result_consistent(&first, level_price, side);
+
+        let residual = original_qty - first_take;
+
+        // Advisory counter, live queue contents, and a snapshot round-trip must
+        // all expose the SAME residual on the stored maker.
+        assert_eq!(price_level.visible_quantity(), residual);
+
+        let resting = price_level.snapshot_by_insertion_seq();
+        assert_eq!(resting.len(), 1);
+        assert_eq!(resting[0].id(), maker_id);
+        assert_eq!(
+            resting[0].visible_quantity().as_u64(),
+            residual,
+            "the resting maker must carry exactly the residual, not its original size"
+        );
+
+        let json = price_level
+            .snapshot_to_json()
+            .expect("snapshot must serialize");
+        let restored = PriceLevel::from_snapshot_json(&json).expect("snapshot must restore");
+        let restored_orders = restored.snapshot_by_insertion_seq();
+        assert_eq!(restored_orders.len(), 1);
+        assert_eq!(
+            restored_orders[0].visible_quantity().as_u64(),
+            residual,
+            "the residual must survive a snapshot round-trip"
+        );
+        assert_eq!(restored.visible_quantity(), residual);
+
+        // Second, over-large taker: it can take only the residual, never the
+        // maker's original size.
+        let second = price_level.match_order(
+            original_qty + 1000,
+            Id::from_u64(902),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(1_716_000_000_001),
+            &trade_id_generator,
+        );
+        assert_eq!(
+            second.executed_quantity().unwrap_or_default().as_u64(),
+            residual,
+            "the second taker can only execute the residual"
+        );
+        assert_match_result_consistent(&second, level_price, side);
+
+        let total = first.executed_quantity().unwrap_or_default().as_u64()
+            + second.executed_quantity().unwrap_or_default().as_u64();
+        assert_eq!(
+            total, original_qty,
+            "total executed across both takers must equal the maker's original quantity, never more"
+        );
+
+        // Maker fully consumed; level empty.
+        assert_eq!(price_level.order_count(), 0);
+        assert_eq!(price_level.visible_quantity(), 0);
+        assert!(price_level.snapshot_by_insertion_seq().is_empty());
+    }
+
+    #[test]
+    fn test_match_trailing_stop_two_takers_second_only_takes_residual() {
+        // TrailingStop rests on Side::Sell.
+        assert_two_takers_conserve_quantity(
+            create_trailing_stop_order(1, 10000, 100),
+            100,
+            40,
+            Side::Sell,
+        );
+    }
+
+    #[test]
+    fn test_match_pegged_two_takers_second_only_takes_residual() {
+        // PeggedOrder rests on Side::Buy.
+        assert_two_takers_conserve_quantity(create_pegged_order(1, 10000, 100), 100, 55, Side::Buy);
+    }
+
+    #[test]
+    fn test_match_market_to_limit_two_takers_second_only_takes_residual() {
+        // MarketToLimit rests on Side::Buy.
+        assert_two_takers_conserve_quantity(
+            create_market_to_limit_order(1, 10000, 100),
+            100,
+            70,
+            Side::Buy,
+        );
+    }
+
+    /// `UpdateQuantity` DECREASE on a resizable maker: the maker is resized to
+    /// exactly `decrease_to` and keeps its front queue position (issue #118 made
+    /// TrailingStop / PeggedOrder / MarketToLimit resizable; the decrease branch
+    /// preserves time priority).
+    fn assert_update_quantity_decrease_keeps_position(front: OrderType<()>, decrease_to: u64) {
+        let level_price = front.price().as_u128();
+        let front_id = front.id();
+        let level = PriceLevel::new(level_price);
+        level.add_order(front);
+        // A plain maker queued behind the resized one.
+        let behind_id = Id::from_u64(778);
+        level.add_order(create_standard_order(778, level_price, 100));
+
+        let updated = level
+            .update_order(OrderUpdate::UpdateQuantity {
+                order_id: front_id,
+                new_quantity: Quantity::new(decrease_to),
+            })
+            .expect("decrease update should succeed")
+            .expect("order must be present");
+        assert_eq!(
+            updated.visible_quantity().as_u64(),
+            decrease_to,
+            "decrease must resize the maker to exactly the new quantity"
+        );
+
+        // Decrease keeps priority: the resized maker is still first by insertion
+        // sequence, ahead of the maker queued behind it.
+        let by_seq: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|order| order.id())
+            .collect();
+        assert_eq!(
+            by_seq,
+            vec![front_id, behind_id],
+            "a decreased maker keeps its front position"
+        );
+    }
+
+    /// `UpdateQuantity` INCREASE on a resizable maker: the maker is resized to
+    /// exactly `increase_to` (`> its original total`) and demoted to the back of
+    /// the queue, behind a later maker (issue #118; increase forfeits time
+    /// priority, matching the existing policy for Standard orders).
+    fn assert_update_quantity_increase_demotes(front: OrderType<()>, increase_to: u64) {
+        let level_price = front.price().as_u128();
+        let front_id = front.id();
+        let level = PriceLevel::new(level_price);
+        level.add_order(front);
+        let behind_id = Id::from_u64(778);
+        level.add_order(create_standard_order(778, level_price, 100));
+
+        let updated = level
+            .update_order(OrderUpdate::UpdateQuantity {
+                order_id: front_id,
+                new_quantity: Quantity::new(increase_to),
+            })
+            .expect("increase update should succeed")
+            .expect("order must be present");
+        assert_eq!(
+            updated.visible_quantity().as_u64(),
+            increase_to,
+            "increase must resize the maker to exactly the new quantity"
+        );
+
+        // Increase demotes: the resized maker moves behind the later maker.
+        let by_seq: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|order| order.id())
+            .collect();
+        assert_eq!(
+            by_seq,
+            vec![behind_id, front_id],
+            "an increased maker is demoted to the back of the queue"
+        );
+    }
+
+    #[test]
+    fn test_update_quantity_trailing_stop_decrease_keeps_position() {
+        assert_update_quantity_decrease_keeps_position(
+            create_trailing_stop_order(1, 10000, 100),
+            40,
+        );
+    }
+
+    #[test]
+    fn test_update_quantity_trailing_stop_increase_demotes() {
+        assert_update_quantity_increase_demotes(create_trailing_stop_order(1, 10000, 100), 150);
+    }
+
+    #[test]
+    fn test_update_quantity_pegged_decrease_keeps_position() {
+        assert_update_quantity_decrease_keeps_position(create_pegged_order(1, 10000, 100), 40);
+    }
+
+    #[test]
+    fn test_update_quantity_pegged_increase_demotes() {
+        assert_update_quantity_increase_demotes(create_pegged_order(1, 10000, 100), 150);
+    }
+
+    #[test]
+    fn test_update_quantity_market_to_limit_decrease_keeps_position() {
+        assert_update_quantity_decrease_keeps_position(
+            create_market_to_limit_order(1, 10000, 100),
+            40,
+        );
+    }
+
+    #[test]
+    fn test_update_quantity_market_to_limit_increase_demotes() {
+        assert_update_quantity_increase_demotes(create_market_to_limit_order(1, 10000, 100), 150);
+    }
+
     // ----- incoming_quantity == 0 boundary -----
 
     #[test]


### PR DESCRIPTION
## Summary

`MatchResult::from_str` advanced byte offsets one at a time and sliced with
`s[pos..]` / `s[i..]`; a multibyte Unicode scalar before the next delimiter
landed an offset inside the scalar and panicked on a non-char-boundary slice.
`FromStr` accepts untrusted text and promises `Result` — it must never unwind.
The scanner now works on `s.as_bytes()` and slices only at ASCII-delimiter
positions, which are always char boundaries.

## Stack

- **Stack:** #118 → #114 → #116 → #111 → #113 → #120 → #119 → #115 → #117 → #112 (**this is 2/10**)
- **Base branch:** `stack/1-118-reduce-all-variants`
- **Stacked on:** #121 — **the diff vs `main` is cumulative**; review against the base branch.

## Changes

- Byte-safe scanning throughout the `FromStr` impl: `find_next_field`, the
  field-name scan, and both bracket scanners (trades, filled-order ids).
  Structural delimiters (`=`, `;`, `[`, `]`) and literal prefixes are ASCII,
  and every byte of a multibyte scalar is ≥ 0x80, so a byte comparison never
  mistakes an interior byte for a delimiter.
- Every direct index is bounds-guarded (audited by `architect` review);
  malformed input returns the existing `InvalidFormat` / `InvalidFieldValue` /
  `MissingField` errors deterministically. No `unsafe`, no new deps, no lossy
  normalization, structural validation unchanged.
- Canonical ASCII `Display` output round-trips unchanged.

## Testing

- [x] Regression: 2/3/4-byte scalars in field names, values, trade bracket
  data, filled-order-id lists; unterminated multibyte brackets — all `Err`,
  no panic (old scanner body panics on these)
- [x] Two co-located proptest properties (1024 cases each): arbitrary UTF-8
  and delimiter-dense structural fuzz never panic
- [x] `Display` → `FromStr` round-trip with populated trades + filled ids
- [x] Pre-push checks clean locally

454 tests passed; 0 failed (435 lib + 9 + 1 + 9 doctests).

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Existing hand-written `PriceLevelError` variants reused — no new variants
- [x] No new production `unsafe`, no new dependencies (`proptest` already a dev-dep)
- [x] Module boundaries respected (`execution` untouched upward)
- [x] Public surface: no signature changes

Note: the `filled_order_ids` branch's tolerance of trailing content after `]`
is pre-existing and out of scope here — it gets tightened in #116 (next in the
stack), which routes `FromStr` through the invariant validator.

Closes #114


- **Blocks:** #123
