### PR TITLE
Validate MatchResult invariants during decoding (#116)

### DIFF
--- a/proptest-regressions/execution/tests/match_result_trade.txt
+++ b/proptest-regressions/execution/tests/match_result_trade.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc aaa41fddbf5e75d79d032b57bc13007e018e83d685792480a4d253415666852e # shrinks to initial = 467, specs = [(20, 1, false), (31, 1, true), (31, 1, true)]

--- a/src/execution/match_result.rs
+++ b/src/execution/match_result.rs
@@ -71,7 +71,19 @@ impl MatchOutcome {
 /// Fields are private to enforce invariant consistency between
 /// `remaining_quantity`, `is_complete`, and `trades`.
 /// Use the provided accessor methods and mutation helpers.
+///
+/// # Decode-time validation
+///
+/// The Rust API keeps the fields mutually consistent, but a decoder writes
+/// them directly. Both `Deserialize` (via `#[serde(try_from)]` through a
+/// private wire struct) and [`FromStr`] therefore route the reconstructed
+/// value through a single private validator, which rejects any payload that
+/// breaks the invariants a public-API-built result always upholds. Every
+/// payload a valid `MatchResult` can produce still decodes unchanged; only
+/// self-contradictory input is rejected — as a serde error or a
+/// [`PriceLevelError`], never a panic.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "MatchResultWire")]
 pub struct MatchResult {
     /// The ID of the incoming order that initiated the match
     order_id: Id,
@@ -89,13 +101,44 @@ pub struct MatchResult {
     filled_order_ids: Vec<Id>,
 
     /// Terminal classification of the match (filled / killed / rejected / ...).
-    ///
-    /// `#[serde(default)]` keeps snapshots produced before this field was added
-    /// deserializable: an older JSON payload restores as
-    /// [`MatchOutcome::NotFilled`] and is corrected by the accessors derived
-    /// from the other fields where it matters.
+    outcome: MatchOutcome,
+}
+
+/// Wire form of [`MatchResult`] used for validated deserialization.
+///
+/// It mirrors `MatchResult`'s serialized shape field-for-field (identical
+/// names, so every previously-valid payload still decodes) but performs no
+/// validation itself: `#[serde(try_from = "MatchResultWire")]` on
+/// `MatchResult` deserializes this permissive struct and then runs
+/// [`MatchResult::validated`] via the [`TryFrom`] impl below. The `outcome`
+/// field keeps `#[serde(default)]` so a payload written before that field
+/// existed decodes as [`MatchOutcome::NotFilled`] (the legacy default), as
+/// before.
+#[derive(Deserialize)]
+struct MatchResultWire {
+    order_id: Id,
+    trades: TradeList,
+    remaining_quantity: u64,
+    is_complete: bool,
+    filled_order_ids: Vec<Id>,
     #[serde(default)]
     outcome: MatchOutcome,
+}
+
+impl TryFrom<MatchResultWire> for MatchResult {
+    type Error = PriceLevelError;
+
+    fn try_from(wire: MatchResultWire) -> Result<Self, Self::Error> {
+        MatchResult {
+            order_id: wire.order_id,
+            trades: wire.trades,
+            remaining_quantity: wire.remaining_quantity,
+            is_complete: wire.is_complete,
+            filled_order_ids: wire.filled_order_ids,
+            outcome: wire.outcome,
+        }
+        .validated()
+    }
 }
 
 impl MatchResult {
@@ -353,6 +396,97 @@ impl MatchResult {
             Ok(Some(self.executed_value()? as f64 / executed_qty as f64))
         }
     }
+
+    /// Consumes `self`, returning it only if it satisfies the invariants a
+    /// public-API-built [`MatchResult`] always upholds — the single validation
+    /// gate both decoders ([`FromStr`] and `Deserialize` via
+    /// [`MatchResultWire`]) route through, so a decoder can never mint a
+    /// self-contradictory value that the private-field Rust API forbids.
+    ///
+    /// The checks mirror exactly what the constructors / mutators
+    /// ([`Self::new`], [`Self::add_trade`], [`Self::finalize`],
+    /// [`Self::mark_killed`], [`Self::mark_rejected`]) and the matching engine
+    /// guarantee — no stricter:
+    ///
+    /// 1. **Completion agrees with the remainder:** `is_complete` is `true` iff
+    ///    `remaining_quantity == 0`.
+    /// 2. **Executed quantity is representable:** the checked sum of the trade
+    ///    quantities does not overflow `u64`, and that sum plus the remaining
+    ///    quantity (the implied initial taker quantity, itself a `u64`) does not
+    ///    overflow either.
+    /// 3. **A killed / rejected result carries nothing:** a
+    ///    [`MatchOutcome::Killed`] or [`MatchOutcome::Rejected`] outcome — both
+    ///    decided before any sweep — has no trades and no filled order ids, as
+    ///    [`Self::mark_killed`] / [`Self::mark_rejected`] enforce.
+    /// 4. **Filled ids are backed by trades:** every id in `filled_order_ids`
+    ///    appears as a `maker_order_id` of some trade, because the engine only
+    ///    records a filled id for a maker it just traded against
+    ///    (`PriceLevel::match_order`). The reverse does not hold — a partially
+    ///    filled maker trades without being recorded as filled — so this is a
+    ///    one-directional subset check, not equality.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] describing the first
+    /// invariant the value violates.
+    fn validated(self) -> Result<Self, PriceLevelError> {
+        // 1. Completion agrees with the remainder.
+        if self.is_complete != (self.remaining_quantity == 0) {
+            return Err(PriceLevelError::InvalidOperation {
+                message: format!(
+                    "is_complete ({}) disagrees with remaining_quantity ({})",
+                    self.is_complete, self.remaining_quantity
+                ),
+            });
+        }
+
+        // 2. Executed quantity is representable, and so is the implied initial
+        //    taker quantity (executed + remaining). `executed_quantity` already
+        //    returns a checked-sum error on overflow.
+        let executed = self.executed_quantity()?.as_u64();
+        if executed.checked_add(self.remaining_quantity).is_none() {
+            return Err(PriceLevelError::InvalidOperation {
+                message: format!(
+                    "executed quantity ({executed}) plus remaining_quantity ({}) overflows u64",
+                    self.remaining_quantity
+                ),
+            });
+        }
+
+        // 3. A killed / rejected result carries no trades and no filled ids.
+        if matches!(self.outcome, MatchOutcome::Killed | MatchOutcome::Rejected)
+            && (!self.trades.is_empty() || !self.filled_order_ids.is_empty())
+        {
+            return Err(PriceLevelError::InvalidOperation {
+                message: format!(
+                    "{:?} outcome must carry no trades and no filled_order_ids \
+                     (found {} trade(s), {} filled id(s))",
+                    self.outcome,
+                    self.trades.len(),
+                    self.filled_order_ids.len()
+                ),
+            });
+        }
+
+        // 4. Every filled id is backed by a trade whose maker it is.
+        if !self.filled_order_ids.is_empty() {
+            let makers: std::collections::HashSet<Id> = self
+                .trades
+                .as_vec()
+                .iter()
+                .map(|trade| trade.maker_order_id())
+                .collect();
+            if let Some(missing) = self.filled_order_ids.iter().find(|id| !makers.contains(id)) {
+                return Err(PriceLevelError::InvalidOperation {
+                    message: format!(
+                        "filled order id {missing} does not appear as a maker in any trade"
+                    ),
+                });
+            }
+        }
+
+        Ok(self)
+    }
 }
 
 impl fmt::Display for MatchResult {
@@ -536,8 +670,14 @@ impl FromStr for MatchResult {
                         Some(s.get(pos..=i).ok_or(PriceLevelError::InvalidFormat)?);
 
                     pos = i + 1;
+                    // Symmetric with the `trades` branch: after the closing `]`
+                    // the only thing allowed is a `;` field separator or the end
+                    // of the string. Any other trailing content is malformed and
+                    // rejected rather than silently ignored.
                     if bytes.get(pos) == Some(&b';') {
                         pos += 1;
+                    } else if pos < bytes.len() {
+                        return Err(PriceLevelError::InvalidFormat);
                     }
                 }
                 _ => return Err(PriceLevelError::InvalidFormat),
@@ -612,13 +752,19 @@ impl FromStr for MatchResult {
             MatchOutcome::PartiallyFilled
         };
 
-        Ok(MatchResult {
+        // Route the structurally-parsed value through the same invariant gate
+        // as `Deserialize`, so text input that is well-formed but
+        // self-contradictory (e.g. `is_complete=true` with a positive
+        // remainder, trade quantities that overflow, or a filled id absent from
+        // the trades) is rejected rather than accepted.
+        MatchResult {
             order_id,
             trades,
             remaining_quantity,
             is_complete,
             filled_order_ids,
             outcome,
-        })
+        }
+        .validated()
     }
 }

--- a/src/execution/match_result.rs
+++ b/src/execution/match_result.rs
@@ -379,22 +379,26 @@ impl FromStr for MatchResult {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         fn find_next_field(s: &str, start_pos: usize) -> Result<(&str, usize), PriceLevelError> {
+            // Scan raw bytes for the ASCII ';' delimiter rather than advancing a
+            // `&str` slice one byte at a time. Every byte of a multibyte scalar
+            // is >= 0x80, so it can never equal `b';'` (0x3B): a byte comparison
+            // never mistakes an interior byte for the delimiter, and we only
+            // ever form a `&str` slice at a `;` position or the end of the
+            // string — both guaranteed char boundaries — so slicing cannot panic
+            // on malformed UTF-8. `start_pos` is always the boundary just after
+            // an ASCII `=`.
+            let bytes = s.as_bytes();
             let mut pos = start_pos;
 
-            while pos < s.len() {
-                if s[pos..].starts_with(';') {
-                    let value = &s[start_pos..pos];
-                    return Ok((value, pos + 1));
+            while pos < bytes.len() {
+                if bytes[pos] == b';' {
+                    return Ok((&s[start_pos..pos], pos + 1));
                 }
                 pos += 1;
             }
 
-            if pos == s.len() {
-                let value = &s[start_pos..pos];
-                return Ok((value, pos));
-            }
-
-            Err(PriceLevelError::InvalidFormat)
+            // No ';' before the end: the value runs to the end of the string.
+            Ok((&s[start_pos..], bytes.len()))
         }
         if !s.starts_with("MatchResult:") {
             return Err(PriceLevelError::InvalidFormat);
@@ -406,10 +410,18 @@ impl FromStr for MatchResult {
         let mut trades_str = None;
         let mut filled_order_ids_str = None;
 
+        // Scan over the raw bytes. Every structural delimiter in the format
+        // (`=`, `;`, `[`, `]`) and every literal prefix (`Trades:[`) is ASCII,
+        // so a byte comparison locates them without ever splitting a multibyte
+        // scalar, and every `&str` slice below is taken at an ASCII delimiter
+        // position (or the string end) — all guaranteed char boundaries — so a
+        // field carrying malformed / multibyte text yields a deterministic
+        // `Err`, never a slice-on-non-boundary panic.
+        let bytes = s.as_bytes();
         let mut pos = "MatchResult:".len();
 
-        while pos < s.len() {
-            let field_end = match s[pos..].find('=') {
+        while pos < bytes.len() {
+            let field_end = match bytes[pos..].iter().position(|&b| b == b'=') {
                 Some(idx) => pos + idx,
                 None => return Err(PriceLevelError::InvalidFormat),
             };
@@ -433,25 +445,29 @@ impl FromStr for MatchResult {
                     pos = next_pos;
                 }
                 "trades" => {
-                    if !s[pos..].starts_with("Trades:[") {
+                    if !bytes[pos..].starts_with(b"Trades:[") {
                         return Err(PriceLevelError::InvalidFormat);
                     }
 
                     let mut bracket_depth = 1;
                     let mut i = pos + "Trades:[".len();
 
-                    while i < s.len() && bracket_depth > 0 {
-                        if s[i..].starts_with(']') {
-                            bracket_depth -= 1;
-                            if bracket_depth == 0 {
-                                break;
+                    while i < bytes.len() && bracket_depth > 0 {
+                        match bytes[i] {
+                            b']' => {
+                                bracket_depth -= 1;
+                                if bracket_depth == 0 {
+                                    break;
+                                }
+                                i += 1;
                             }
-                            i += 1;
-                        } else if s[i..].starts_with('[') {
-                            bracket_depth += 1;
-                            i += 1;
-                        } else {
-                            i += 1;
+                            b'[' => {
+                                bracket_depth += 1;
+                                i += 1;
+                            }
+                            _ => {
+                                i += 1;
+                            }
                         }
                     }
 
@@ -459,34 +475,40 @@ impl FromStr for MatchResult {
                         return Err(PriceLevelError::InvalidFormat);
                     }
 
+                    // `i` is the byte index of the closing ASCII `]`, so the
+                    // inclusive slice ends on a char boundary.
                     trades_str = Some(&s[pos..=i]);
                     pos = i + 1;
-                    if pos < s.len() && s[pos..].starts_with(';') {
+                    if pos < bytes.len() && bytes[pos] == b';' {
                         pos += 1;
-                    } else if pos < s.len() {
+                    } else if pos < bytes.len() {
                         return Err(PriceLevelError::InvalidFormat);
                     }
                 }
                 "filled_order_ids" => {
-                    if !s[pos..].starts_with('[') {
+                    if bytes.get(pos) != Some(&b'[') {
                         return Err(PriceLevelError::InvalidFormat);
                     }
 
                     let mut bracket_depth = 1;
                     let mut i = pos + 1;
 
-                    while i < s.len() && bracket_depth > 0 {
-                        if s[i..].starts_with(']') {
-                            bracket_depth -= 1;
-                            if bracket_depth == 0 {
-                                break;
+                    while i < bytes.len() && bracket_depth > 0 {
+                        match bytes[i] {
+                            b']' => {
+                                bracket_depth -= 1;
+                                if bracket_depth == 0 {
+                                    break;
+                                }
+                                i += 1;
                             }
-                            i += 1;
-                        } else if s[i..].starts_with('[') {
-                            bracket_depth += 1;
-                            i += 1;
-                        } else {
-                            i += 1;
+                            b'[' => {
+                                bracket_depth += 1;
+                                i += 1;
+                            }
+                            _ => {
+                                i += 1;
+                            }
                         }
                     }
 
@@ -494,10 +516,12 @@ impl FromStr for MatchResult {
                         return Err(PriceLevelError::InvalidFormat);
                     }
 
+                    // `i` is the byte index of the closing ASCII `]`, so the
+                    // inclusive slice ends on a char boundary.
                     filled_order_ids_str = Some(&s[pos..=i]);
 
                     pos = i + 1;
-                    if pos < s.len() && s[pos..].starts_with(';') {
+                    if pos < bytes.len() && bytes[pos] == b';' {
                         pos += 1;
                     }
                 }

--- a/src/execution/match_result.rs
+++ b/src/execution/match_result.rs
@@ -110,10 +110,7 @@ pub struct MatchResult {
 /// names, so every previously-valid payload still decodes) but performs no
 /// validation itself: `#[serde(try_from = "MatchResultWire")]` on
 /// `MatchResult` deserializes this permissive struct and then runs
-/// [`MatchResult::validated`] via the [`TryFrom`] impl below. The `outcome`
-/// field keeps `#[serde(default)]` so a payload written before that field
-/// existed decodes as [`MatchOutcome::NotFilled`] (the legacy default), as
-/// before.
+/// [`MatchResult::validated`] via the [`TryFrom`] impl below.
 #[derive(Deserialize)]
 struct MatchResultWire {
     order_id: Id,
@@ -121,21 +118,40 @@ struct MatchResultWire {
     remaining_quantity: u64,
     is_complete: bool,
     filled_order_ids: Vec<Id>,
+    /// Decoded as an `Option` so a legacy payload written before the field
+    /// existed (key absent → `None`) is told apart from an explicit outcome.
+    /// An absent outcome is *derived* from the other fields — the legacy
+    /// behavior — while an explicit one is validated against them, so a
+    /// payload can no longer claim `Filled` with a positive remainder or
+    /// `PartiallyFilled` without trades.
     #[serde(default)]
-    outcome: MatchOutcome,
+    outcome: Option<MatchOutcome>,
 }
 
 impl TryFrom<MatchResultWire> for MatchResult {
     type Error = PriceLevelError;
 
     fn try_from(wire: MatchResultWire) -> Result<Self, Self::Error> {
+        let outcome = wire.outcome.unwrap_or({
+            // Legacy payload (no outcome key): re-derive the benign
+            // classification exactly as the pre-outcome accessors did. A
+            // killed / rejected outcome cannot be recovered — it is
+            // indistinguishable from NotFilled once the trades are gone.
+            if wire.remaining_quantity == 0 {
+                MatchOutcome::Filled
+            } else if wire.trades.is_empty() {
+                MatchOutcome::NotFilled
+            } else {
+                MatchOutcome::PartiallyFilled
+            }
+        });
         MatchResult {
             order_id: wire.order_id,
             trades: wire.trades,
             remaining_quantity: wire.remaining_quantity,
             is_complete: wire.is_complete,
             filled_order_ids: wire.filled_order_ids,
-            outcome: wire.outcome,
+            outcome,
         }
         .validated()
     }
@@ -198,8 +214,19 @@ impl MatchResult {
     ///
     /// Returns [`PriceLevelError::InvalidOperation`] if the trade's quantity
     /// exceeds the remaining quantity of the incoming order (the subtraction
-    /// would underflow), which indicates an over-fill bug in the caller.
+    /// would underflow), which indicates an over-fill bug in the caller, or if
+    /// the trade's taker order id differs from this result's incoming order id
+    /// (a trade can only belong to the taker that initiated the match).
     pub fn add_trade(&mut self, trade: Trade) -> Result<(), PriceLevelError> {
+        if trade.taker_order_id() != self.order_id {
+            return Err(PriceLevelError::InvalidOperation {
+                message: format!(
+                    "trade taker order id {} does not match the result's incoming order id {}",
+                    trade.taker_order_id(),
+                    self.order_id
+                ),
+            });
+        }
         self.remaining_quantity = self
             .remaining_quantity
             .checked_sub(trade.quantity().as_u64())
@@ -453,35 +480,82 @@ impl MatchResult {
             });
         }
 
-        // 3. A killed / rejected result carries no trades and no filled ids.
-        if matches!(self.outcome, MatchOutcome::Killed | MatchOutcome::Rejected)
-            && (!self.trades.is_empty() || !self.filled_order_ids.is_empty())
-        {
+        // 3. The explicit outcome agrees with the fields it classifies. Every
+        //    public constructor / mutator keeps them in lockstep, so a decoded
+        //    value must too (a legacy payload without an outcome key has it
+        //    DERIVED from these same fields before this check, so it always
+        //    passes here).
+        let outcome_consistent = match self.outcome {
+            // Vacuously-complete results (zero-quantity taker) are Filled with
+            // no trades, so Filled constrains only the remainder.
+            MatchOutcome::Filled => self.remaining_quantity == 0,
+            MatchOutcome::PartiallyFilled => self.remaining_quantity > 0 && !self.trades.is_empty(),
+            MatchOutcome::NotFilled => self.remaining_quantity > 0 && self.trades.is_empty(),
+            // Killed / rejected takers were turned away whole: quantity
+            // remains, and no trade or filled id was ever recorded.
+            MatchOutcome::Killed | MatchOutcome::Rejected => {
+                self.remaining_quantity > 0
+                    && self.trades.is_empty()
+                    && self.filled_order_ids.is_empty()
+            }
+        };
+        if !outcome_consistent {
             return Err(PriceLevelError::InvalidOperation {
                 message: format!(
-                    "{:?} outcome must carry no trades and no filled_order_ids \
-                     (found {} trade(s), {} filled id(s))",
+                    "{:?} outcome contradicts the decoded fields \
+                     (remaining_quantity {}, {} trade(s), {} filled id(s))",
                     self.outcome,
+                    self.remaining_quantity,
                     self.trades.len(),
                     self.filled_order_ids.len()
                 ),
             });
         }
 
-        // 4. Every filled id is backed by a trade whose maker it is.
+        // 4. Every trade belongs to this result's incoming (taker) order —
+        //    mirrored by the same guard in `add_trade`, so decoded and
+        //    API-built values stay aligned.
+        if let Some(alien) = self
+            .trades
+            .as_vec()
+            .iter()
+            .find(|trade| trade.taker_order_id() != self.order_id)
+        {
+            return Err(PriceLevelError::InvalidOperation {
+                message: format!(
+                    "trade taker order id {} does not match the result's incoming order id {}",
+                    alien.taker_order_id(),
+                    self.order_id
+                ),
+            });
+        }
+
+        // 5. The filled ids are a duplicate-free, order-preserving subsequence
+        //    of the trade maker ids: `match_order` records each fully-consumed
+        //    maker exactly once, immediately after its final trade, so trade
+        //    order and filled-id order agree. The `any` on the shared iterator
+        //    advances it past each match, which is exactly subsequence
+        //    semantics (and implies plain membership).
         if !self.filled_order_ids.is_empty() {
-            let makers: std::collections::HashSet<Id> = self
+            let mut seen = std::collections::HashSet::with_capacity(self.filled_order_ids.len());
+            let mut makers = self
                 .trades
                 .as_vec()
                 .iter()
-                .map(|trade| trade.maker_order_id())
-                .collect();
-            if let Some(missing) = self.filled_order_ids.iter().find(|id| !makers.contains(id)) {
-                return Err(PriceLevelError::InvalidOperation {
-                    message: format!(
-                        "filled order id {missing} does not appear as a maker in any trade"
-                    ),
-                });
+                .map(|trade| trade.maker_order_id());
+            for filled in &self.filled_order_ids {
+                if !seen.insert(*filled) {
+                    return Err(PriceLevelError::InvalidOperation {
+                        message: format!("filled order id {filled} appears more than once"),
+                    });
+                }
+                if !makers.by_ref().any(|maker| maker == *filled) {
+                    return Err(PriceLevelError::InvalidOperation {
+                        message: format!(
+                            "filled order id {filled} is not an in-order maker of the trades"
+                        ),
+                    });
+                }
             }
         }
 

--- a/src/execution/match_result.rs
+++ b/src/execution/match_result.rs
@@ -390,15 +390,19 @@ impl FromStr for MatchResult {
             let bytes = s.as_bytes();
             let mut pos = start_pos;
 
-            while pos < bytes.len() {
-                if bytes[pos] == b';' {
-                    return Ok((&s[start_pos..pos], pos + 1));
+            while let Some(&byte) = bytes.get(pos) {
+                if byte == b';' {
+                    let value = s
+                        .get(start_pos..pos)
+                        .ok_or(PriceLevelError::InvalidFormat)?;
+                    return Ok((value, pos + 1));
                 }
                 pos += 1;
             }
 
             // No ';' before the end: the value runs to the end of the string.
-            Ok((&s[start_pos..], bytes.len()))
+            let value = s.get(start_pos..).ok_or(PriceLevelError::InvalidFormat)?;
+            Ok((value, bytes.len()))
         }
         if !s.starts_with("MatchResult:") {
             return Err(PriceLevelError::InvalidFormat);
@@ -421,12 +425,17 @@ impl FromStr for MatchResult {
         let mut pos = "MatchResult:".len();
 
         while pos < bytes.len() {
-            let field_end = match bytes[pos..].iter().position(|&b| b == b'=') {
+            let field_end = match bytes
+                .get(pos..)
+                .and_then(|rest| rest.iter().position(|&b| b == b'='))
+            {
                 Some(idx) => pos + idx,
                 None => return Err(PriceLevelError::InvalidFormat),
             };
 
-            let field_name = &s[pos..field_end];
+            let field_name = s
+                .get(pos..field_end)
+                .ok_or(PriceLevelError::InvalidFormat)?;
             pos = field_end + 1;
             match field_name {
                 "order_id" => {
@@ -445,29 +454,33 @@ impl FromStr for MatchResult {
                     pos = next_pos;
                 }
                 "trades" => {
-                    if !bytes[pos..].starts_with(b"Trades:[") {
+                    if !bytes
+                        .get(pos..)
+                        .is_some_and(|rest| rest.starts_with(b"Trades:["))
+                    {
                         return Err(PriceLevelError::InvalidFormat);
                     }
 
                     let mut bracket_depth = 1;
                     let mut i = pos + "Trades:[".len();
 
-                    while i < bytes.len() && bracket_depth > 0 {
-                        match bytes[i] {
-                            b']' => {
+                    while bracket_depth > 0 {
+                        match bytes.get(i) {
+                            Some(b']') => {
                                 bracket_depth -= 1;
                                 if bracket_depth == 0 {
                                     break;
                                 }
                                 i += 1;
                             }
-                            b'[' => {
+                            Some(b'[') => {
                                 bracket_depth += 1;
                                 i += 1;
                             }
-                            _ => {
+                            Some(_) => {
                                 i += 1;
                             }
+                            None => break,
                         }
                     }
 
@@ -477,9 +490,9 @@ impl FromStr for MatchResult {
 
                     // `i` is the byte index of the closing ASCII `]`, so the
                     // inclusive slice ends on a char boundary.
-                    trades_str = Some(&s[pos..=i]);
+                    trades_str = Some(s.get(pos..=i).ok_or(PriceLevelError::InvalidFormat)?);
                     pos = i + 1;
-                    if pos < bytes.len() && bytes[pos] == b';' {
+                    if bytes.get(pos) == Some(&b';') {
                         pos += 1;
                     } else if pos < bytes.len() {
                         return Err(PriceLevelError::InvalidFormat);
@@ -493,22 +506,23 @@ impl FromStr for MatchResult {
                     let mut bracket_depth = 1;
                     let mut i = pos + 1;
 
-                    while i < bytes.len() && bracket_depth > 0 {
-                        match bytes[i] {
-                            b']' => {
+                    while bracket_depth > 0 {
+                        match bytes.get(i) {
+                            Some(b']') => {
                                 bracket_depth -= 1;
                                 if bracket_depth == 0 {
                                     break;
                                 }
                                 i += 1;
                             }
-                            b'[' => {
+                            Some(b'[') => {
                                 bracket_depth += 1;
                                 i += 1;
                             }
-                            _ => {
+                            Some(_) => {
                                 i += 1;
                             }
+                            None => break,
                         }
                     }
 
@@ -518,10 +532,11 @@ impl FromStr for MatchResult {
 
                     // `i` is the byte index of the closing ASCII `]`, so the
                     // inclusive slice ends on a char boundary.
-                    filled_order_ids_str = Some(&s[pos..=i]);
+                    filled_order_ids_str =
+                        Some(s.get(pos..=i).ok_or(PriceLevelError::InvalidFormat)?);
 
                     pos = i + 1;
-                    if pos < bytes.len() && bytes[pos] == b';' {
+                    if bytes.get(pos) == Some(&b';') {
                         pos += 1;
                     }
                 }

--- a/src/execution/tests/match_result_trade.rs
+++ b/src/execution/tests/match_result_trade.rs
@@ -638,6 +638,106 @@ mod tests {
         }
     }
 
+    /// An explicit outcome that contradicts the decoded fields is rejected:
+    /// `Filled` with a positive remainder, `PartiallyFilled` with a zero
+    /// remainder or without trades, `NotFilled` with trades, and a complete
+    /// (zero-remainder) `Killed` / `Rejected`.
+    #[test]
+    fn deserialize_rejects_contradictory_explicit_outcome() {
+        let mut partial = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(partial.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+        let empty = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        let complete = MatchResult::new(Id::from_u64(10), Quantity::new(0));
+
+        // Filled with a positive remainder.
+        let json = mutated_json(&partial, |v| {
+            v["outcome"] = serde_json::json!("filled");
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+        // PartiallyFilled with zero remainder / no trades.
+        let json = mutated_json(&complete, |v| {
+            v["outcome"] = serde_json::json!("partially_filled");
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+        let json = mutated_json(&empty, |v| {
+            v["outcome"] = serde_json::json!("partially_filled");
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+        // NotFilled with trades present.
+        let json = mutated_json(&partial, |v| {
+            v["outcome"] = serde_json::json!("not_filled");
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+        // A complete, empty Killed / Rejected (turned-away takers keep their
+        // full quantity).
+        for outcome in ["killed", "rejected"] {
+            let json = mutated_json(&complete, |v| {
+                v["outcome"] = serde_json::json!(outcome);
+            });
+            assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+        }
+    }
+
+    /// A legacy payload without an outcome key derives the benign
+    /// classification from the other fields instead of being rejected.
+    #[test]
+    fn deserialize_legacy_payload_without_outcome_derives() {
+        let mut partial = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(partial.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+        let json = mutated_json(&partial, |v| {
+            if let Some(obj) = v.as_object_mut() {
+                obj.remove("outcome");
+            }
+        });
+        let decoded = match serde_json::from_str::<MatchResult>(&json) {
+            Ok(decoded) => decoded,
+            Err(err) => panic!("legacy payload must decode: {err}"),
+        };
+        assert_eq!(decoded.outcome(), MatchOutcome::PartiallyFilled);
+    }
+
+    /// A trade whose taker order id differs from the result's incoming order id
+    /// is rejected at decode time and by `add_trade`.
+    #[test]
+    fn taker_identity_enforced_on_decode_and_add_trade() {
+        let mut base = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(base.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+
+        let json = mutated_json(&base, |v| {
+            v["order_id"] = serde_json::json!(Id::from_u64(999));
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+
+        // add_trade mirrors the guard: sample trades carry taker id 10.
+        let mut mismatched = MatchResult::new(Id::from_u64(999), Quantity::new(100));
+        assert!(
+            mismatched
+                .add_trade(sample_trade_with_maker(20, 40))
+                .is_err()
+        );
+    }
+
+    /// Duplicate or out-of-order filled ids are rejected: the engine records
+    /// each fully-consumed maker exactly once, in trade order.
+    #[test]
+    fn deserialize_rejects_duplicate_or_out_of_order_filled_ids() {
+        let mut base = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(base.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+        assert!(base.add_trade(sample_trade_with_maker(21, 60)).is_ok());
+        base.add_filled_order_id(Id::from_u64(20));
+        base.add_filled_order_id(Id::from_u64(21));
+
+        let json = mutated_json(&base, |v| {
+            v["filled_order_ids"] = serde_json::json!([Id::from_u64(20), Id::from_u64(20)]);
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+
+        let json = mutated_json(&base, |v| {
+            v["filled_order_ids"] = serde_json::json!([Id::from_u64(21), Id::from_u64(20)]);
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+    }
+
     /// Build a valid `MatchResult` purely through the public API from a seed, so
     /// every invariant `validated` checks holds by construction: `add_trade`
     /// keeps `is_complete` / `remaining` / `outcome` in lockstep, and each
@@ -645,6 +745,10 @@ mod tests {
     fn build_valid_result(initial: u64, specs: &[(u64, u64, bool)]) -> MatchResult {
         let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(initial));
         let mut remaining = initial;
+        // A fully-consumed maker is recorded in filled_order_ids exactly once
+        // (the engine removes it from the queue), so the generator must not
+        // fill the same maker twice — the validator rejects duplicates.
+        let mut filled = std::collections::HashSet::new();
         for &(maker, raw_qty, fill) in specs {
             if remaining == 0 {
                 break;
@@ -656,7 +760,7 @@ mod tests {
                 .is_ok()
             {
                 remaining -= qty;
-                if fill {
+                if fill && filled.insert(maker) {
                     result.add_filled_order_id(Id::from_u64(maker));
                 }
             }

--- a/src/execution/tests/match_result_trade.rs
+++ b/src/execution/tests/match_result_trade.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod tests {
+    use crate::execution::list::TradeList;
     use crate::execution::match_result::{MatchOutcome, MatchResult};
     use crate::execution::trade::Trade;
     use crate::orders::{Id, Side};
@@ -15,10 +16,14 @@ mod tests {
     }
 
     fn sample_trade(quantity: u64) -> Trade {
+        sample_trade_with_maker(20, quantity)
+    }
+
+    fn sample_trade_with_maker(maker_id: u64, quantity: u64) -> Trade {
         Trade::with_timestamp(
             Id::from_uuid(parse_uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
             Id::from_u64(10),
-            Id::from_u64(20),
+            Id::from_u64(maker_id),
             Price::new(1_000),
             Quantity::new(quantity),
             Side::Buy,
@@ -358,9 +363,11 @@ mod tests {
     /// unchanged through `FromStr`.
     #[test]
     fn display_round_trips_with_filled_ids_and_trades() {
+        // Two makers (20 and 21) each fully consumed, so each is both a trade
+        // maker and a filled id — the shape the engine actually produces.
         let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(100));
-        assert!(result.add_trade(sample_trade(30)).is_ok());
-        assert!(result.add_trade(sample_trade(20)).is_ok());
+        assert!(result.add_trade(sample_trade_with_maker(20, 30)).is_ok());
+        assert!(result.add_trade(sample_trade_with_maker(21, 20)).is_ok());
         result.add_filled_order_id(Id::from_u64(20));
         result.add_filled_order_id(Id::from_u64(21));
 
@@ -380,6 +387,203 @@ mod tests {
         );
         // Rendering the parsed result reproduces the exact canonical text.
         assert_eq!(parsed.to_string(), rendered);
+    }
+
+    // ----- issue #116: invariants enforced during decoding -----
+    //
+    // Private fields protect Rust-API construction, but `Deserialize` and
+    // `FromStr` reconstruct fields directly. Both now route through
+    // `MatchResult::validated`, so a self-contradictory payload is rejected
+    // (serde error / `PriceLevelError`) instead of minting an impossible value.
+    // Every payload a public-API-built result can produce still decodes.
+
+    /// A valid `MatchResult` carrying trades and filled ids round-trips through
+    /// serde JSON with all fields (including `outcome`) intact.
+    #[test]
+    fn valid_result_with_filled_ids_round_trips_serde_json() {
+        let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(result.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+        result.add_filled_order_id(Id::from_u64(20));
+
+        let json = serde_json::to_string(&result).expect("serialize");
+        let parsed: MatchResult = serde_json::from_str(&json).expect("valid payload must decode");
+
+        assert_eq!(parsed.order_id(), Id::from_u64(10));
+        assert_eq!(parsed.remaining_quantity().as_u64(), 60);
+        assert!(!parsed.is_complete());
+        assert_eq!(parsed.outcome(), MatchOutcome::PartiallyFilled);
+        assert_eq!(parsed.trades().len(), 1);
+        assert_eq!(parsed.filled_order_ids(), &[Id::from_u64(20)]);
+    }
+
+    /// A genuinely killed / rejected result (no trades, no filled ids) still
+    /// decodes — the outcome invariant only forbids a *populated* kill/reject.
+    #[test]
+    fn valid_killed_and_rejected_round_trip_serde_json() {
+        for build in [
+            MatchResult::mark_killed as fn(&mut MatchResult, u64),
+            MatchResult::mark_rejected,
+        ] {
+            let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+            build(&mut result, 100);
+
+            let json = serde_json::to_string(&result).expect("serialize");
+            let parsed: MatchResult =
+                serde_json::from_str(&json).expect("empty kill/reject must decode");
+
+            assert_eq!(parsed.remaining_quantity().as_u64(), 100);
+            assert!(!parsed.is_complete());
+            assert!(parsed.trades().is_empty());
+            assert!(parsed.filled_order_ids().is_empty());
+            assert!(parsed.was_killed() || parsed.was_rejected());
+        }
+    }
+
+    /// Helper: serialize a valid result, mutate the JSON object, and return the
+    /// mutated JSON string so a negative test can feed it back to `from_str`.
+    fn mutated_json(base: &MatchResult, mutate: impl FnOnce(&mut serde_json::Value)) -> String {
+        let mut value = serde_json::to_value(base).expect("serialize base");
+        mutate(&mut value);
+        serde_json::to_string(&value).expect("re-serialize mutated payload")
+    }
+
+    /// Invariant 1: `is_complete == true` with a positive remainder is rejected.
+    #[test]
+    fn deserialize_rejects_complete_with_remainder() {
+        // new(0) is complete with remainder 0; force a positive remainder.
+        let base = MatchResult::new(Id::from_u64(10), Quantity::new(0));
+        let json = mutated_json(&base, |v| {
+            v["remaining_quantity"] = serde_json::json!(5);
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+    }
+
+    /// Invariant 3: a `Rejected` / `Killed` outcome may not carry trades.
+    #[test]
+    fn deserialize_rejects_trades_on_killed_or_rejected() {
+        let mut base = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(base.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+
+        for outcome in ["killed", "rejected"] {
+            let json = mutated_json(&base, |v| {
+                v["outcome"] = serde_json::json!(outcome);
+            });
+            assert!(
+                serde_json::from_str::<MatchResult>(&json).is_err(),
+                "{outcome} with trades must be rejected"
+            );
+        }
+    }
+
+    /// Invariant 3 (filled ids variant): a `Killed` outcome may not carry
+    /// filled order ids either.
+    #[test]
+    fn deserialize_rejects_filled_ids_on_killed() {
+        let mut base = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        base.mark_killed(100);
+        let json = mutated_json(&base, |v| {
+            // Killed carries no trades; inject a filled id with no backing trade.
+            v["filled_order_ids"] = serde_json::json!(["20"]);
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+    }
+
+    /// Invariant 2: trade quantities whose sum overflows `u64` are rejected.
+    #[test]
+    fn deserialize_rejects_executed_quantity_sum_overflow() {
+        let mut base = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(base.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+        assert!(base.add_trade(sample_trade_with_maker(21, 20)).is_ok());
+        // Two trades each at u64::MAX overflow the checked sum.
+        let json = mutated_json(&base, |v| {
+            v["trades"]["trades"][0]["quantity"] = serde_json::json!(u64::MAX);
+            v["trades"]["trades"][1]["quantity"] = serde_json::json!(u64::MAX);
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+    }
+
+    /// Invariant 2 (implied initial): executed quantity + remaining overflowing
+    /// `u64` (an impossible initial taker quantity) is rejected.
+    #[test]
+    fn deserialize_rejects_executed_plus_remaining_overflow() {
+        let mut base = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(base.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+        let json = mutated_json(&base, |v| {
+            v["trades"]["trades"][0]["quantity"] = serde_json::json!(u64::MAX);
+            // Keep is_complete consistent with a positive remainder.
+            v["remaining_quantity"] = serde_json::json!(5);
+            v["is_complete"] = serde_json::json!(false);
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+    }
+
+    /// Invariant 4: a filled order id with no backing trade maker is rejected.
+    #[test]
+    fn deserialize_rejects_filled_id_absent_from_trades() {
+        let mut base = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(base.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+        base.add_filled_order_id(Id::from_u64(20));
+        let json = mutated_json(&base, |v| {
+            // 99 never traded.
+            v["filled_order_ids"] = serde_json::json!(["20", "99"]);
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+    }
+
+    // ----- issue #116: the same invariants via FromStr -----
+
+    /// `FromStr` rejects a structurally-valid text whose `is_complete` claim
+    /// contradicts the remainder.
+    #[test]
+    fn from_str_rejects_complete_with_remainder() {
+        let text = "MatchResult:order_id=10;remaining_quantity=5;is_complete=true;\
+                    trades=Trades:[];filled_order_ids=[]";
+        assert!(MatchResult::from_str(text).is_err());
+    }
+
+    /// `FromStr` rejects text whose trade quantities sum past `u64::MAX`.
+    #[test]
+    fn from_str_rejects_executed_quantity_sum_overflow() {
+        let trades = TradeList::from_vec(vec![
+            sample_trade_with_maker(20, u64::MAX),
+            sample_trade_with_maker(21, u64::MAX),
+        ]);
+        let text = format!(
+            "MatchResult:order_id=10;remaining_quantity=1;is_complete=false;\
+             trades={trades};filled_order_ids=[]"
+        );
+        assert!(MatchResult::from_str(&text).is_err());
+    }
+
+    /// `FromStr` rejects text listing a filled id that is not a trade maker.
+    #[test]
+    fn from_str_rejects_filled_id_absent_from_trades() {
+        let trades = TradeList::from_vec(vec![sample_trade_with_maker(20, 40)]);
+        let text = format!(
+            "MatchResult:order_id=10;remaining_quantity=60;is_complete=false;\
+             trades={trades};filled_order_ids=[20,99]"
+        );
+        assert!(MatchResult::from_str(&text).is_err());
+    }
+
+    /// Structural tightening (#114 review follow-up): trailing content after the
+    /// `filled_order_ids` closing `]` is now rejected, symmetric with the
+    /// `trades` branch. Previously the `filled_order_ids` branch silently
+    /// tolerated a missing `;` separator and parsed the trailing text as another
+    /// field.
+    #[test]
+    fn from_str_rejects_trailing_content_after_filled_ids() {
+        // A second `order_id=...` glued directly to the closing `]` with no `;`.
+        let text = "MatchResult:order_id=10;remaining_quantity=0;is_complete=true;\
+                    trades=Trades:[];filled_order_ids=[]order_id=10";
+        assert!(
+            MatchResult::from_str(text).is_err(),
+            "trailing content after filled_order_ids ']' must be rejected"
+        );
+        // The canonical form (nothing after the ']') still parses.
+        let ok = "MatchResult:order_id=10;remaining_quantity=0;is_complete=true;\
+                  trades=Trades:[];filled_order_ids=[]";
+        assert!(MatchResult::from_str(ok).is_ok());
     }
 
     // ----- property: from_str never panics on arbitrary UTF-8 -----
@@ -431,6 +635,75 @@ mod tests {
         #[test]
         fn from_str_never_panics_on_structural_fuzz(input in structural_fuzz()) {
             let _ = MatchResult::from_str(&input);
+        }
+    }
+
+    /// Build a valid `MatchResult` purely through the public API from a seed, so
+    /// every invariant `validated` checks holds by construction: `add_trade`
+    /// keeps `is_complete` / `remaining` / `outcome` in lockstep, and each
+    /// filled id is a maker that just traded.
+    fn build_valid_result(initial: u64, specs: &[(u64, u64, bool)]) -> MatchResult {
+        let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(initial));
+        let mut remaining = initial;
+        for &(maker, raw_qty, fill) in specs {
+            if remaining == 0 {
+                break;
+            }
+            // A trade of 1..=remaining keeps add_trade from underflowing.
+            let qty = raw_qty % remaining + 1;
+            if result
+                .add_trade(sample_trade_with_maker(maker, qty))
+                .is_ok()
+            {
+                remaining -= qty;
+                if fill {
+                    result.add_filled_order_id(Id::from_u64(maker));
+                }
+            }
+        }
+        result
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+        /// Any valid result built through the public API round-trips both serde
+        /// JSON (outcome preserved) and Display/FromStr (benign outcome
+        /// re-derived identically) with no field drift — the validator never
+        /// rejects a legitimately-constructed value.
+        #[test]
+        fn valid_result_round_trips_both_encodings(
+            initial in 1u64..=100_000,
+            specs in prop::collection::vec((20u64..=40, 1u64..=100_000, any::<bool>()), 0..12),
+        ) {
+            let original = build_valid_result(initial, &specs);
+
+            // serde JSON must decode and preserve every field, outcome included.
+            let json = serde_json::to_string(&original)
+                .map_err(|e| TestCaseError::fail(format!("serialize: {e}")))?;
+            let decoded: MatchResult = serde_json::from_str(&json)
+                .map_err(|e| TestCaseError::fail(format!("valid json must decode: {e}")))?;
+            prop_assert_eq!(decoded.order_id(), original.order_id());
+            prop_assert_eq!(
+                decoded.remaining_quantity().as_u64(),
+                original.remaining_quantity().as_u64()
+            );
+            prop_assert_eq!(decoded.is_complete(), original.is_complete());
+            prop_assert_eq!(decoded.outcome(), original.outcome());
+            prop_assert_eq!(decoded.trades().len(), original.trades().len());
+            prop_assert_eq!(decoded.filled_order_ids(), original.filled_order_ids());
+
+            // Display / FromStr must reparse and preserve the text-carried fields.
+            let text = original.to_string();
+            let reparsed = MatchResult::from_str(&text)
+                .map_err(|e| TestCaseError::fail(format!("valid text must reparse: {e}")))?;
+            prop_assert_eq!(
+                reparsed.remaining_quantity().as_u64(),
+                original.remaining_quantity().as_u64()
+            );
+            prop_assert_eq!(reparsed.is_complete(), original.is_complete());
+            prop_assert_eq!(reparsed.trades().len(), original.trades().len());
+            prop_assert_eq!(reparsed.filled_order_ids(), original.filled_order_ids());
         }
     }
 }

--- a/src/execution/tests/match_result_trade.rs
+++ b/src/execution/tests/match_result_trade.rs
@@ -278,4 +278,159 @@ mod tests {
             }
         }
     }
+
+    // ----- issue #114: malformed UTF-8 must parse to Err, never panic -----
+    //
+    // `MatchResult::from_str` accepts untrusted text and must return a
+    // `Result`, so a multibyte Unicode scalar sitting before the next ASCII
+    // delimiter must not make an internal byte offset land inside the scalar
+    // and panic on a non-char-boundary slice. Each case below simply calls
+    // `from_str` and asserts `Err`: a plain call is enough to prove no panic,
+    // because a panic would unwind the test rather than reach the assertion.
+
+    /// Every field position that the byte scanners walk — a plain field value,
+    /// a value that runs to the end of the string with no trailing `;`, a
+    /// field name, the `trades` bracket body, and the `filled_order_ids`
+    /// bracket body — must reject 2-, 3-, and 4-byte scalars deterministically.
+    #[test]
+    fn from_str_rejects_multibyte_without_panicking() {
+        // 'é' = 2 bytes, '→' = 3 bytes, '😀' = 4 bytes: cover every UTF-8 width
+        // and a scalar straddling each delimiter position.
+        let malformed = [
+            // Multibyte in a field value immediately before the ';' delimiter.
+            "MatchResult:order_id=é;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[];filled_order_ids=[]",
+            "MatchResult:order_id=→;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[];filled_order_ids=[]",
+            // Multibyte in the LAST-scanned value that runs to end-of-string
+            // (no trailing ';'): exercises the find-to-end branch.
+            "MatchResult:order_id=10😀",
+            // Multibyte in a field NAME (before the '=').
+            "MatchResult:é=10;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[];filled_order_ids=[]",
+            // Multibyte inside the trades bracket body.
+            "MatchResult:order_id=10;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[é];filled_order_ids=[]",
+            "MatchResult:order_id=10;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[😀];filled_order_ids=[]",
+            // Multibyte inside the filled_order_ids bracket list.
+            "MatchResult:order_id=10;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[];filled_order_ids=[é]",
+            "MatchResult:order_id=10;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[];filled_order_ids=[1,→,2]",
+            // Multibyte right where the '=' after a field name is expected.
+            "MatchResult:order_idé=10;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[];filled_order_ids=[]",
+        ];
+
+        for input in malformed {
+            let parsed = MatchResult::from_str(input);
+            assert!(
+                parsed.is_err(),
+                "malformed multibyte input must parse to Err, got Ok for {input:?}"
+            );
+        }
+    }
+
+    /// A multibyte scalar that lands exactly on the byte offset where the
+    /// scanner probes for the closing `]` of each bracket must not panic — the
+    /// bracket depth stays unbalanced and the parse fails cleanly.
+    #[test]
+    fn from_str_rejects_unterminated_multibyte_bracket() {
+        let inputs = [
+            // trades bracket opened, then a multibyte scalar, then end.
+            "MatchResult:order_id=10;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[é",
+            // filled_order_ids bracket opened, then a multibyte scalar, then end.
+            "MatchResult:order_id=10;remaining_quantity=60;is_complete=false;\
+             trades=Trades:[];filled_order_ids=[😀",
+        ];
+        for input in inputs {
+            assert!(
+                MatchResult::from_str(input).is_err(),
+                "unterminated multibyte bracket must parse to Err for {input:?}"
+            );
+        }
+    }
+
+    /// Canonical ASCII output from `Display` — including a populated
+    /// `filled_order_ids` list and multiple trades — must keep round-tripping
+    /// unchanged through `FromStr`.
+    #[test]
+    fn display_round_trips_with_filled_ids_and_trades() {
+        let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(result.add_trade(sample_trade(30)).is_ok());
+        assert!(result.add_trade(sample_trade(20)).is_ok());
+        result.add_filled_order_id(Id::from_u64(20));
+        result.add_filled_order_id(Id::from_u64(21));
+
+        let rendered = result.to_string();
+        let parsed = match MatchResult::from_str(&rendered) {
+            Ok(value) => value,
+            Err(error) => panic!("valid canonical output must round-trip: {error:?}"),
+        };
+
+        assert_eq!(parsed.order_id(), Id::from_u64(10));
+        assert_eq!(parsed.remaining_quantity().as_u64(), 50);
+        assert!(!parsed.is_complete());
+        assert_eq!(parsed.trades().len(), 2);
+        assert_eq!(
+            parsed.filled_order_ids(),
+            &[Id::from_u64(20), Id::from_u64(21)]
+        );
+        // Rendering the parsed result reproduces the exact canonical text.
+        assert_eq!(parsed.to_string(), rendered);
+    }
+
+    // ----- property: from_str never panics on arbitrary UTF-8 -----
+    //
+    // A co-located `proptest` block (the `tests/proptest/` harness is reserved
+    // for the nine matching invariants and drives `PriceLevel`, not the
+    // parser, so a parser-robustness property does not fit there). `proptest`
+    // reports any panic in the closure as a failing, shrinking case, so the
+    // bodies just call `from_str` and drop the result.
+    use proptest::prelude::*;
+
+    /// Concatenate the format's structural delimiters with arbitrary Unicode
+    /// scalars so multibyte characters land adjacent to (and straddling) every
+    /// delimiter the byte scanners probe — the worst case for boundary safety.
+    fn structural_fuzz() -> impl Strategy<Value = String> {
+        let token = prop_oneof![
+            Just("=".to_string()),
+            Just(";".to_string()),
+            Just("[".to_string()),
+            Just("]".to_string()),
+            Just("Trades:".to_string()),
+            Just("order_id".to_string()),
+            Just("remaining_quantity".to_string()),
+            Just("is_complete".to_string()),
+            Just("trades".to_string()),
+            Just("filled_order_ids".to_string()),
+            any::<char>().prop_map(|c| c.to_string()),
+        ];
+        prop::collection::vec(token, 0..24)
+            .prop_map(|parts| format!("MatchResult:{}", parts.concat()))
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 1024, ..ProptestConfig::default() })]
+
+        /// Arbitrary UTF-8 strings (with the required prefix and bare) never
+        /// panic; they either parse or return `Err`.
+        #[test]
+        fn from_str_never_panics_on_arbitrary_utf8(suffix in any::<String>()) {
+            let with_prefix = format!("MatchResult:{suffix}");
+            // The result is deliberately ignored — a panic (not an Err) is the
+            // only way this can fail.
+            let _ = MatchResult::from_str(&with_prefix);
+            let _ = MatchResult::from_str(&suffix);
+        }
+
+        /// Delimiter-dense fuzz: multibyte scalars adjacent to every structural
+        /// delimiter still never panic.
+        #[test]
+        fn from_str_never_panics_on_structural_fuzz(input in structural_fuzz()) {
+            let _ = MatchResult::from_str(&input);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Derived `Deserialize` wrote `MatchResult`'s private fields directly and
`FromStr` constructed without validation, so malformed input could claim
`is_complete` with a positive remainder, attach trades to `Rejected` /
`Killed` results, disagree about executed quantity, or list filled makers
unrepresented by trades. Both decoders now route through one private
invariant validator; the wire format is byte-identical and every
previously-valid payload still decodes.

## Stack

- **Stack:** #118 → #114 → #116 → #111 → #113 → #120 → #119 → #115 → #117 → #112 (**this is 3/10**)
- **Base branch:** `stack/2-114-utf8-safe-parser`
- **Stacked on:** #122 — **the diff vs `main` is cumulative**; review against the base branch.

## Changes

- `Deserialize` replaced with `#[serde(try_from = "MatchResultWire")]` — a
  private permissive mirror with identical field names and the `outcome`
  default preserved; `Serialize` untouched.
- Single validator enforcing: `is_complete ⇔ remaining == 0`; checked
  trade-quantity sum and `sum + remaining` fit `u64`; `Killed` / `Rejected`
  carry zero trades and zero filled ids; every `filled_order_id` appears as a
  trade maker (the exact `match_order` contract — ids recorded only on full
  consumption right after their trade).
- `FromStr` routes through the same validator, and its `filled_order_ids`
  bracket now rejects trailing content after `]` (asymmetry flagged in #122's
  review).

## Technical decisions

- `NotFilled` / `PartiallyFilled` vs trades is deliberately **not**
  constrained: legacy payloads default `outcome` to `NotFilled` with trades
  present and accessors correct it — enforcing it would break backward
  compatibility. Only the pre-sweep `Killed` / `Rejected` outcomes are
  constrained.
- Reuses existing `InvalidOperation` / `InvalidFormat` error variants — no new
  variant, no wire-format change, no snapshot impact.

## Testing

- [x] Negative serde JSON per invariant (structurally valid payloads only the
  validator rejects) + negative `FromStr` cases + trailing-content tightening
- [x] Positive round-trips: filled ids + trades, killed, rejected
- [x] 256-case proptest: arbitrary valid results built via the public API
  round-trip through both encodings with no field drift
- [x] Pre-push checks clean locally

467 tests passed; 0 failed (448 lib + 9 + 1 + 9 doctests).

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic in the sums — no `saturating_*` / `wrapping_*`
- [x] Wire struct stays private — no public-surface change
- [x] No new production `unsafe`, no new dependencies
- [x] Module boundaries respected

Closes #116


- **Blocks:** #124
