### PR TITLE
Reject quantity overflow before mutating level state (#111)

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,21 @@ before; the snapshot format version is **not** bumped and the SHA-256
 checksum over an unchanged payload still validates. Existing snapshot JSON
 restores without migration.
 
+### Migration Guide (`PriceLevel::add_order` is now checked — breaking)
+
+[`PriceLevel::add_order`] now returns
+`Result<Arc<OrderType<()>>, PriceLevelError>` instead of
+`Arc<OrderType<()>>`. It reserves the order's visible / hidden quantity and
+its count slot on the level's atomic counters (with checked `fetch_update`)
+**before** publishing the order to the queue, and returns
+[`PriceLevelError::InvalidOperation`] if any counter would overflow `u64` —
+leaving the level completely unchanged rather than wrapping a counter while
+the queue already holds the admitted order. Callers must handle the
+`Result` — propagate with `level.add_order(order)?` (test fixtures and
+binaries may prefer `.expect(...)`); the returned `Arc` is unchanged on
+success. Admissions that stay within `u64` (all normal use) behave exactly
+as before.
+
 
  ## Setup Instructions
 

--- a/benches/concurrent/contention.rs
+++ b/benches/concurrent/contention.rs
@@ -64,7 +64,9 @@ fn measure_read_write_contention(
     // Pre-populate with orders to read/match against
     for i in 0..500 {
         let order = create_standard_order(i, 10000, 10);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     let mut handles = Vec::with_capacity(thread_count);
@@ -102,7 +104,9 @@ fn measure_read_write_contention(
                             // Add a new order
                             let base_id = thread_id as u64 * 1_000_000 + i;
                             let order = create_standard_order(base_id, 10000, 10);
-                            thread_price_level.add_order(order);
+                            thread_price_level
+                                .add_order(order)
+                                .expect("add_order should succeed");
                         }
                         1 => {
                             // Match against existing orders
@@ -164,13 +168,17 @@ fn measure_hot_spot_contention(
     // First 20 orders are the "hot spot" that may be contended
     for i in 0..20 {
         let order = create_standard_order(i, 10000, 10);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     // Additional 980 orders for the non-hot spot operations
     for i in 20..1000 {
         let order = create_standard_order(i, 10000, 10);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     let mut handles = Vec::with_capacity(thread_count);
@@ -212,7 +220,9 @@ fn measure_hot_spot_contention(
                         // Add a new order to replace canceled ones
                         let base_id = order_idx;
                         let order = create_standard_order(base_id, 10000, 10);
-                        thread_price_level.add_order(order);
+                        thread_price_level
+                            .add_order(order)
+                            .expect("add_order should succeed");
                     }
                     2 => {
                         // Update quantity

--- a/benches/concurrent/register.rs
+++ b/benches/concurrent/register.rs
@@ -26,7 +26,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
                             // Each thread adds orders with unique IDs
                             let base_id = thread_id as u64 * 1_000_000 + iteration;
                             let order = create_standard_order(base_id, 10000, 100);
-                            price_level.add_order(order);
+                            price_level
+                                .add_order(order)
+                                .expect("add_order should succeed");
                         },
                     )
                 });
@@ -51,7 +53,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
                                 3 => create_reserve_order(base_id, 10000, 50, 150, 10, true, None),
                                 _ => create_pegged_order(base_id, 10000, 100),
                             };
-                            price_level.add_order(order);
+                            price_level
+                                .add_order(order)
+                                .expect("add_order should succeed");
                         },
                     )
                 });
@@ -231,7 +235,9 @@ where
         for i in 0..100 {
             let order_id = thread_id as u64 * 100 + i;
             let order = create_standard_order(order_id, 10000, 10);
-            initial_price_level.add_order(order);
+            initial_price_level
+                .add_order(order)
+                .expect("add_order should succeed");
         }
     }
 
@@ -288,7 +294,9 @@ fn measure_concurrent_mixed_operations(thread_count: usize, iterations: u64) -> 
     // Pre-populate with some orders
     for i in 0..200 {
         let order = create_standard_order(i, 10000, 10);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     let mut handles = Vec::with_capacity(thread_count);
@@ -309,7 +317,9 @@ fn measure_concurrent_mixed_operations(thread_count: usize, iterations: u64) -> 
                         // Add a new order
                         let base_id = thread_id as u64 * 1_000_000 + i;
                         let order = create_standard_order(base_id, 10000, 10);
-                        thread_price_level.add_order(order);
+                        thread_price_level
+                            .add_order(order)
+                            .expect("add_order should succeed");
                     }
                     1 => {
                         // Match against existing orders
@@ -462,7 +472,9 @@ fn setup_standard_orders(order_count: u64) -> PriceLevel {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     price_level

--- a/benches/price_level/add_orders.rs
+++ b/benches/price_level/add_orders.rs
@@ -15,7 +15,11 @@ pub fn register_benchmarks(c: &mut Criterion) {
             let price_level = PriceLevel::new(10000);
             for i in 0..100 {
                 let order = create_standard_order(i, 10000, 100);
-                black_box(price_level.add_order(order));
+                black_box(
+                    price_level
+                        .add_order(order)
+                        .expect("add_order should succeed"),
+                );
             }
         })
     });
@@ -26,7 +30,11 @@ pub fn register_benchmarks(c: &mut Criterion) {
             let price_level = PriceLevel::new(10000);
             for i in 0..100 {
                 let order = create_iceberg_order(i, 10000, 50, 150);
-                black_box(price_level.add_order(order));
+                black_box(
+                    price_level
+                        .add_order(order)
+                        .expect("add_order should succeed"),
+                );
             }
         })
     });
@@ -37,7 +45,11 @@ pub fn register_benchmarks(c: &mut Criterion) {
             let price_level = PriceLevel::new(10000);
             for i in 0..100 {
                 let order = create_reserve_order(i, 10000, 50, 150, 10, true, None);
-                black_box(price_level.add_order(order));
+                black_box(
+                    price_level
+                        .add_order(order)
+                        .expect("add_order should succeed"),
+                );
             }
         })
     });
@@ -54,7 +66,11 @@ pub fn register_benchmarks(c: &mut Criterion) {
                     3 => create_reserve_order(i, 10000, 50, 150, 10, true, None),
                     _ => create_pegged_order(i, 10000, 100),
                 };
-                black_box(price_level.add_order(order));
+                black_box(
+                    price_level
+                        .add_order(order)
+                        .expect("add_order should succeed"),
+                );
             }
         })
     });
@@ -69,7 +85,11 @@ pub fn register_benchmarks(c: &mut Criterion) {
                     let price_level = PriceLevel::new(10000);
                     for i in 0..order_count {
                         let order = create_standard_order(i, 10000, 100);
-                        black_box(price_level.add_order(order));
+                        black_box(
+                            price_level
+                                .add_order(order)
+                                .expect("add_order should succeed"),
+                        );
                     }
                 })
             },

--- a/benches/price_level/checked_arithmetic.rs
+++ b/benches/price_level/checked_arithmetic.rs
@@ -133,16 +133,18 @@ pub fn register_benchmarks(c: &mut Criterion) {
 fn setup_standard_level(order_count: u64) -> PriceLevel {
     let level = PriceLevel::new(10000);
     for i in 0..order_count {
-        level.add_order(OrderType::Standard {
-            id: Id::from_u64(i),
-            price: Price::new(10000),
-            quantity: Quantity::new(10),
-            side: Side::Buy,
-            user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(1_616_823_000_000 + i),
-            time_in_force: TimeInForce::Gtc,
-            extra_fields: (),
-        });
+        level
+            .add_order(OrderType::Standard {
+                id: Id::from_u64(i),
+                price: Price::new(10000),
+                quantity: Quantity::new(10),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_616_823_000_000 + i),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
     }
     level
 }
@@ -188,7 +190,7 @@ fn setup_mixed_level(order_count: u64) -> PriceLevel {
                 extra_fields: (),
             },
         };
-        level.add_order(order);
+        level.add_order(order).expect("add_order should succeed");
     }
     level
 }

--- a/benches/price_level/iter_orders.rs
+++ b/benches/price_level/iter_orders.rs
@@ -63,7 +63,9 @@ fn setup_level(order_count: u64) -> PriceLevel {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
     price_level
 }

--- a/benches/price_level/lifecycle.rs
+++ b/benches/price_level/lifecycle.rs
@@ -20,7 +20,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
 
             // Phase 1: Add 100 orders
             for i in 0..100_u64 {
-                level.add_order(create_standard_order(i, 10000, 50));
+                level
+                    .add_order(create_standard_order(i, 10000, 50))
+                    .expect("add_order should succeed");
             }
 
             // Phase 2: Update quantity on 20 orders
@@ -76,7 +78,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
                     ));
                 } else {
                     // Add order
-                    level.add_order(create_standard_order(i, 10000, 20));
+                    level
+                        .add_order(create_standard_order(i, 10000, 20))
+                        .expect("add_order should succeed");
                 }
             }
             black_box(level.order_count());
@@ -90,7 +94,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
 
             // Add 200 orders
             for i in 0..200_u64 {
-                level.add_order(create_standard_order(i, 10000, 10));
+                level
+                    .add_order(create_standard_order(i, 10000, 10))
+                    .expect("add_order should succeed");
             }
 
             // Cancel 150 of them
@@ -112,7 +118,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
 
             // Add 100 orders with quantity 10 each = 1000 total
             for i in 0..100_u64 {
-                level.add_order(create_standard_order(i, 10000, 10));
+                level
+                    .add_order(create_standard_order(i, 10000, 10))
+                    .expect("add_order should succeed");
             }
 
             // Drain completely
@@ -136,7 +144,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
 
             // Add 100 orders
             for i in 0..100_u64 {
-                level.add_order(create_standard_order(i, 10000, 50));
+                level
+                    .add_order(create_standard_order(i, 10000, 50))
+                    .expect("add_order should succeed");
             }
 
             // Replace 50 orders (same price = quantity update)
@@ -169,7 +179,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
             let level = PriceLevel::new(10000);
 
             for i in 0..100_u64 {
-                level.add_order(create_standard_order(i, 10000, 20));
+                level
+                    .add_order(create_standard_order(i, 10000, 20))
+                    .expect("add_order should succeed");
 
                 // Query stats every 10 adds
                 if i % 10 == 0 {

--- a/benches/price_level/match_orders.rs
+++ b/benches/price_level/match_orders.rs
@@ -189,7 +189,9 @@ fn setup_standard_orders(order_count: u64) -> PriceLevel {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     price_level
@@ -211,7 +213,9 @@ fn setup_iceberg_orders(order_count: u64) -> PriceLevel {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     price_level
@@ -236,7 +240,9 @@ fn setup_reserve_orders(order_count: u64) -> PriceLevel {
             auto_replenish: true,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     price_level
@@ -284,7 +290,9 @@ fn setup_mixed_orders(order_count: u64) -> PriceLevel {
                 extra_fields: (),
             },
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     price_level

--- a/benches/price_level/mixed_operations.rs
+++ b/benches/price_level/mixed_operations.rs
@@ -25,7 +25,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
                     7..=8 => create_iceberg_order(i, 10000, 5, 15),
                     _ => create_reserve_order(i, 10000, 5, 15, 2, true, None),
                 };
-                price_level.add_order(order);
+                price_level
+                    .add_order(order)
+                    .expect("add_order should succeed");
             }
 
             // Phase 2: Execute some matches
@@ -61,7 +63,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
                     7..=8 => create_iceberg_order(i, 10000, 5, 15),
                     _ => create_reserve_order(i, 10000, 5, 15, 2, true, None),
                 };
-                price_level.add_order(order);
+                price_level
+                    .add_order(order)
+                    .expect("add_order should succeed");
             }
 
             // Phase 5: Execute final matches
@@ -88,7 +92,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
             // Add initial orders
             for i in 0..200 {
                 let order = create_standard_order(i, 10000, 5);
-                price_level.add_order(order);
+                price_level
+                    .add_order(order)
+                    .expect("add_order should succeed");
             }
 
             // Execute many small matches interspersed with new orders and cancellations
@@ -105,7 +111,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
 
                 // Add a new order
                 let order = create_standard_order(200 + i, 10000, 5);
-                price_level.add_order(order);
+                price_level
+                    .add_order(order)
+                    .expect("add_order should succeed");
 
                 // Cancel an order
                 if i % 10 == 0 {
@@ -127,7 +135,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
             // Add a large number of small orders
             for i in 0..500 {
                 let order = create_standard_order(i, 10000, 2);
-                price_level.add_order(order);
+                price_level
+                    .add_order(order)
+                    .expect("add_order should succeed");
             }
 
             // Execute a few large matches
@@ -240,7 +250,9 @@ fn setup_mixed_orders(order_count: u64) -> PriceLevel {
             1 => create_iceberg_order(i, 10000, 5, 15),
             _ => create_reserve_order(i, 10000, 5, 15, 2, true, None),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     price_level

--- a/benches/price_level/serialization.rs
+++ b/benches/price_level/serialization.rs
@@ -134,16 +134,18 @@ pub fn register_benchmarks(c: &mut Criterion) {
 fn setup_standard_level(order_count: u64) -> PriceLevel {
     let level = PriceLevel::new(10000);
     for i in 0..order_count {
-        level.add_order(OrderType::Standard {
-            id: Id::from_u64(i),
-            price: Price::new(10000),
-            quantity: Quantity::new(10),
-            side: Side::Buy,
-            user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(1_616_823_000_000 + i),
-            time_in_force: TimeInForce::Gtc,
-            extra_fields: (),
-        });
+        level
+            .add_order(OrderType::Standard {
+                id: Id::from_u64(i),
+                price: Price::new(10000),
+                quantity: Quantity::new(10),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_616_823_000_000 + i),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
     }
     level
 }

--- a/benches/price_level/snapshot_recovery.rs
+++ b/benches/price_level/snapshot_recovery.rs
@@ -124,7 +124,9 @@ fn setup_mixed_level(order_count: u64) -> PriceLevel {
                 extra_fields: (),
             },
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
     price_level
 }

--- a/benches/price_level/special_orders.rs
+++ b/benches/price_level/special_orders.rs
@@ -116,16 +116,18 @@ pub fn register_benchmarks(c: &mut Criterion) {
 fn setup_post_only_level(order_count: u64) -> PriceLevel {
     let level = PriceLevel::new(10000);
     for i in 0..order_count {
-        level.add_order(OrderType::PostOnly {
-            id: Id::from_u64(i),
-            price: Price::new(10000),
-            quantity: Quantity::new(10),
-            side: Side::Buy,
-            user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(1_616_823_000_000 + i),
-            time_in_force: TimeInForce::Gtc,
-            extra_fields: (),
-        });
+        level
+            .add_order(OrderType::PostOnly {
+                id: Id::from_u64(i),
+                price: Price::new(10000),
+                quantity: Quantity::new(10),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_616_823_000_000 + i),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
     }
     level
 }
@@ -134,18 +136,20 @@ fn setup_post_only_level(order_count: u64) -> PriceLevel {
 fn setup_trailing_stop_level(order_count: u64) -> PriceLevel {
     let level = PriceLevel::new(10000);
     for i in 0..order_count {
-        level.add_order(OrderType::TrailingStop {
-            id: Id::from_u64(i),
-            price: Price::new(10000),
-            quantity: Quantity::new(10),
-            side: Side::Buy,
-            user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(1_616_823_000_000 + i),
-            time_in_force: TimeInForce::Gtc,
-            trail_amount: Quantity::new(100),
-            last_reference_price: Price::new(10100),
-            extra_fields: (),
-        });
+        level
+            .add_order(OrderType::TrailingStop {
+                id: Id::from_u64(i),
+                price: Price::new(10000),
+                quantity: Quantity::new(10),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_616_823_000_000 + i),
+                time_in_force: TimeInForce::Gtc,
+                trail_amount: Quantity::new(100),
+                last_reference_price: Price::new(10100),
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
     }
     level
 }
@@ -154,18 +158,20 @@ fn setup_trailing_stop_level(order_count: u64) -> PriceLevel {
 fn setup_pegged_level(order_count: u64) -> PriceLevel {
     let level = PriceLevel::new(10000);
     for i in 0..order_count {
-        level.add_order(OrderType::PeggedOrder {
-            id: Id::from_u64(i),
-            price: Price::new(10000),
-            quantity: Quantity::new(10),
-            side: Side::Buy,
-            user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(1_616_823_000_000 + i),
-            time_in_force: TimeInForce::Gtc,
-            reference_price_offset: -50,
-            reference_price_type: PegReferenceType::BestAsk,
-            extra_fields: (),
-        });
+        level
+            .add_order(OrderType::PeggedOrder {
+                id: Id::from_u64(i),
+                price: Price::new(10000),
+                quantity: Quantity::new(10),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_616_823_000_000 + i),
+                time_in_force: TimeInForce::Gtc,
+                reference_price_offset: -50,
+                reference_price_type: PegReferenceType::BestAsk,
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
     }
     level
 }
@@ -174,16 +180,18 @@ fn setup_pegged_level(order_count: u64) -> PriceLevel {
 fn setup_market_to_limit_level(order_count: u64) -> PriceLevel {
     let level = PriceLevel::new(10000);
     for i in 0..order_count {
-        level.add_order(OrderType::MarketToLimit {
-            id: Id::from_u64(i),
-            price: Price::new(10000),
-            quantity: Quantity::new(10),
-            side: Side::Buy,
-            user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(1_616_823_000_000 + i),
-            time_in_force: TimeInForce::Gtc,
-            extra_fields: (),
-        });
+        level
+            .add_order(OrderType::MarketToLimit {
+                id: Id::from_u64(i),
+                price: Price::new(10000),
+                quantity: Quantity::new(10),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_616_823_000_000 + i),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
     }
     level
 }
@@ -238,7 +246,7 @@ fn setup_all_special_mixed(order_count: u64) -> PriceLevel {
                 extra_fields: (),
             },
         };
-        level.add_order(order);
+        level.add_order(order).expect("add_order should succeed");
     }
     level
 }

--- a/benches/price_level/update_orders.rs
+++ b/benches/price_level/update_orders.rs
@@ -119,7 +119,9 @@ fn setup_standard_orders(order_count: u64) -> PriceLevel {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     price_level
@@ -141,7 +143,9 @@ fn setup_iceberg_orders(order_count: u64) -> PriceLevel {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     price_level

--- a/examples/src/bin/contention_test.rs
+++ b/examples/src/bin/contention_test.rs
@@ -103,7 +103,9 @@ fn test_read_write_ratio() {
                                 // Add a new order
                                 let order_id = thread_id as u64 * 10000 + local_counter;
                                 let order = create_standard_order(order_id, 10000, 10);
-                                thread_price_level.add_order(order);
+                                thread_price_level
+                                    .add_order(order)
+                                    .expect("add_order should succeed");
                             }
                             1 => {
                                 // Match order. Takers live in a disjoint high id
@@ -198,7 +200,9 @@ fn setup_orders_for_read_write_test(price_level: &PriceLevel) {
     // Add 500 orders
     for i in 0..500 {
         let order = create_standard_order(i, 10000, 10);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 }
 
@@ -226,7 +230,9 @@ fn setup_orders_for_hot_spot_test(price_level: &PriceLevel) {
     // Add 1000 orders (first 20 are hot spot)
     for i in 0..1000 {
         let order = create_standard_order(i, 10000, 10);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 }
 
@@ -300,7 +306,9 @@ fn test_hot_spot_contention() {
                         0 => {
                             // Add a new order with same ID (this will likely fail, but creates contention)
                             let order = create_standard_order(order_idx, 10000, 10);
-                            thread_price_level.add_order(order);
+                            thread_price_level
+                                .add_order(order)
+                                .expect("add_order should succeed");
                         }
                         1 => {
                             // Cancel an order

--- a/examples/src/bin/hft_simulation.rs
+++ b/examples/src/bin/hft_simulation.rs
@@ -93,7 +93,9 @@ fn main() {
                     _ => create_pegged_order(order_id),
                 };
 
-                thread_price_level.add_order(order_type);
+                thread_price_level
+                    .add_order(order_type)
+                    .expect("add_order should succeed");
                 local_counter += 1;
 
                 // Update global counter periodically to reduce contention
@@ -321,7 +323,9 @@ fn setup_initial_orders(price_level: &PriceLevel, count: u64) {
             _ => create_reserve_order(i),
         };
 
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 }
 

--- a/examples/src/bin/integration_basic_lifecycle.rs
+++ b/examples/src/bin/integration_basic_lifecycle.rs
@@ -34,7 +34,9 @@ fn main() {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     assert_eq_or_exit(price_level.order_count(), 10, "order_count after add");

--- a/examples/src/bin/integration_checked_arithmetic.rs
+++ b/examples/src/bin/integration_checked_arithmetic.rs
@@ -33,28 +33,32 @@ fn test_total_quantity_checked() {
     println!("[total_quantity] Checked addition...");
 
     let level = PriceLevel::new(10_000);
-    level.add_order(OrderType::Standard {
-        id: Id::from_u64(1),
-        price: Price::new(10_000),
-        quantity: Quantity::new(500),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(1_000_000),
-        time_in_force: TimeInForce::Gtc,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::Standard {
+            id: Id::from_u64(1),
+            price: Price::new(10_000),
+            quantity: Quantity::new(500),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_000_000),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
-    level.add_order(OrderType::IcebergOrder {
-        id: Id::from_u64(2),
-        price: Price::new(10_000),
-        visible_quantity: Quantity::new(100),
-        hidden_quantity: Quantity::new(400),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(1_000_001),
-        time_in_force: TimeInForce::Gtc,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::IcebergOrder {
+            id: Id::from_u64(2),
+            price: Price::new(10_000),
+            visible_quantity: Quantity::new(100),
+            hidden_quantity: Quantity::new(400),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_000_001),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     let total = level
         .total_quantity()
@@ -73,16 +77,18 @@ fn test_executed_quantity_and_value(id_gen: &UuidGenerator) {
     let level = PriceLevel::new(5_000);
 
     for i in 1..=3_u64 {
-        level.add_order(OrderType::Standard {
-            id: Id::from_u64(i),
-            price: Price::new(5_000),
-            quantity: Quantity::new(100),
-            side: Side::Buy,
-            user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(1_000_000 + i),
-            time_in_force: TimeInForce::Gtc,
-            extra_fields: (),
-        });
+        level
+            .add_order(OrderType::Standard {
+                id: Id::from_u64(i),
+                price: Price::new(5_000),
+                quantity: Quantity::new(100),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_000_000 + i),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
     }
 
     let result = level.match_order(
@@ -130,16 +136,18 @@ fn test_average_price(id_gen: &UuidGenerator) {
     println!("[average_price] Computation...");
 
     let level = PriceLevel::new(7_500);
-    level.add_order(OrderType::Standard {
-        id: Id::from_u64(50),
-        price: Price::new(7_500),
-        quantity: Quantity::new(200),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(2_000_000),
-        time_in_force: TimeInForce::Gtc,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::Standard {
+            id: Id::from_u64(50),
+            price: Price::new(7_500),
+            quantity: Quantity::new(200),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(2_000_000),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     let result = level.match_order(
         100,
@@ -246,16 +254,18 @@ fn test_match_result_display_fromstr(id_gen: &UuidGenerator) {
     println!("[MatchResult] Display/FromStr with checked fields...");
 
     let level = PriceLevel::new(3_000);
-    level.add_order(OrderType::Standard {
-        id: Id::from_u64(77),
-        price: Price::new(3_000),
-        quantity: Quantity::new(50),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(3_000_000),
-        time_in_force: TimeInForce::Gtc,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::Standard {
+            id: Id::from_u64(77),
+            price: Price::new(3_000),
+            quantity: Quantity::new(50),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(3_000_000),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     let result = level.match_order(
         30,

--- a/examples/src/bin/integration_snapshot_recovery.rs
+++ b/examples/src/bin/integration_snapshot_recovery.rs
@@ -22,48 +22,54 @@ fn main() {
 
     // Standard orders
     for i in 1..=5_u64 {
-        original.add_order(OrderType::Standard {
-            id: Id::from_u64(i),
+        original
+            .add_order(OrderType::Standard {
+                id: Id::from_u64(i),
+                price: Price::new(10_000),
+                quantity: Quantity::new(100),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(ts),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
+        ts += 1;
+    }
+
+    // Iceberg order
+    original
+        .add_order(OrderType::IcebergOrder {
+            id: Id::from_u64(10),
             price: Price::new(10_000),
-            quantity: Quantity::new(100),
+            visible_quantity: Quantity::new(20),
+            hidden_quantity: Quantity::new(80),
             side: Side::Buy,
             user_id: Hash32::zero(),
             timestamp: TimestampMs::new(ts),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
-        });
-        ts += 1;
-    }
-
-    // Iceberg order
-    original.add_order(OrderType::IcebergOrder {
-        id: Id::from_u64(10),
-        price: Price::new(10_000),
-        visible_quantity: Quantity::new(20),
-        hidden_quantity: Quantity::new(80),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(ts),
-        time_in_force: TimeInForce::Gtc,
-        extra_fields: (),
-    });
+        })
+        .expect("add_order should succeed");
     ts += 1;
 
     // Reserve order
-    original.add_order(OrderType::ReserveOrder {
-        id: Id::from_u64(11),
-        price: Price::new(10_000),
-        visible_quantity: Quantity::new(15),
-        hidden_quantity: Quantity::new(60),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(ts),
-        time_in_force: TimeInForce::Gtc,
-        replenish_threshold: Quantity::new(5),
-        replenish_amount: NonZeroU64::new(10),
-        auto_replenish: true,
-        extra_fields: (),
-    });
+    original
+        .add_order(OrderType::ReserveOrder {
+            id: Id::from_u64(11),
+            price: Price::new(10_000),
+            visible_quantity: Quantity::new(15),
+            hidden_quantity: Quantity::new(60),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(ts),
+            time_in_force: TimeInForce::Gtc,
+            replenish_threshold: Quantity::new(5),
+            replenish_amount: NonZeroU64::new(10),
+            auto_replenish: true,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     let orig_order_count = original.order_count();
     let orig_visible = original.visible_quantity();

--- a/examples/src/bin/integration_special_orders.rs
+++ b/examples/src/bin/integration_special_orders.rs
@@ -34,17 +34,19 @@ fn test_iceberg_order(id_gen: &UuidGenerator) {
     println!("[Iceberg] Visible/hidden quantity tracking...");
     let level = PriceLevel::new(10_000);
 
-    level.add_order(OrderType::IcebergOrder {
-        id: Id::from_u64(1),
-        price: Price::new(10_000),
-        visible_quantity: Quantity::new(10),
-        hidden_quantity: Quantity::new(90),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(1_000_000),
-        time_in_force: TimeInForce::Gtc,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::IcebergOrder {
+            id: Id::from_u64(1),
+            price: Price::new(10_000),
+            visible_quantity: Quantity::new(10),
+            hidden_quantity: Quantity::new(90),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_000_000),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     assert_eq_or_exit(level.visible_quantity(), 10, "iceberg visible_qty");
     assert_eq_or_exit(level.hidden_quantity(), 90, "iceberg hidden_qty");
@@ -81,20 +83,22 @@ fn test_reserve_order(id_gen: &UuidGenerator) {
     println!("[Reserve] Auto-replenish behavior...");
     let level = PriceLevel::new(10_000);
 
-    level.add_order(OrderType::ReserveOrder {
-        id: Id::from_u64(2),
-        price: Price::new(10_000),
-        visible_quantity: Quantity::new(10),
-        hidden_quantity: Quantity::new(50),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(1_000_001),
-        time_in_force: TimeInForce::Gtc,
-        replenish_threshold: Quantity::new(2),
-        replenish_amount: NonZeroU64::new(10),
-        auto_replenish: true,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::ReserveOrder {
+            id: Id::from_u64(2),
+            price: Price::new(10_000),
+            visible_quantity: Quantity::new(10),
+            hidden_quantity: Quantity::new(50),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_000_001),
+            time_in_force: TimeInForce::Gtc,
+            replenish_threshold: Quantity::new(2),
+            replenish_amount: NonZeroU64::new(10),
+            auto_replenish: true,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     assert_eq_or_exit(level.visible_quantity(), 10, "reserve visible_qty");
     assert_eq_or_exit(level.hidden_quantity(), 50, "reserve hidden_qty");
@@ -134,16 +138,18 @@ fn test_post_only_order(id_gen: &UuidGenerator) {
     println!("[PostOnly] Add and match behavior...");
     let level = PriceLevel::new(10_000);
 
-    level.add_order(OrderType::PostOnly {
-        id: Id::from_u64(3),
-        price: Price::new(10_000),
-        quantity: Quantity::new(50),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(1_000_002),
-        time_in_force: TimeInForce::Gtc,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::PostOnly {
+            id: Id::from_u64(3),
+            price: Price::new(10_000),
+            quantity: Quantity::new(50),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_000_002),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     assert_eq_or_exit(level.visible_quantity(), 50, "postonly visible_qty");
     assert_eq_or_exit(level.order_count(), 1, "postonly order_count");
@@ -181,18 +187,20 @@ fn test_trailing_stop_order(id_gen: &UuidGenerator) {
     println!("[TrailingStop] Add and match behavior...");
     let level = PriceLevel::new(10_000);
 
-    level.add_order(OrderType::TrailingStop {
-        id: Id::from_u64(4),
-        price: Price::new(10_000),
-        quantity: Quantity::new(30),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(1_000_003),
-        time_in_force: TimeInForce::Gtc,
-        trail_amount: Quantity::new(100),
-        last_reference_price: Price::new(10_100),
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::TrailingStop {
+            id: Id::from_u64(4),
+            price: Price::new(10_000),
+            quantity: Quantity::new(30),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_000_003),
+            time_in_force: TimeInForce::Gtc,
+            trail_amount: Quantity::new(100),
+            last_reference_price: Price::new(10_100),
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     assert_eq_or_exit(level.visible_quantity(), 30, "trailing visible_qty");
 
@@ -221,18 +229,20 @@ fn test_pegged_order(id_gen: &UuidGenerator) {
     println!("[Pegged] Add and match behavior...");
     let level = PriceLevel::new(10_000);
 
-    level.add_order(OrderType::PeggedOrder {
-        id: Id::from_u64(5),
-        price: Price::new(10_000),
-        quantity: Quantity::new(25),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(1_000_004),
-        time_in_force: TimeInForce::Gtc,
-        reference_price_offset: 50,
-        reference_price_type: PegReferenceType::MidPrice,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::PeggedOrder {
+            id: Id::from_u64(5),
+            price: Price::new(10_000),
+            quantity: Quantity::new(25),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_000_004),
+            time_in_force: TimeInForce::Gtc,
+            reference_price_offset: 50,
+            reference_price_type: PegReferenceType::MidPrice,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     assert_eq_or_exit(level.visible_quantity(), 25, "pegged visible_qty");
 
@@ -261,16 +271,18 @@ fn test_market_to_limit_order(id_gen: &UuidGenerator) {
     println!("[MarketToLimit] Add and match behavior...");
     let level = PriceLevel::new(10_000);
 
-    level.add_order(OrderType::MarketToLimit {
-        id: Id::from_u64(6),
-        price: Price::new(10_000),
-        quantity: Quantity::new(40),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(1_000_005),
-        time_in_force: TimeInForce::Gtc,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::MarketToLimit {
+            id: Id::from_u64(6),
+            price: Price::new(10_000),
+            quantity: Quantity::new(40),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_000_005),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     assert_eq_or_exit(level.visible_quantity(), 40, "m2l visible_qty");
 

--- a/examples/src/bin/integration_trade_roundtrip.rs
+++ b/examples/src/bin/integration_trade_roundtrip.rs
@@ -119,16 +119,18 @@ fn main() {
     println!("[Phase 5] MatchResult from real matching...");
     let price_level = PriceLevel::new(10_000);
     for i in 1..=5_u64 {
-        price_level.add_order(OrderType::Standard {
-            id: Id::from_u64(i),
-            price: Price::new(10_000),
-            quantity: Quantity::new(20),
-            side: Side::Buy,
-            user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(1_616_823_000_000 + i),
-            time_in_force: TimeInForce::Gtc,
-            extra_fields: (),
-        });
+        price_level
+            .add_order(OrderType::Standard {
+                id: Id::from_u64(i),
+                price: Price::new(10_000),
+                quantity: Quantity::new(20),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_616_823_000_000 + i),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
     }
 
     let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8")

--- a/examples/src/bin/simple.rs
+++ b/examples/src/bin/simple.rs
@@ -54,7 +54,9 @@ fn main() {
                     for i in 0..50 {
                         let order_id = thread_id as u64 * 1000 + i;
                         let order = create_order(thread_id, order_id);
-                        thread_price_level.add_order(order);
+                        thread_price_level
+                            .add_order(order)
+                            .expect("add_order should succeed");
 
                         // Simulate some work
                         thread::sleep(Duration::from_millis(1));
@@ -214,7 +216,9 @@ fn setup_initial_orders(price_level: &PriceLevel) {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     // Add some iceberg orders
@@ -230,7 +234,9 @@ fn setup_initial_orders(price_level: &PriceLevel) {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     // Add some reserve orders
@@ -249,7 +255,9 @@ fn setup_initial_orders(price_level: &PriceLevel) {
             auto_replenish: true,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 }
 

--- a/proptest-regressions/execution/tests/match_result_trade.txt
+++ b/proptest-regressions/execution/tests/match_result_trade.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc aaa41fddbf5e75d79d032b57bc13007e018e83d685792480a4d253415666852e # shrinks to initial = 467, specs = [(20, 1, false), (31, 1, true), (31, 1, true)]

--- a/src/execution/match_result.rs
+++ b/src/execution/match_result.rs
@@ -71,7 +71,19 @@ impl MatchOutcome {
 /// Fields are private to enforce invariant consistency between
 /// `remaining_quantity`, `is_complete`, and `trades`.
 /// Use the provided accessor methods and mutation helpers.
+///
+/// # Decode-time validation
+///
+/// The Rust API keeps the fields mutually consistent, but a decoder writes
+/// them directly. Both `Deserialize` (via `#[serde(try_from)]` through a
+/// private wire struct) and [`FromStr`] therefore route the reconstructed
+/// value through a single private validator, which rejects any payload that
+/// breaks the invariants a public-API-built result always upholds. Every
+/// payload a valid `MatchResult` can produce still decodes unchanged; only
+/// self-contradictory input is rejected — as a serde error or a
+/// [`PriceLevelError`], never a panic.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "MatchResultWire")]
 pub struct MatchResult {
     /// The ID of the incoming order that initiated the match
     order_id: Id,
@@ -89,13 +101,44 @@ pub struct MatchResult {
     filled_order_ids: Vec<Id>,
 
     /// Terminal classification of the match (filled / killed / rejected / ...).
-    ///
-    /// `#[serde(default)]` keeps snapshots produced before this field was added
-    /// deserializable: an older JSON payload restores as
-    /// [`MatchOutcome::NotFilled`] and is corrected by the accessors derived
-    /// from the other fields where it matters.
+    outcome: MatchOutcome,
+}
+
+/// Wire form of [`MatchResult`] used for validated deserialization.
+///
+/// It mirrors `MatchResult`'s serialized shape field-for-field (identical
+/// names, so every previously-valid payload still decodes) but performs no
+/// validation itself: `#[serde(try_from = "MatchResultWire")]` on
+/// `MatchResult` deserializes this permissive struct and then runs
+/// [`MatchResult::validated`] via the [`TryFrom`] impl below. The `outcome`
+/// field keeps `#[serde(default)]` so a payload written before that field
+/// existed decodes as [`MatchOutcome::NotFilled`] (the legacy default), as
+/// before.
+#[derive(Deserialize)]
+struct MatchResultWire {
+    order_id: Id,
+    trades: TradeList,
+    remaining_quantity: u64,
+    is_complete: bool,
+    filled_order_ids: Vec<Id>,
     #[serde(default)]
     outcome: MatchOutcome,
+}
+
+impl TryFrom<MatchResultWire> for MatchResult {
+    type Error = PriceLevelError;
+
+    fn try_from(wire: MatchResultWire) -> Result<Self, Self::Error> {
+        MatchResult {
+            order_id: wire.order_id,
+            trades: wire.trades,
+            remaining_quantity: wire.remaining_quantity,
+            is_complete: wire.is_complete,
+            filled_order_ids: wire.filled_order_ids,
+            outcome: wire.outcome,
+        }
+        .validated()
+    }
 }
 
 impl MatchResult {
@@ -353,6 +396,97 @@ impl MatchResult {
             Ok(Some(self.executed_value()? as f64 / executed_qty as f64))
         }
     }
+
+    /// Consumes `self`, returning it only if it satisfies the invariants a
+    /// public-API-built [`MatchResult`] always upholds — the single validation
+    /// gate both decoders ([`FromStr`] and `Deserialize` via
+    /// [`MatchResultWire`]) route through, so a decoder can never mint a
+    /// self-contradictory value that the private-field Rust API forbids.
+    ///
+    /// The checks mirror exactly what the constructors / mutators
+    /// ([`Self::new`], [`Self::add_trade`], [`Self::finalize`],
+    /// [`Self::mark_killed`], [`Self::mark_rejected`]) and the matching engine
+    /// guarantee — no stricter:
+    ///
+    /// 1. **Completion agrees with the remainder:** `is_complete` is `true` iff
+    ///    `remaining_quantity == 0`.
+    /// 2. **Executed quantity is representable:** the checked sum of the trade
+    ///    quantities does not overflow `u64`, and that sum plus the remaining
+    ///    quantity (the implied initial taker quantity, itself a `u64`) does not
+    ///    overflow either.
+    /// 3. **A killed / rejected result carries nothing:** a
+    ///    [`MatchOutcome::Killed`] or [`MatchOutcome::Rejected`] outcome — both
+    ///    decided before any sweep — has no trades and no filled order ids, as
+    ///    [`Self::mark_killed`] / [`Self::mark_rejected`] enforce.
+    /// 4. **Filled ids are backed by trades:** every id in `filled_order_ids`
+    ///    appears as a `maker_order_id` of some trade, because the engine only
+    ///    records a filled id for a maker it just traded against
+    ///    (`PriceLevel::match_order`). The reverse does not hold — a partially
+    ///    filled maker trades without being recorded as filled — so this is a
+    ///    one-directional subset check, not equality.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] describing the first
+    /// invariant the value violates.
+    fn validated(self) -> Result<Self, PriceLevelError> {
+        // 1. Completion agrees with the remainder.
+        if self.is_complete != (self.remaining_quantity == 0) {
+            return Err(PriceLevelError::InvalidOperation {
+                message: format!(
+                    "is_complete ({}) disagrees with remaining_quantity ({})",
+                    self.is_complete, self.remaining_quantity
+                ),
+            });
+        }
+
+        // 2. Executed quantity is representable, and so is the implied initial
+        //    taker quantity (executed + remaining). `executed_quantity` already
+        //    returns a checked-sum error on overflow.
+        let executed = self.executed_quantity()?.as_u64();
+        if executed.checked_add(self.remaining_quantity).is_none() {
+            return Err(PriceLevelError::InvalidOperation {
+                message: format!(
+                    "executed quantity ({executed}) plus remaining_quantity ({}) overflows u64",
+                    self.remaining_quantity
+                ),
+            });
+        }
+
+        // 3. A killed / rejected result carries no trades and no filled ids.
+        if matches!(self.outcome, MatchOutcome::Killed | MatchOutcome::Rejected)
+            && (!self.trades.is_empty() || !self.filled_order_ids.is_empty())
+        {
+            return Err(PriceLevelError::InvalidOperation {
+                message: format!(
+                    "{:?} outcome must carry no trades and no filled_order_ids \
+                     (found {} trade(s), {} filled id(s))",
+                    self.outcome,
+                    self.trades.len(),
+                    self.filled_order_ids.len()
+                ),
+            });
+        }
+
+        // 4. Every filled id is backed by a trade whose maker it is.
+        if !self.filled_order_ids.is_empty() {
+            let makers: std::collections::HashSet<Id> = self
+                .trades
+                .as_vec()
+                .iter()
+                .map(|trade| trade.maker_order_id())
+                .collect();
+            if let Some(missing) = self.filled_order_ids.iter().find(|id| !makers.contains(id)) {
+                return Err(PriceLevelError::InvalidOperation {
+                    message: format!(
+                        "filled order id {missing} does not appear as a maker in any trade"
+                    ),
+                });
+            }
+        }
+
+        Ok(self)
+    }
 }
 
 impl fmt::Display for MatchResult {
@@ -536,8 +670,14 @@ impl FromStr for MatchResult {
                         Some(s.get(pos..=i).ok_or(PriceLevelError::InvalidFormat)?);
 
                     pos = i + 1;
+                    // Symmetric with the `trades` branch: after the closing `]`
+                    // the only thing allowed is a `;` field separator or the end
+                    // of the string. Any other trailing content is malformed and
+                    // rejected rather than silently ignored.
                     if bytes.get(pos) == Some(&b';') {
                         pos += 1;
+                    } else if pos < bytes.len() {
+                        return Err(PriceLevelError::InvalidFormat);
                     }
                 }
                 _ => return Err(PriceLevelError::InvalidFormat),
@@ -612,13 +752,19 @@ impl FromStr for MatchResult {
             MatchOutcome::PartiallyFilled
         };
 
-        Ok(MatchResult {
+        // Route the structurally-parsed value through the same invariant gate
+        // as `Deserialize`, so text input that is well-formed but
+        // self-contradictory (e.g. `is_complete=true` with a positive
+        // remainder, trade quantities that overflow, or a filled id absent from
+        // the trades) is rejected rather than accepted.
+        MatchResult {
             order_id,
             trades,
             remaining_quantity,
             is_complete,
             filled_order_ids,
             outcome,
-        })
+        }
+        .validated()
     }
 }

--- a/src/execution/match_result.rs
+++ b/src/execution/match_result.rs
@@ -110,10 +110,7 @@ pub struct MatchResult {
 /// names, so every previously-valid payload still decodes) but performs no
 /// validation itself: `#[serde(try_from = "MatchResultWire")]` on
 /// `MatchResult` deserializes this permissive struct and then runs
-/// [`MatchResult::validated`] via the [`TryFrom`] impl below. The `outcome`
-/// field keeps `#[serde(default)]` so a payload written before that field
-/// existed decodes as [`MatchOutcome::NotFilled`] (the legacy default), as
-/// before.
+/// [`MatchResult::validated`] via the [`TryFrom`] impl below.
 #[derive(Deserialize)]
 struct MatchResultWire {
     order_id: Id,
@@ -121,21 +118,40 @@ struct MatchResultWire {
     remaining_quantity: u64,
     is_complete: bool,
     filled_order_ids: Vec<Id>,
+    /// Decoded as an `Option` so a legacy payload written before the field
+    /// existed (key absent → `None`) is told apart from an explicit outcome.
+    /// An absent outcome is *derived* from the other fields — the legacy
+    /// behavior — while an explicit one is validated against them, so a
+    /// payload can no longer claim `Filled` with a positive remainder or
+    /// `PartiallyFilled` without trades.
     #[serde(default)]
-    outcome: MatchOutcome,
+    outcome: Option<MatchOutcome>,
 }
 
 impl TryFrom<MatchResultWire> for MatchResult {
     type Error = PriceLevelError;
 
     fn try_from(wire: MatchResultWire) -> Result<Self, Self::Error> {
+        let outcome = wire.outcome.unwrap_or({
+            // Legacy payload (no outcome key): re-derive the benign
+            // classification exactly as the pre-outcome accessors did. A
+            // killed / rejected outcome cannot be recovered — it is
+            // indistinguishable from NotFilled once the trades are gone.
+            if wire.remaining_quantity == 0 {
+                MatchOutcome::Filled
+            } else if wire.trades.is_empty() {
+                MatchOutcome::NotFilled
+            } else {
+                MatchOutcome::PartiallyFilled
+            }
+        });
         MatchResult {
             order_id: wire.order_id,
             trades: wire.trades,
             remaining_quantity: wire.remaining_quantity,
             is_complete: wire.is_complete,
             filled_order_ids: wire.filled_order_ids,
-            outcome: wire.outcome,
+            outcome,
         }
         .validated()
     }
@@ -198,8 +214,19 @@ impl MatchResult {
     ///
     /// Returns [`PriceLevelError::InvalidOperation`] if the trade's quantity
     /// exceeds the remaining quantity of the incoming order (the subtraction
-    /// would underflow), which indicates an over-fill bug in the caller.
+    /// would underflow), which indicates an over-fill bug in the caller, or if
+    /// the trade's taker order id differs from this result's incoming order id
+    /// (a trade can only belong to the taker that initiated the match).
     pub fn add_trade(&mut self, trade: Trade) -> Result<(), PriceLevelError> {
+        if trade.taker_order_id() != self.order_id {
+            return Err(PriceLevelError::InvalidOperation {
+                message: format!(
+                    "trade taker order id {} does not match the result's incoming order id {}",
+                    trade.taker_order_id(),
+                    self.order_id
+                ),
+            });
+        }
         self.remaining_quantity = self
             .remaining_quantity
             .checked_sub(trade.quantity().as_u64())
@@ -453,35 +480,82 @@ impl MatchResult {
             });
         }
 
-        // 3. A killed / rejected result carries no trades and no filled ids.
-        if matches!(self.outcome, MatchOutcome::Killed | MatchOutcome::Rejected)
-            && (!self.trades.is_empty() || !self.filled_order_ids.is_empty())
-        {
+        // 3. The explicit outcome agrees with the fields it classifies. Every
+        //    public constructor / mutator keeps them in lockstep, so a decoded
+        //    value must too (a legacy payload without an outcome key has it
+        //    DERIVED from these same fields before this check, so it always
+        //    passes here).
+        let outcome_consistent = match self.outcome {
+            // Vacuously-complete results (zero-quantity taker) are Filled with
+            // no trades, so Filled constrains only the remainder.
+            MatchOutcome::Filled => self.remaining_quantity == 0,
+            MatchOutcome::PartiallyFilled => self.remaining_quantity > 0 && !self.trades.is_empty(),
+            MatchOutcome::NotFilled => self.remaining_quantity > 0 && self.trades.is_empty(),
+            // Killed / rejected takers were turned away whole: quantity
+            // remains, and no trade or filled id was ever recorded.
+            MatchOutcome::Killed | MatchOutcome::Rejected => {
+                self.remaining_quantity > 0
+                    && self.trades.is_empty()
+                    && self.filled_order_ids.is_empty()
+            }
+        };
+        if !outcome_consistent {
             return Err(PriceLevelError::InvalidOperation {
                 message: format!(
-                    "{:?} outcome must carry no trades and no filled_order_ids \
-                     (found {} trade(s), {} filled id(s))",
+                    "{:?} outcome contradicts the decoded fields \
+                     (remaining_quantity {}, {} trade(s), {} filled id(s))",
                     self.outcome,
+                    self.remaining_quantity,
                     self.trades.len(),
                     self.filled_order_ids.len()
                 ),
             });
         }
 
-        // 4. Every filled id is backed by a trade whose maker it is.
+        // 4. Every trade belongs to this result's incoming (taker) order —
+        //    mirrored by the same guard in `add_trade`, so decoded and
+        //    API-built values stay aligned.
+        if let Some(alien) = self
+            .trades
+            .as_vec()
+            .iter()
+            .find(|trade| trade.taker_order_id() != self.order_id)
+        {
+            return Err(PriceLevelError::InvalidOperation {
+                message: format!(
+                    "trade taker order id {} does not match the result's incoming order id {}",
+                    alien.taker_order_id(),
+                    self.order_id
+                ),
+            });
+        }
+
+        // 5. The filled ids are a duplicate-free, order-preserving subsequence
+        //    of the trade maker ids: `match_order` records each fully-consumed
+        //    maker exactly once, immediately after its final trade, so trade
+        //    order and filled-id order agree. The `any` on the shared iterator
+        //    advances it past each match, which is exactly subsequence
+        //    semantics (and implies plain membership).
         if !self.filled_order_ids.is_empty() {
-            let makers: std::collections::HashSet<Id> = self
+            let mut seen = std::collections::HashSet::with_capacity(self.filled_order_ids.len());
+            let mut makers = self
                 .trades
                 .as_vec()
                 .iter()
-                .map(|trade| trade.maker_order_id())
-                .collect();
-            if let Some(missing) = self.filled_order_ids.iter().find(|id| !makers.contains(id)) {
-                return Err(PriceLevelError::InvalidOperation {
-                    message: format!(
-                        "filled order id {missing} does not appear as a maker in any trade"
-                    ),
-                });
+                .map(|trade| trade.maker_order_id());
+            for filled in &self.filled_order_ids {
+                if !seen.insert(*filled) {
+                    return Err(PriceLevelError::InvalidOperation {
+                        message: format!("filled order id {filled} appears more than once"),
+                    });
+                }
+                if !makers.by_ref().any(|maker| maker == *filled) {
+                    return Err(PriceLevelError::InvalidOperation {
+                        message: format!(
+                            "filled order id {filled} is not an in-order maker of the trades"
+                        ),
+                    });
+                }
             }
         }
 

--- a/src/execution/tests/match_result_trade.rs
+++ b/src/execution/tests/match_result_trade.rs
@@ -638,6 +638,106 @@ mod tests {
         }
     }
 
+    /// An explicit outcome that contradicts the decoded fields is rejected:
+    /// `Filled` with a positive remainder, `PartiallyFilled` with a zero
+    /// remainder or without trades, `NotFilled` with trades, and a complete
+    /// (zero-remainder) `Killed` / `Rejected`.
+    #[test]
+    fn deserialize_rejects_contradictory_explicit_outcome() {
+        let mut partial = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(partial.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+        let empty = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        let complete = MatchResult::new(Id::from_u64(10), Quantity::new(0));
+
+        // Filled with a positive remainder.
+        let json = mutated_json(&partial, |v| {
+            v["outcome"] = serde_json::json!("filled");
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+        // PartiallyFilled with zero remainder / no trades.
+        let json = mutated_json(&complete, |v| {
+            v["outcome"] = serde_json::json!("partially_filled");
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+        let json = mutated_json(&empty, |v| {
+            v["outcome"] = serde_json::json!("partially_filled");
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+        // NotFilled with trades present.
+        let json = mutated_json(&partial, |v| {
+            v["outcome"] = serde_json::json!("not_filled");
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+        // A complete, empty Killed / Rejected (turned-away takers keep their
+        // full quantity).
+        for outcome in ["killed", "rejected"] {
+            let json = mutated_json(&complete, |v| {
+                v["outcome"] = serde_json::json!(outcome);
+            });
+            assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+        }
+    }
+
+    /// A legacy payload without an outcome key derives the benign
+    /// classification from the other fields instead of being rejected.
+    #[test]
+    fn deserialize_legacy_payload_without_outcome_derives() {
+        let mut partial = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(partial.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+        let json = mutated_json(&partial, |v| {
+            if let Some(obj) = v.as_object_mut() {
+                obj.remove("outcome");
+            }
+        });
+        let decoded = match serde_json::from_str::<MatchResult>(&json) {
+            Ok(decoded) => decoded,
+            Err(err) => panic!("legacy payload must decode: {err}"),
+        };
+        assert_eq!(decoded.outcome(), MatchOutcome::PartiallyFilled);
+    }
+
+    /// A trade whose taker order id differs from the result's incoming order id
+    /// is rejected at decode time and by `add_trade`.
+    #[test]
+    fn taker_identity_enforced_on_decode_and_add_trade() {
+        let mut base = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(base.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+
+        let json = mutated_json(&base, |v| {
+            v["order_id"] = serde_json::json!(Id::from_u64(999));
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+
+        // add_trade mirrors the guard: sample trades carry taker id 10.
+        let mut mismatched = MatchResult::new(Id::from_u64(999), Quantity::new(100));
+        assert!(
+            mismatched
+                .add_trade(sample_trade_with_maker(20, 40))
+                .is_err()
+        );
+    }
+
+    /// Duplicate or out-of-order filled ids are rejected: the engine records
+    /// each fully-consumed maker exactly once, in trade order.
+    #[test]
+    fn deserialize_rejects_duplicate_or_out_of_order_filled_ids() {
+        let mut base = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(base.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+        assert!(base.add_trade(sample_trade_with_maker(21, 60)).is_ok());
+        base.add_filled_order_id(Id::from_u64(20));
+        base.add_filled_order_id(Id::from_u64(21));
+
+        let json = mutated_json(&base, |v| {
+            v["filled_order_ids"] = serde_json::json!([Id::from_u64(20), Id::from_u64(20)]);
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+
+        let json = mutated_json(&base, |v| {
+            v["filled_order_ids"] = serde_json::json!([Id::from_u64(21), Id::from_u64(20)]);
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+    }
+
     /// Build a valid `MatchResult` purely through the public API from a seed, so
     /// every invariant `validated` checks holds by construction: `add_trade`
     /// keeps `is_complete` / `remaining` / `outcome` in lockstep, and each
@@ -645,6 +745,10 @@ mod tests {
     fn build_valid_result(initial: u64, specs: &[(u64, u64, bool)]) -> MatchResult {
         let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(initial));
         let mut remaining = initial;
+        // A fully-consumed maker is recorded in filled_order_ids exactly once
+        // (the engine removes it from the queue), so the generator must not
+        // fill the same maker twice — the validator rejects duplicates.
+        let mut filled = std::collections::HashSet::new();
         for &(maker, raw_qty, fill) in specs {
             if remaining == 0 {
                 break;
@@ -656,7 +760,7 @@ mod tests {
                 .is_ok()
             {
                 remaining -= qty;
-                if fill {
+                if fill && filled.insert(maker) {
                     result.add_filled_order_id(Id::from_u64(maker));
                 }
             }

--- a/src/execution/tests/match_result_trade.rs
+++ b/src/execution/tests/match_result_trade.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod tests {
+    use crate::execution::list::TradeList;
     use crate::execution::match_result::{MatchOutcome, MatchResult};
     use crate::execution::trade::Trade;
     use crate::orders::{Id, Side};
@@ -15,10 +16,14 @@ mod tests {
     }
 
     fn sample_trade(quantity: u64) -> Trade {
+        sample_trade_with_maker(20, quantity)
+    }
+
+    fn sample_trade_with_maker(maker_id: u64, quantity: u64) -> Trade {
         Trade::with_timestamp(
             Id::from_uuid(parse_uuid("6ba7b810-9dad-11d1-80b4-00c04fd430c8")),
             Id::from_u64(10),
-            Id::from_u64(20),
+            Id::from_u64(maker_id),
             Price::new(1_000),
             Quantity::new(quantity),
             Side::Buy,
@@ -358,9 +363,11 @@ mod tests {
     /// unchanged through `FromStr`.
     #[test]
     fn display_round_trips_with_filled_ids_and_trades() {
+        // Two makers (20 and 21) each fully consumed, so each is both a trade
+        // maker and a filled id — the shape the engine actually produces.
         let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(100));
-        assert!(result.add_trade(sample_trade(30)).is_ok());
-        assert!(result.add_trade(sample_trade(20)).is_ok());
+        assert!(result.add_trade(sample_trade_with_maker(20, 30)).is_ok());
+        assert!(result.add_trade(sample_trade_with_maker(21, 20)).is_ok());
         result.add_filled_order_id(Id::from_u64(20));
         result.add_filled_order_id(Id::from_u64(21));
 
@@ -380,6 +387,203 @@ mod tests {
         );
         // Rendering the parsed result reproduces the exact canonical text.
         assert_eq!(parsed.to_string(), rendered);
+    }
+
+    // ----- issue #116: invariants enforced during decoding -----
+    //
+    // Private fields protect Rust-API construction, but `Deserialize` and
+    // `FromStr` reconstruct fields directly. Both now route through
+    // `MatchResult::validated`, so a self-contradictory payload is rejected
+    // (serde error / `PriceLevelError`) instead of minting an impossible value.
+    // Every payload a public-API-built result can produce still decodes.
+
+    /// A valid `MatchResult` carrying trades and filled ids round-trips through
+    /// serde JSON with all fields (including `outcome`) intact.
+    #[test]
+    fn valid_result_with_filled_ids_round_trips_serde_json() {
+        let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(result.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+        result.add_filled_order_id(Id::from_u64(20));
+
+        let json = serde_json::to_string(&result).expect("serialize");
+        let parsed: MatchResult = serde_json::from_str(&json).expect("valid payload must decode");
+
+        assert_eq!(parsed.order_id(), Id::from_u64(10));
+        assert_eq!(parsed.remaining_quantity().as_u64(), 60);
+        assert!(!parsed.is_complete());
+        assert_eq!(parsed.outcome(), MatchOutcome::PartiallyFilled);
+        assert_eq!(parsed.trades().len(), 1);
+        assert_eq!(parsed.filled_order_ids(), &[Id::from_u64(20)]);
+    }
+
+    /// A genuinely killed / rejected result (no trades, no filled ids) still
+    /// decodes — the outcome invariant only forbids a *populated* kill/reject.
+    #[test]
+    fn valid_killed_and_rejected_round_trip_serde_json() {
+        for build in [
+            MatchResult::mark_killed as fn(&mut MatchResult, u64),
+            MatchResult::mark_rejected,
+        ] {
+            let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+            build(&mut result, 100);
+
+            let json = serde_json::to_string(&result).expect("serialize");
+            let parsed: MatchResult =
+                serde_json::from_str(&json).expect("empty kill/reject must decode");
+
+            assert_eq!(parsed.remaining_quantity().as_u64(), 100);
+            assert!(!parsed.is_complete());
+            assert!(parsed.trades().is_empty());
+            assert!(parsed.filled_order_ids().is_empty());
+            assert!(parsed.was_killed() || parsed.was_rejected());
+        }
+    }
+
+    /// Helper: serialize a valid result, mutate the JSON object, and return the
+    /// mutated JSON string so a negative test can feed it back to `from_str`.
+    fn mutated_json(base: &MatchResult, mutate: impl FnOnce(&mut serde_json::Value)) -> String {
+        let mut value = serde_json::to_value(base).expect("serialize base");
+        mutate(&mut value);
+        serde_json::to_string(&value).expect("re-serialize mutated payload")
+    }
+
+    /// Invariant 1: `is_complete == true` with a positive remainder is rejected.
+    #[test]
+    fn deserialize_rejects_complete_with_remainder() {
+        // new(0) is complete with remainder 0; force a positive remainder.
+        let base = MatchResult::new(Id::from_u64(10), Quantity::new(0));
+        let json = mutated_json(&base, |v| {
+            v["remaining_quantity"] = serde_json::json!(5);
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+    }
+
+    /// Invariant 3: a `Rejected` / `Killed` outcome may not carry trades.
+    #[test]
+    fn deserialize_rejects_trades_on_killed_or_rejected() {
+        let mut base = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(base.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+
+        for outcome in ["killed", "rejected"] {
+            let json = mutated_json(&base, |v| {
+                v["outcome"] = serde_json::json!(outcome);
+            });
+            assert!(
+                serde_json::from_str::<MatchResult>(&json).is_err(),
+                "{outcome} with trades must be rejected"
+            );
+        }
+    }
+
+    /// Invariant 3 (filled ids variant): a `Killed` outcome may not carry
+    /// filled order ids either.
+    #[test]
+    fn deserialize_rejects_filled_ids_on_killed() {
+        let mut base = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        base.mark_killed(100);
+        let json = mutated_json(&base, |v| {
+            // Killed carries no trades; inject a filled id with no backing trade.
+            v["filled_order_ids"] = serde_json::json!(["20"]);
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+    }
+
+    /// Invariant 2: trade quantities whose sum overflows `u64` are rejected.
+    #[test]
+    fn deserialize_rejects_executed_quantity_sum_overflow() {
+        let mut base = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(base.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+        assert!(base.add_trade(sample_trade_with_maker(21, 20)).is_ok());
+        // Two trades each at u64::MAX overflow the checked sum.
+        let json = mutated_json(&base, |v| {
+            v["trades"]["trades"][0]["quantity"] = serde_json::json!(u64::MAX);
+            v["trades"]["trades"][1]["quantity"] = serde_json::json!(u64::MAX);
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+    }
+
+    /// Invariant 2 (implied initial): executed quantity + remaining overflowing
+    /// `u64` (an impossible initial taker quantity) is rejected.
+    #[test]
+    fn deserialize_rejects_executed_plus_remaining_overflow() {
+        let mut base = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(base.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+        let json = mutated_json(&base, |v| {
+            v["trades"]["trades"][0]["quantity"] = serde_json::json!(u64::MAX);
+            // Keep is_complete consistent with a positive remainder.
+            v["remaining_quantity"] = serde_json::json!(5);
+            v["is_complete"] = serde_json::json!(false);
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+    }
+
+    /// Invariant 4: a filled order id with no backing trade maker is rejected.
+    #[test]
+    fn deserialize_rejects_filled_id_absent_from_trades() {
+        let mut base = MatchResult::new(Id::from_u64(10), Quantity::new(100));
+        assert!(base.add_trade(sample_trade_with_maker(20, 40)).is_ok());
+        base.add_filled_order_id(Id::from_u64(20));
+        let json = mutated_json(&base, |v| {
+            // 99 never traded.
+            v["filled_order_ids"] = serde_json::json!(["20", "99"]);
+        });
+        assert!(serde_json::from_str::<MatchResult>(&json).is_err());
+    }
+
+    // ----- issue #116: the same invariants via FromStr -----
+
+    /// `FromStr` rejects a structurally-valid text whose `is_complete` claim
+    /// contradicts the remainder.
+    #[test]
+    fn from_str_rejects_complete_with_remainder() {
+        let text = "MatchResult:order_id=10;remaining_quantity=5;is_complete=true;\
+                    trades=Trades:[];filled_order_ids=[]";
+        assert!(MatchResult::from_str(text).is_err());
+    }
+
+    /// `FromStr` rejects text whose trade quantities sum past `u64::MAX`.
+    #[test]
+    fn from_str_rejects_executed_quantity_sum_overflow() {
+        let trades = TradeList::from_vec(vec![
+            sample_trade_with_maker(20, u64::MAX),
+            sample_trade_with_maker(21, u64::MAX),
+        ]);
+        let text = format!(
+            "MatchResult:order_id=10;remaining_quantity=1;is_complete=false;\
+             trades={trades};filled_order_ids=[]"
+        );
+        assert!(MatchResult::from_str(&text).is_err());
+    }
+
+    /// `FromStr` rejects text listing a filled id that is not a trade maker.
+    #[test]
+    fn from_str_rejects_filled_id_absent_from_trades() {
+        let trades = TradeList::from_vec(vec![sample_trade_with_maker(20, 40)]);
+        let text = format!(
+            "MatchResult:order_id=10;remaining_quantity=60;is_complete=false;\
+             trades={trades};filled_order_ids=[20,99]"
+        );
+        assert!(MatchResult::from_str(&text).is_err());
+    }
+
+    /// Structural tightening (#114 review follow-up): trailing content after the
+    /// `filled_order_ids` closing `]` is now rejected, symmetric with the
+    /// `trades` branch. Previously the `filled_order_ids` branch silently
+    /// tolerated a missing `;` separator and parsed the trailing text as another
+    /// field.
+    #[test]
+    fn from_str_rejects_trailing_content_after_filled_ids() {
+        // A second `order_id=...` glued directly to the closing `]` with no `;`.
+        let text = "MatchResult:order_id=10;remaining_quantity=0;is_complete=true;\
+                    trades=Trades:[];filled_order_ids=[]order_id=10";
+        assert!(
+            MatchResult::from_str(text).is_err(),
+            "trailing content after filled_order_ids ']' must be rejected"
+        );
+        // The canonical form (nothing after the ']') still parses.
+        let ok = "MatchResult:order_id=10;remaining_quantity=0;is_complete=true;\
+                  trades=Trades:[];filled_order_ids=[]";
+        assert!(MatchResult::from_str(ok).is_ok());
     }
 
     // ----- property: from_str never panics on arbitrary UTF-8 -----
@@ -431,6 +635,75 @@ mod tests {
         #[test]
         fn from_str_never_panics_on_structural_fuzz(input in structural_fuzz()) {
             let _ = MatchResult::from_str(&input);
+        }
+    }
+
+    /// Build a valid `MatchResult` purely through the public API from a seed, so
+    /// every invariant `validated` checks holds by construction: `add_trade`
+    /// keeps `is_complete` / `remaining` / `outcome` in lockstep, and each
+    /// filled id is a maker that just traded.
+    fn build_valid_result(initial: u64, specs: &[(u64, u64, bool)]) -> MatchResult {
+        let mut result = MatchResult::new(Id::from_u64(10), Quantity::new(initial));
+        let mut remaining = initial;
+        for &(maker, raw_qty, fill) in specs {
+            if remaining == 0 {
+                break;
+            }
+            // A trade of 1..=remaining keeps add_trade from underflowing.
+            let qty = raw_qty % remaining + 1;
+            if result
+                .add_trade(sample_trade_with_maker(maker, qty))
+                .is_ok()
+            {
+                remaining -= qty;
+                if fill {
+                    result.add_filled_order_id(Id::from_u64(maker));
+                }
+            }
+        }
+        result
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+        /// Any valid result built through the public API round-trips both serde
+        /// JSON (outcome preserved) and Display/FromStr (benign outcome
+        /// re-derived identically) with no field drift — the validator never
+        /// rejects a legitimately-constructed value.
+        #[test]
+        fn valid_result_round_trips_both_encodings(
+            initial in 1u64..=100_000,
+            specs in prop::collection::vec((20u64..=40, 1u64..=100_000, any::<bool>()), 0..12),
+        ) {
+            let original = build_valid_result(initial, &specs);
+
+            // serde JSON must decode and preserve every field, outcome included.
+            let json = serde_json::to_string(&original)
+                .map_err(|e| TestCaseError::fail(format!("serialize: {e}")))?;
+            let decoded: MatchResult = serde_json::from_str(&json)
+                .map_err(|e| TestCaseError::fail(format!("valid json must decode: {e}")))?;
+            prop_assert_eq!(decoded.order_id(), original.order_id());
+            prop_assert_eq!(
+                decoded.remaining_quantity().as_u64(),
+                original.remaining_quantity().as_u64()
+            );
+            prop_assert_eq!(decoded.is_complete(), original.is_complete());
+            prop_assert_eq!(decoded.outcome(), original.outcome());
+            prop_assert_eq!(decoded.trades().len(), original.trades().len());
+            prop_assert_eq!(decoded.filled_order_ids(), original.filled_order_ids());
+
+            // Display / FromStr must reparse and preserve the text-carried fields.
+            let text = original.to_string();
+            let reparsed = MatchResult::from_str(&text)
+                .map_err(|e| TestCaseError::fail(format!("valid text must reparse: {e}")))?;
+            prop_assert_eq!(
+                reparsed.remaining_quantity().as_u64(),
+                original.remaining_quantity().as_u64()
+            );
+            prop_assert_eq!(reparsed.is_complete(), original.is_complete());
+            prop_assert_eq!(reparsed.trades().len(), original.trades().len());
+            prop_assert_eq!(reparsed.filled_order_ids(), original.filled_order_ids());
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,6 +490,21 @@
 //! checksum over an unchanged payload still validates. Existing snapshot JSON
 //! restores without migration.
 //!
+//! ## Migration Guide (`PriceLevel::add_order` is now checked — breaking)
+//!
+//! [`PriceLevel::add_order`] now returns
+//! `Result<Arc<OrderType<()>>, PriceLevelError>` instead of
+//! `Arc<OrderType<()>>`. It reserves the order's visible / hidden quantity and
+//! its count slot on the level's atomic counters (with checked `fetch_update`)
+//! **before** publishing the order to the queue, and returns
+//! [`PriceLevelError::InvalidOperation`] if any counter would overflow `u64` —
+//! leaving the level completely unchanged rather than wrapping a counter while
+//! the queue already holds the admitted order. Callers must handle the
+//! `Result` — propagate with `level.add_order(order)?` (test fixtures and
+//! binaries may prefer `.expect(...)`); the returned `Arc` is unchanged on
+//! success. Admissions that stay within `u64` (all normal use) behave exactly
+//! as before.
+//!
 
 mod orders;
 mod price_level;

--- a/src/orders/order_type.rs
+++ b/src/orders/order_type.rs
@@ -660,6 +660,19 @@ impl<T: Clone> OrderType<T> {
     /// - Optionally, an updated version of this order (if partially filled)
     /// - The quantity that was reduced from hidden portion (for iceberg/reserve orders)
     /// - The remaining quantity of the incoming order
+    ///
+    /// # Overflow
+    ///
+    /// The only quantity *addition* on any match path is a reserve order's
+    /// partial-fill replenishment (`new_visible + replenish_qty`). If that sum
+    /// would overflow `u64` — reachable only for a pathological reserve whose
+    /// visible + hidden already exceeds `u64::MAX` — this returns the
+    /// no-progress sentinel `(0, Some(self.clone()), 0, incoming_quantity)`
+    /// instead of panicking or wrapping. The caller's sweep (and the
+    /// fill-or-kill dry run) already treat that sentinel as "set this maker
+    /// aside", so the step fails atomically: no trade, maker and taker
+    /// unchanged. Every other path uses only subtraction / `min`, which cannot
+    /// overflow.
     #[must_use]
     pub fn match_against(&self, incoming_quantity: u64) -> (u64, Option<Self>, u64, u64) {
         match self {
@@ -853,7 +866,22 @@ impl<T: Clone> OrderType<T> {
                         && hidden_quantity.as_u64() > 0
                         && *auto_replenish
                     {
-                        // Restore from the hidden quantity
+                        // Refreshed visible is `new_visible + replenish_qty`.
+                        // Guard the sum with `checked_add`: a reserve whose
+                        // visible + hidden exceeds `u64::MAX` is admissible (the
+                        // two are separate `u64` components) yet would panic in
+                        // debug / wrap in release here. On overflow make NO
+                        // progress — hand the maker back unchanged with
+                        // `consumed == 0` and `remaining` untouched. That is the
+                        // no-progress sentinel both the real sweep and the
+                        // fill-or-kill dry run already detect and set aside, so
+                        // the match step fails atomically: no trade emitted, and
+                        // maker + taker state preserved. Never a partial or a
+                        // manufactured (wrapped) fill.
+                        let Some(refreshed_visible) = new_visible.checked_add(replenish_qty) else {
+                            return (0, Some(self.clone()), 0, incoming_quantity);
+                        };
+                        // Restore from the hidden quantity.
                         let new_hidden = hidden_quantity.as_u64() - replenish_qty;
 
                         (
@@ -861,7 +889,7 @@ impl<T: Clone> OrderType<T> {
                             Some(Self::ReserveOrder {
                                 id: *id,
                                 price: *price,
-                                visible_quantity: Quantity::new(new_visible + replenish_qty),
+                                visible_quantity: Quantity::new(refreshed_visible),
                                 hidden_quantity: Quantity::new(new_hidden),
                                 side: *side,
                                 user_id: *user_id,

--- a/src/orders/order_type.rs
+++ b/src/orders/order_type.rs
@@ -867,17 +867,22 @@ impl<T: Clone> OrderType<T> {
                         && *auto_replenish
                     {
                         // Refreshed visible is `new_visible + replenish_qty`.
-                        // Guard the sum with `checked_add`: a reserve whose
-                        // visible + hidden exceeds `u64::MAX` is admissible (the
-                        // two are separate `u64` components) yet would panic in
-                        // debug / wrap in release here. On overflow make NO
-                        // progress — hand the maker back unchanged with
-                        // `consumed == 0` and `remaining` untouched. That is the
+                        // This sum is provably `<= u64::MAX` for any order the
+                        // level admits: `new_visible <= visible_quantity`,
+                        // `replenish_qty` is capped by `.min(hidden_quantity)`
+                        // above, and `PriceLevel::add_order` /
+                        // `PriceLevelSnapshot::refresh_aggregates` reject any
+                        // order whose own `visible + hidden` overflows `u64`,
+                        // so `new_visible + replenish_qty <= visible + hidden
+                        // <= u64::MAX`. The `checked_add` is therefore kept as
+                        // defense-in-depth against an unadmitted / internally
+                        // constructed order (e.g. a direct `match_against` unit
+                        // test): on the unreachable overflow it makes NO progress
+                        // — the maker is handed back unchanged with
+                        // `consumed == 0` and `remaining` untouched, the
                         // no-progress sentinel both the real sweep and the
-                        // fill-or-kill dry run already detect and set aside, so
-                        // the match step fails atomically: no trade emitted, and
-                        // maker + taker state preserved. Never a partial or a
-                        // manufactured (wrapped) fill.
+                        // fill-or-kill dry run detect and set aside — never a
+                        // partial or a manufactured (wrapped) fill.
                         let Some(refreshed_visible) = new_visible.checked_add(replenish_qty) else {
                             return (0, Some(self.clone()), 0, incoming_quantity);
                         };

--- a/src/orders/tests/order_type.rs
+++ b/src/orders/tests/order_type.rs
@@ -449,6 +449,56 @@ mod tests {
     }
 
     #[test]
+    fn test_match_against_reserve_replenish_overflow_sentinel_no_progress() {
+        // Defense-in-depth sentinel for a state `PriceLevel::add_order` /
+        // `refresh_aggregates` now REJECT at admission: a reserve whose own
+        // visible + hidden overflows `u64`. Such an order can never rest at a
+        // level, but `match_against` is a pure function that can still be handed
+        // one directly (as here), so it must not panic in debug / wrap in
+        // release when the replenish add `new_visible + replenish_qty` overflows.
+        // It must make NO progress: consumed 0, remaining untouched, maker handed
+        // back byte-identical, no hidden drawn — the no-progress sentinel the
+        // sweep and the fill-or-kill dry run both detect.
+        let order = OrderType::<()>::ReserveOrder {
+            id: Id::from_u64(200),
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(u64::MAX),
+            hidden_quantity: Quantity::new(u64::MAX),
+            side: Side::Sell,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1616823000000),
+            time_in_force: TimeInForce::Gtc,
+            // Any partial fill leaves visible below threshold -> replenish.
+            replenish_threshold: Quantity::new(u64::MAX),
+            replenish_amount: Some(nz(u64::MAX)),
+            auto_replenish: true,
+            extra_fields: (),
+        };
+
+        // A one-unit taker triggers a partial fill: new_visible = u64::MAX - 1,
+        // replenish_qty = min(u64::MAX, u64::MAX) = u64::MAX, and their sum
+        // overflows u64 -> the sentinel fires.
+        let (consumed, updated, hidden_reduced, remaining) = order.match_against(1);
+        assert_eq!(consumed, 0, "overflowing replenish must consume nothing");
+        assert_eq!(
+            hidden_reduced, 0,
+            "overflowing replenish must draw no hidden"
+        );
+        assert_eq!(remaining, 1, "the taker's remaining must be untouched");
+        match updated {
+            Some(OrderType::<()>::ReserveOrder {
+                visible_quantity,
+                hidden_quantity,
+                ..
+            }) => {
+                assert_eq!(visible_quantity, Quantity::new(u64::MAX));
+                assert_eq!(hidden_quantity, Quantity::new(u64::MAX));
+            }
+            _ => panic!("Expected the maker handed back unchanged"),
+        }
+    }
+
+    #[test]
     fn test_from_str_standard() {
         let order_str = "Standard:id=00000000-0000-007b-0000-000000000000;price=10000;quantity=5;side=BUY;timestamp=1616823000000;time_in_force=GTC";
         let order: OrderType<()> = OrderType::from_str(order_str).unwrap();

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -195,38 +195,97 @@ impl PriceLevel {
         self.stats.clone()
     }
 
-    /// Add an order to this price level
-    pub fn add_order(&self, order: OrderType<()>) -> Arc<OrderType<()>> {
-        // Calculate quantities
+    /// Add an order to this price level.
+    ///
+    /// Reserves the order's visible / hidden quantity and one count slot on the
+    /// atomic counters **before** publishing it to the queue, so an admission
+    /// that would overflow any counter is rejected with nothing mutated: the
+    /// queue, the counters, the statistics, and therefore any snapshot are left
+    /// exactly as they were. On success the returned `Arc` is the admitted
+    /// order.
+    ///
+    /// # Overflow safety
+    ///
+    /// Each counter is bumped with a checked [`AtomicU64::fetch_update`] /
+    /// [`AtomicUsize::fetch_update`] (`checked_add`), which is an atomic
+    /// compare-exchange loop and therefore free of the check-then-`fetch_add`
+    /// TOCTOU race two concurrent admissions near `u64::MAX` would otherwise
+    /// hit. Capacity is reserved in the order visible → hidden → count; if a
+    /// later reservation overflows, the earlier ones are rolled back (by the
+    /// exact delta this call added — a commutative, concurrency-safe undo on
+    /// these advisory counters) before returning, so no counter is ever left
+    /// drifted. Only once all three are reserved is the order published to the
+    /// queue, so the queue can never hold an order whose admission overflowed a
+    /// counter — the invariant this method now upholds.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if admitting the order
+    /// would overflow the level's visible-quantity, hidden-quantity, or
+    /// order-count counter. In that case the level is unchanged.
+    pub fn add_order(&self, order: OrderType<()>) -> Result<Arc<OrderType<()>>, PriceLevelError> {
+        // Calculate quantities.
         let visible_qty = order.visible_quantity().as_u64();
         let hidden_qty = order.hidden_quantity().as_u64();
 
-        // On this path, publish to the queue FIRST, then bump the counters, so a
-        // concurrent reader of this add tends to see the order resting before it
-        // is counted rather than the reverse. This is a local ordering choice,
-        // not a cross-method guarantee (other paths, e.g. iceberg replenishment
-        // in `match_order`, adjust counters before pushing). The bare counters
-        // are advisory under concurrency; `snapshot()` is the mutually-consistent
-        // view (see `visible_quantity`).
+        // Reserve capacity on each counter BEFORE publishing, using a checked
+        // `fetch_update` (an atomic CAS loop). `Relaxed` on both the success and
+        // failure orderings: these are the advisory counters (issue #68); the
+        // queue publication below carries the real happens-before for a
+        // concurrent reader, so the counters are not a synchronization channel.
+        if self
+            .visible_quantity
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
+                c.checked_add(visible_qty)
+            })
+            .is_err()
+        {
+            return Err(PriceLevelError::InvalidOperation {
+                message: "price level visible quantity overflow on admission".to_string(),
+            });
+        }
+
+        if self
+            .hidden_quantity
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
+                c.checked_add(hidden_qty)
+            })
+            .is_err()
+        {
+            // Roll back the visible reservation this call made.
+            self.visible_quantity
+                .fetch_sub(visible_qty, Ordering::Relaxed);
+            return Err(PriceLevelError::InvalidOperation {
+                message: "price level hidden quantity overflow on admission".to_string(),
+            });
+        }
+
+        if self
+            .order_count
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| c.checked_add(1))
+            .is_err()
+        {
+            // Roll back the visible + hidden reservations this call made.
+            self.visible_quantity
+                .fetch_sub(visible_qty, Ordering::Relaxed);
+            self.hidden_quantity
+                .fetch_sub(hidden_qty, Ordering::Relaxed);
+            return Err(PriceLevelError::InvalidOperation {
+                message: "price level order count overflow on admission".to_string(),
+            });
+        }
+
+        // All capacity reserved; publish the order to the queue. A concurrent
+        // reader can briefly see the reserved count before the order rests
+        // (the advisory-counter window), but never the reverse overflow the
+        // reservation just ruled out.
         let order_arc = Arc::new(order);
         self.orders.push(order_arc.clone());
 
-        // Update atomic counters. `Relaxed` on all three: these are the
-        // advisory counters (issue #68). The queue publication above (the
-        // `push` into `OrderQueue`'s `SkipMap` / `DashMap`) carries the actual
-        // happens-before for a concurrent reader; the counters are not a
-        // synchronization channel, so a release here would publish nothing a
-        // reader relies on. The RMWs only need to be atomic, not ordered.
-        self.visible_quantity
-            .fetch_add(visible_qty, Ordering::Relaxed);
-        self.hidden_quantity
-            .fetch_add(hidden_qty, Ordering::Relaxed);
-        self.order_count.fetch_add(1, Ordering::Relaxed);
-
-        // Update statistics
+        // Update statistics only after a committed admission.
         self.stats.record_order_added();
 
-        order_arc
+        Ok(order_arc)
     }
 
     /// Creates a non-allocating iterator over current orders in this level.
@@ -1192,9 +1251,10 @@ impl TryFrom<PriceLevelData> for PriceLevel {
     fn try_from(data: PriceLevelData) -> Result<Self, Self::Error> {
         let price_level = PriceLevel::new(data.price);
 
-        // Add orders to the price level
+        // Add orders to the price level. Propagate an admission overflow rather
+        // than panicking while reconstructing from external data.
         for order in data.orders {
-            price_level.add_order(order);
+            price_level.add_order(order)?;
         }
 
         Ok(price_level)
@@ -1281,7 +1341,7 @@ impl FromStr for PriceLevel {
                                 message: format!("Order parse error: {e}"),
                             }
                         })?;
-                        price_level.add_order(order);
+                        price_level.add_order(order)?;
                         last_split = i + 1;
                     }
                     _ => {}
@@ -1295,7 +1355,7 @@ impl FromStr for PriceLevel {
                         message: format!("Order parse error: {e}"),
                     }
                 })?;
-                price_level.add_order(order);
+                price_level.add_order(order)?;
             }
         }
 

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -47,8 +47,10 @@ impl PriceLevel {
     ///
     /// # Errors
     ///
-    /// Returns [`PriceLevelError::InvalidOperation`] if recomputing the snapshot
-    /// aggregates overflows `u64`.
+    /// Returns [`PriceLevelError::InvalidOperation`] if any restored order's own
+    /// visible + hidden total overflows `u64`, or if recomputing the snapshot's
+    /// level aggregates overflows `u64` — the same per-order and per-level
+    /// invariants [`Self::add_order`] enforces at admission.
     pub fn from_snapshot(mut snapshot: PriceLevelSnapshot) -> Result<Self, PriceLevelError> {
         snapshot.refresh_aggregates()?;
 
@@ -220,13 +222,31 @@ impl PriceLevel {
     ///
     /// # Errors
     ///
-    /// Returns [`PriceLevelError::InvalidOperation`] if admitting the order
-    /// would overflow the level's visible-quantity, hidden-quantity, or
-    /// order-count counter. In that case the level is unchanged.
+    /// Returns [`PriceLevelError::InvalidOperation`] if the order's own
+    /// visible + hidden total overflows `u64`, or if admitting it would
+    /// overflow the level's visible-quantity, hidden-quantity, or order-count
+    /// counter. In every case the level is unchanged.
     pub fn add_order(&self, order: OrderType<()>) -> Result<Arc<OrderType<()>>, PriceLevelError> {
         // Calculate quantities.
         let visible_qty = order.visible_quantity().as_u64();
         let hidden_qty = order.hidden_quantity().as_u64();
+
+        // Reject an order whose OWN visible + hidden total is not representable
+        // in `u64`, before touching any counter. The level tracks visible and
+        // hidden in two independent `u64` counters, so an order with, say,
+        // visible `u64::MAX` and hidden `u64::MAX` would clear the per-counter
+        // reservations below yet leave the level holding an order whose total
+        // quantity overflows. Worse, the match sweep's reserve replenishment
+        // computes `new_visible + drawn_hidden` (see `OrderType::match_against`),
+        // where `drawn_hidden` is capped by the order's hidden tranche; that sum
+        // is `<= visible + hidden`, so it can only overflow `u64` when the
+        // order's own total already does. Enforcing the invariant here makes that
+        // replenish add provably overflow-free for every admitted order.
+        if visible_qty.checked_add(hidden_qty).is_none() {
+            return Err(PriceLevelError::InvalidOperation {
+                message: "order total quantity overflows u64".to_string(),
+            });
+        }
 
         // Reserve capacity on each counter BEFORE publishing, using a checked
         // `fetch_update` (an atomic CAS loop). `Relaxed` on both the success and
@@ -643,14 +663,28 @@ impl PriceLevel {
             new_remaining: u64,
         }
 
-        // Either the maker progressed (carrying `StepData`) or it was parked by
-        // the no-progress guard (`SetAside`). The parked variant threads the
-        // maker's id and insertion seq OUT of the locked decision closure so the
-        // no-progress `warn!` can name the parked maker without logging inside
-        // the per-entry lock.
+        // Either the maker progressed (carrying `StepData`), was parked by the
+        // no-progress guard (`SetAside`), or forced the sweep to abort because
+        // committing its replenishment would overflow the level's visible
+        // counter (`Abort`). The parked / abort variants thread the maker's id
+        // (and, for `SetAside`, its insertion seq) OUT of the locked decision
+        // closure so the `warn!` / `error!` can name the maker without logging
+        // inside the per-entry lock.
         enum StepResult {
             Progressed(StepData),
-            SetAside { maker_id: Id, seq: u64 },
+            SetAside {
+                maker_id: Id,
+                seq: u64,
+            },
+            /// The FIFO-front maker would replenish, but moving the drawn hidden
+            /// tranche into the level's visible counter would take it past
+            /// `u64::MAX` — a depth the level cannot represent. The maker is left
+            /// byte-identical (the queue action is `SetAside`, a pure no-op that
+            /// mutates nothing) and the sweep terminates immediately, so no
+            /// younger maker trades past this front and no counter wraps.
+            Abort {
+                maker_id: Id,
+            },
         }
 
         while remaining > 0 {
@@ -717,6 +751,35 @@ impl PriceLevel {
                     None => FrontAction::Remove,
                     Some(updated) => {
                         if hidden_reduced > 0 {
+                            // Replenishment: a fresh tranche moves from hidden
+                            // into visible, so the level's visible counter takes
+                            // the net delta `hidden_reduced - consumed` (the
+                            // `fetch_sub(consumed)` + `fetch_add(hidden_reduced)`
+                            // applied after this closure returns). Even when every
+                            // resting order's own total fits `u64`, the level's
+                            // visible SUM can exceed `u64::MAX` once hidden depth
+                            // is converted to visible — a state the counter (and
+                            // the true queue visible sum) cannot represent.
+                            //
+                            // Pre-validate that net delta against the LIVE visible
+                            // counter with checked arithmetic BEFORE committing:
+                            // read the counter (the same reserve-before-commit
+                            // pattern used under the entry lock), and if
+                            // `current - consumed + hidden_reduced` would not fit
+                            // `u64`, ABORT. The abort leaves the maker
+                            // byte-identical (`SetAside` mutates nothing), emits
+                            // no trade, and terminates the sweep, so no younger
+                            // maker trades past this FIFO front and the counter
+                            // never wraps. The stuck depth is unreachable until a
+                            // cancel / downsize frees headroom.
+                            let current_visible = self.visible_quantity.load(Ordering::Relaxed);
+                            let fits = current_visible
+                                .checked_sub(consumed)
+                                .and_then(|v| v.checked_add(hidden_reduced))
+                                .is_some();
+                            if !fits {
+                                return (FrontAction::SetAside, StepResult::Abort { maker_id });
+                            }
                             // Replenishment: refreshed tranche loses priority.
                             FrontAction::ReplaceAtTail(Arc::new(updated))
                         } else {
@@ -746,6 +809,25 @@ impl PriceLevel {
                                 "match sweep: front maker made no progress; set aside to avoid re-pop"
                             );
                             continue;
+                        }
+                        StepResult::Abort { maker_id } => {
+                            // The FIFO-front maker's replenishment would overflow
+                            // the level's visible counter. The queue committed a
+                            // no-op (`SetAside`), so the maker rests unchanged and
+                            // no counter moved. Terminate the sweep here WITHOUT
+                            // decrementing `remaining`: no trade is emitted for
+                            // this maker, and stopping (rather than advancing to a
+                            // younger maker) preserves strict FIFO — liquidity
+                            // behind this front stays unreachable until a cancel /
+                            // downsize frees enough headroom to represent the
+                            // replenished depth.
+                            tracing::error!(
+                                price = self.price,
+                                remaining,
+                                order_id = %maker_id,
+                                "match sweep aborted: replenishment would overflow the level visible counter; front maker left intact, sweep terminated"
+                            );
+                            break;
                         }
                         StepResult::Progressed(data) => data,
                     };
@@ -956,8 +1038,10 @@ impl PriceLevel {
     ///
     /// Returns [`PriceLevelError::InvalidOperation`] if an
     /// [`OrderUpdate::UpdatePrice`] / [`OrderUpdate::Replace`] would not move
-    /// the order to a different price level, or if computing an order's total
-    /// quantity overflows `u64`.
+    /// the order to a different price level, if computing an order's total
+    /// quantity overflows `u64`, or if applying a quantity update's counter
+    /// delta would take the level's visible- or hidden-quantity counter past
+    /// `u64::MAX` (rejected with the queue and counters untouched).
     #[must_use = "the updated order (or None when the order is absent) must be handled"]
     pub fn update_order(
         &self,
@@ -1035,6 +1119,37 @@ impl PriceLevel {
                         message: "order total quantity overflow".to_string(),
                     }
                 })?;
+
+                // Pre-validate the LEVEL counter deltas before mutating the
+                // queue: an upsize (or a visible/hidden reshuffle) whose delta
+                // would take a level counter past `u64::MAX` must be rejected
+                // with the queue and counters untouched, never committed and then
+                // wrapped by the raw `fetch_add` below. Project each counter from
+                // its live value using the pre-read order's components as `old`;
+                // if either projection does not fit `u64`, reject.
+                //
+                // This uses the pre-read `order` (not the value the queue mutation
+                // will actually replace), so a concurrent update of the same id
+                // could make the projection stale (TOCTOU) — strictly better than
+                // the unchecked wrap it replaces, and #115 closes the window
+                // exactly by reserving under the entry lock.
+                let old_visible_pre = order.visible_quantity().as_u64();
+                let old_hidden_pre = order.hidden_quantity().as_u64();
+                let projects = |counter: &AtomicU64, old: u64, new: u64| -> bool {
+                    let cur = counter.load(Ordering::Relaxed);
+                    if new >= old {
+                        cur.checked_add(new - old).is_some()
+                    } else {
+                        cur.checked_sub(old - new).is_some()
+                    }
+                };
+                if !projects(&self.visible_quantity, old_visible_pre, new_visible)
+                    || !projects(&self.hidden_quantity, old_hidden_pre, new_hidden)
+                {
+                    return Err(PriceLevelError::InvalidOperation {
+                        message: "price level quantity counter overflow on update".to_string(),
+                    });
+                }
 
                 let new_order_arc = Arc::new(new_order);
 

--- a/src/price_level/snapshot.rs
+++ b/src/price_level/snapshot.rs
@@ -215,8 +215,9 @@ impl PriceLevelSnapshot {
     ///
     /// # Errors
     ///
-    /// Returns [`PriceLevelError::InvalidOperation`] if summing the per-order
-    /// visible or hidden quantities overflows `u64`.
+    /// Returns [`PriceLevelError::InvalidOperation`] if any single order's own
+    /// visible + hidden total overflows `u64`, or if summing the per-order
+    /// visible or hidden quantities across the level overflows `u64`.
     pub fn refresh_aggregates(&mut self) -> Result<(), PriceLevelError> {
         self.order_count = self.orders.len();
 
@@ -224,6 +225,22 @@ impl PriceLevelSnapshot {
         let mut hidden_total: u64 = 0;
 
         for order in &self.orders {
+            // Reject any order whose OWN visible + hidden total is not
+            // representable in `u64`. `PriceLevel::add_order` enforces this same
+            // per-order invariant at admission, and the match sweep's reserve
+            // replenishment relies on it (a refreshed tranche is
+            // `new_visible + drawn_hidden <= visible + hidden`, which overflows
+            // only if the order's own total already does). Restoring such an
+            // order would smuggle in a state admission rejects, so the restore
+            // path validates it too rather than trusting the serialized bytes.
+            order
+                .visible_quantity()
+                .as_u64()
+                .checked_add(order.hidden_quantity().as_u64())
+                .ok_or_else(|| PriceLevelError::InvalidOperation {
+                    message: "order total quantity overflows u64".to_string(),
+                })?;
+
             visible_total = visible_total
                 .checked_add(order.visible_quantity().as_u64())
                 .ok_or_else(|| PriceLevelError::InvalidOperation {

--- a/src/price_level/tests/entry.rs
+++ b/src/price_level/tests/entry.rs
@@ -134,7 +134,7 @@ mod tests {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        level.add_order(order);
+        level.add_order(order).expect("add_order should succeed");
 
         // Serialize the entry
         let json = serde_json::to_string(&entry).unwrap();
@@ -227,7 +227,9 @@ mod tests_order_book_entry {
             extra_fields: (),
         };
 
-        level1.add_order(order_type);
+        level1
+            .add_order(order_type)
+            .expect("add_order should succeed");
         assert_eq!(entry1.order_count(), 1);
 
         // Add another order
@@ -242,7 +244,9 @@ mod tests_order_book_entry {
             extra_fields: (),
         };
 
-        level1.add_order(order_type2);
+        level1
+            .add_order(order_type2)
+            .expect("add_order should succeed");
         assert_eq!(entry1.order_count(), 2);
     }
 
@@ -373,7 +377,9 @@ mod tests_order_book_entry {
             time_in_force: crate::orders::TimeInForce::Gtc,
             extra_fields: (),
         };
-        level.add_order(standard_order);
+        level
+            .add_order(standard_order)
+            .expect("add_order should succeed");
 
         // Check quantities after adding order
         assert_eq!(entry.visible_quantity(), 10);
@@ -391,7 +397,9 @@ mod tests_order_book_entry {
             time_in_force: crate::orders::TimeInForce::Gtc,
             extra_fields: (),
         };
-        level.add_order(iceberg_order);
+        level
+            .add_order(iceberg_order)
+            .expect("add_order should succeed");
 
         // Check quantities after adding iceberg order
         assert_eq!(entry.visible_quantity(), 15); // 10 + 5

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -6327,29 +6327,123 @@ mod tests {
     }
 
     #[test]
-    fn test_reserve_replenish_overflow_no_trade_maker_preserved() {
-        // A reserve whose visible + hidden exceed u64::MAX is admissible (the
-        // two are separate u64 counters). A partial match that would replenish
-        // it computes `new_visible + replenish_qty`, which overflows u64. The
-        // match step must fail atomically: no trade, maker unchanged, no panic
-        // (this test runs under debug assertions, where an unchecked `+` would
-        // panic).
+    fn test_reserve_own_total_overflow_rejected_at_admission() {
+        // A reserve whose OWN visible + hidden overflows u64 is now rejected at
+        // admission (issue #111 follow-up): the level cannot hold an order whose
+        // total quantity is not representable, and the match sweep's replenish
+        // add relies on that invariant. Nothing is mutated on rejection.
+        let level = PriceLevel::new(10_000);
+        match level.add_order(create_reserve_order(
+            1,
+            10_000,
+            u64::MAX,       // visible
+            u64::MAX,       // hidden -> visible + hidden overflows u64
+            u64::MAX,       // threshold
+            true,           // auto_replenish
+            Some(u64::MAX), // replenish amount
+        )) {
+            Err(PriceLevelError::InvalidOperation { message }) => {
+                assert!(
+                    message.contains("order total quantity overflows u64"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected order-total-overflow InvalidOperation, got {other:?}"),
+        }
+
+        // The level is untouched: no counters, no order, no stats moved.
+        assert_eq!(level.visible_quantity(), 0);
+        assert_eq!(level.hidden_quantity(), 0);
+        assert_eq!(level.order_count(), 0);
+        assert_eq!(level.snapshot_by_insertion_seq().len(), 0);
+    }
+
+    #[test]
+    fn test_iceberg_own_total_overflow_rejected_at_admission() {
+        // Same per-order invariant for an iceberg: visible + hidden must fit u64.
+        let level = PriceLevel::new(10_000);
+        match level.add_order(create_iceberg_order(1, 10_000, u64::MAX, u64::MAX)) {
+            Err(PriceLevelError::InvalidOperation { message }) => {
+                assert!(
+                    message.contains("order total quantity overflows u64"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected order-total-overflow InvalidOperation, got {other:?}"),
+        }
+
+        assert_eq!(level.visible_quantity(), 0);
+        assert_eq!(level.hidden_quantity(), 0);
+        assert_eq!(level.order_count(), 0);
+        assert_eq!(level.snapshot_by_insertion_seq().len(), 0);
+    }
+
+    #[test]
+    fn test_from_snapshot_rejects_order_own_total_overflow() {
+        // The restore path admits orders too, so it enforces the SAME per-order
+        // total invariant as add_order: a snapshot carrying an order whose own
+        // visible + hidden overflows u64 is rejected (via the topology scan in
+        // `refresh_aggregates`, shared by `from_snapshot` and the checksum
+        // package path) rather than smuggled in.
+        let overflowing = create_iceberg_order(1, 10_000, u64::MAX, u64::MAX);
+        let snapshot = crate::price_level::PriceLevelSnapshot::from_raw_parts(
+            Price::new(10_000),
+            // Stored aggregates are recomputed by `refresh_aggregates`; the
+            // per-order scan rejects the order before they matter.
+            Quantity::new(0),
+            Quantity::new(0),
+            1,
+            vec![std::sync::Arc::new(overflowing)],
+        );
+
+        match PriceLevel::from_snapshot(snapshot) {
+            Err(PriceLevelError::InvalidOperation { message }) => {
+                assert!(
+                    message.contains("order total quantity overflows u64"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => {
+                panic!("expected order-total-overflow InvalidOperation on restore, got {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn test_replenish_would_wrap_level_counter_aborts_sweep_no_trade() {
+        // Issue #111 follow-up, finding 2: even when every order's OWN total
+        // fits u64, converting hidden depth to visible can push the LEVEL visible
+        // counter (and the true queue visible sum) past u64::MAX. The sweep must
+        // abort at the FIFO front rather than wrap the counter or trade a younger
+        // maker.
+        //
+        // auto-reserve(visible 1, hidden 100, replenish 100) admitted FIRST
+        // (own total 101, fits) + standard(visible u64::MAX - 1) admitted second
+        // (own total fits). Level visible counter = 1 + (u64::MAX - 1) = u64::MAX.
         let level = PriceLevel::new(10_000);
         level
             .add_order(create_reserve_order(
                 1,
                 10_000,
-                u64::MAX,       // visible
-                u64::MAX,       // hidden
-                u64::MAX,       // threshold: any partial fill falls below -> replenish
-                true,           // auto_replenish
-                Some(u64::MAX), // replenish amount: draws the full hidden
+                1,
+                100,
+                100,
+                true,
+                Some(100),
             ))
-            .expect("reserve with separately-valid u64 components must admit");
+            .expect("reserve own total fits u64");
+        level
+            .add_order(create_standard_order(2, 10_000, u64::MAX - 1))
+            .expect("standard own total fits u64");
+        assert_eq!(level.visible_quantity(), u64::MAX);
+
+        let before_json = level.snapshot_to_json().expect("snapshot serializes");
 
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let generator = UuidGenerator::new(namespace);
-        // A tiny taker triggers a partial fill and the overflowing replenish.
+        // A one-unit taker: consuming the reserve's visible 1 IS representable,
+        // but the +100 replenish would take the level visible counter to
+        // u64::MAX + 99 -> the sweep aborts at the reserve.
         let result = level.match_order(
             1,
             Id::from_u64(999),
@@ -6359,31 +6453,82 @@ mod tests {
             &generator,
         );
 
-        // No trade emitted and the taker is left fully unconsumed.
-        assert_eq!(
-            result.trades().len(),
-            0,
-            "an overflowing replenish must emit no trade"
-        );
+        // Zero trades, taker remainder full: the reserve's 1-unit fill was NOT
+        // emitted because it is inseparable from the overflowing replenish.
+        assert_eq!(result.trades().len(), 0, "aborted sweep must emit no trade");
         assert_eq!(
             result.remaining_quantity().as_u64(),
             1,
             "the taker must be left fully unconsumed"
         );
 
-        // The maker is still resting, unchanged.
-        let resting = level.snapshot_by_insertion_seq();
-        assert_eq!(resting.len(), 1, "the maker must still rest");
-        assert_eq!(resting[0].id(), Id::from_u64(1));
+        // NO wrap: the level visible counter is still exactly u64::MAX.
         assert_eq!(
-            resting[0].visible_quantity().as_u64(),
+            level.visible_quantity(),
             u64::MAX,
-            "maker visible quantity must be unchanged"
+            "the level visible counter must not have wrapped"
         );
+        assert_eq!(level.hidden_quantity(), 100, "hidden counter unchanged");
+        assert_eq!(level.order_count(), 2, "both makers still rest");
+
+        // Both makers are byte-identical, and FIFO is preserved: the younger
+        // standard maker did NOT trade and the reserve is untouched.
+        let resting = level.snapshot_by_insertion_seq();
+        assert_eq!(resting.len(), 2);
+        assert_eq!(resting[0].id(), Id::from_u64(1));
+        assert_eq!(resting[0].visible_quantity().as_u64(), 1);
+        assert_eq!(resting[0].hidden_quantity().as_u64(), 100);
+        assert_eq!(resting[1].id(), Id::from_u64(2));
+        assert_eq!(resting[1].visible_quantity().as_u64(), u64::MAX - 1);
+
+        // counters == queue == snapshot: the snapshot is byte-identical to the
+        // pre-match one, proving no counter drifted from the queue.
+        let after_json = level.snapshot_to_json().expect("snapshot serializes");
         assert_eq!(
-            resting[0].hidden_quantity().as_u64(),
-            u64::MAX,
-            "maker hidden quantity must be unchanged"
+            before_json, after_json,
+            "an aborted sweep must leave the level byte-identical"
+        );
+    }
+
+    #[test]
+    fn test_update_order_upsize_wrapping_level_counter_rejected() {
+        // update_order must reject a quantity update whose counter delta would
+        // wrap the level visible counter, leaving the level unchanged and
+        // deterministic. Fill the visible counter to u64::MAX with a standard
+        // maker, add a tiny second maker, then try to upsize the tiny one — its
+        // +delta would take the counter past u64::MAX.
+        let level = PriceLevel::new(10_000);
+        level
+            .add_order(create_standard_order(1, 10_000, u64::MAX - 5))
+            .expect("first admission ok");
+        level
+            .add_order(create_standard_order(2, 10_000, 5))
+            .expect("second admission reaches exactly u64::MAX");
+        assert_eq!(level.visible_quantity(), u64::MAX);
+
+        let before_json = level.snapshot_to_json().expect("snapshot serializes");
+
+        // Upsize maker 2 from 5 to 10: delta +5 would wrap the level counter.
+        match level.update_order(OrderUpdate::UpdateQuantity {
+            order_id: Id::from_u64(2),
+            new_quantity: Quantity::new(10),
+        }) {
+            Err(PriceLevelError::InvalidOperation { message }) => {
+                assert!(
+                    message.contains("price level quantity counter overflow on update"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected counter-overflow InvalidOperation, got {other:?}"),
+        }
+
+        // Nothing mutated: counters, order sizes, and a byte-identical snapshot.
+        assert_eq!(level.visible_quantity(), u64::MAX);
+        assert_eq!(level.order_count(), 2);
+        let after_json = level.snapshot_to_json().expect("snapshot serializes");
+        assert_eq!(
+            before_json, after_json,
+            "a rejected update must leave the level byte-identical"
         );
     }
 

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -36,8 +36,12 @@ mod tests {
     #[test]
     fn test_price_level_snapshot_roundtrip() {
         let price_level = PriceLevel::new(10000);
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_iceberg_order(2, 10000, 50, 200));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_iceberg_order(2, 10000, 50, 200))
+            .expect("add_order should succeed");
 
         let package = price_level
             .snapshot_package()
@@ -73,7 +77,9 @@ mod tests {
     #[test]
     fn test_price_level_snapshot_checksum_failure() {
         let price_level = PriceLevel::new(20000);
-        price_level.add_order(create_standard_order(1, 20000, 100));
+        price_level
+            .add_order(create_standard_order(1, 20000, 100))
+            .expect("add_order should succeed");
 
         let package = price_level
             .snapshot_package()
@@ -109,9 +115,15 @@ mod tests {
 
         // Rest several makers so we accumulate non-trivial waiting-time and
         // arrival aggregates, then partially match them to drive every counter.
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 100));
-        price_level.add_order(create_standard_order(3, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(3, 10000, 100))
+            .expect("add_order should succeed");
 
         // Execution timestamp is comfortably after the order arrival timestamps
         // (TIMESTAMP_COUNTER starts at 1_616_823_000_000), so waiting times are
@@ -190,7 +202,9 @@ mod tests {
         // with a clear version mismatch (InvalidOperation), not a checksum error
         // and not a panic.
         let price_level = PriceLevel::new(10000);
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let json = price_level
             .snapshot_to_json()
@@ -225,10 +239,18 @@ mod tests {
     #[test]
     fn test_price_level_from_snapshot_preserves_order_positions() {
         let price_level = PriceLevel::new(15000);
-        price_level.add_order(create_standard_order(1, 15000, 100));
-        price_level.add_order(create_iceberg_order(2, 15000, 40, 120));
-        price_level.add_order(create_post_only_order(3, 15000, 60));
-        price_level.add_order(create_reserve_order(4, 15000, 30, 90, 15, true, Some(20)));
+        price_level
+            .add_order(create_standard_order(1, 15000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_iceberg_order(2, 15000, 40, 120))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_post_only_order(3, 15000, 60))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_reserve_order(4, 15000, 30, 90, 15, true, Some(20)))
+            .expect("add_order should succeed");
 
         let snapshot = price_level.snapshot();
         let restored = PriceLevel::from(&snapshot);
@@ -258,10 +280,18 @@ mod tests {
     #[test]
     fn test_price_level_from_snapshot_package_preserves_order_positions() {
         let price_level = PriceLevel::new(17500);
-        price_level.add_order(create_standard_order(10, 17500, 80));
-        price_level.add_order(create_trailing_stop_order(11, 17500, 50));
-        price_level.add_order(create_pegged_order(12, 17500, 40));
-        price_level.add_order(create_market_to_limit_order(13, 17500, 70));
+        price_level
+            .add_order(create_standard_order(10, 17500, 80))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_trailing_stop_order(11, 17500, 50))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_pegged_order(12, 17500, 40))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_market_to_limit_order(13, 17500, 70))
+            .expect("add_order should succeed");
 
         let package = price_level
             .snapshot_package()
@@ -460,7 +490,9 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let order = create_standard_order(1, 10000, 100);
 
-        let order_arc = price_level.add_order(order);
+        let order_arc = price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         assert_eq!(price_level.visible_quantity(), 100);
         assert_eq!(price_level.hidden_quantity(), 0);
@@ -481,7 +513,9 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let order = create_iceberg_order(2, 10000, 50, 200);
 
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         assert_eq!(price_level.visible_quantity(), 50);
         assert_eq!(price_level.hidden_quantity(), 200);
@@ -494,10 +528,18 @@ mod tests {
         let price_level = PriceLevel::new(10000);
 
         // Add different order types
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_iceberg_order(2, 10000, 50, 200));
-        price_level.add_order(create_post_only_order(3, 10000, 75));
-        price_level.add_order(create_reserve_order(4, 10000, 25, 100, 100, true, None));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_iceberg_order(2, 10000, 50, 200))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_post_only_order(3, 10000, 75))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_reserve_order(4, 10000, 25, 100, 100, true, None))
+            .expect("add_order should succeed");
 
         assert_eq!(price_level.visible_quantity(), 250); // 100 + 50 + 75 + 25
         assert_eq!(price_level.hidden_quantity(), 300); // 0 + 200 + 0 + 100
@@ -512,8 +554,12 @@ mod tests {
     fn test_update_order_cancel() {
         let price_level = PriceLevel::new(10000);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_iceberg_order(2, 10000, 50, 200));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_iceberg_order(2, 10000, 50, 200))
+            .expect("add_order should succeed");
 
         // Cancel the standard order using OrderUpdate
         let result = price_level.update_order(OrderUpdate::Cancel {
@@ -557,8 +603,12 @@ mod tests {
     fn test_iter_orders() {
         let price_level = PriceLevel::new(10000);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_iceberg_order(2, 10000, 50, 200));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_iceberg_order(2, 10000, 50, 200))
+            .expect("add_order should succeed");
 
         let orders = price_level.snapshot_orders();
 
@@ -576,7 +626,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Match the entire order
         let taker_id = Id::from_u64(999); // market order ID
@@ -640,9 +692,15 @@ mod tests {
         // the last maker) so the trade stream has multiple entries.
         let run = || {
             let price_level = PriceLevel::new(10000);
-            price_level.add_order(mk(1, 40));
-            price_level.add_order(mk(2, 30));
-            price_level.add_order(mk(3, 50));
+            price_level
+                .add_order(mk(1, 40))
+                .expect("add_order should succeed");
+            price_level
+                .add_order(mk(2, 30))
+                .expect("add_order should succeed");
+            price_level
+                .add_order(mk(3, 50))
+                .expect("add_order should succeed");
 
             let trade_id_generator = UuidGenerator::new(namespace);
             price_level.match_order(
@@ -682,7 +740,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Match part of the order
         let taker_id = Id::from_u64(999);
@@ -725,7 +785,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Match with quantity exceeding available
         let taker_id = Id::from_u64(999);
@@ -768,7 +830,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Add a new iceberg order with a visible quantity of 50 and a hidden quantity of 100.
-        price_level.add_order(create_iceberg_order(1, 10000, 50, 100));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 50, 100))
+            .expect("add_order should succeed");
 
         // Match the visible portion of the iceberg order.
         let taker_id = Id::from_u64(999);
@@ -849,7 +913,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Add a new iceberg order with a visible quantity of 50 and a hidden quantity of 100.
-        price_level.add_order(create_iceberg_order(1, 10000, 100, 100));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 100, 100))
+            .expect("add_order should succeed");
 
         // Match the visible portion of the iceberg order.
         let taker_id = Id::from_u64(999);
@@ -931,7 +997,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_iceberg_order(1, 10000, 50, 150));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 50, 150))
+            .expect("add_order should succeed");
 
         // Match part of the visible portion
         let taker_id = Id::from_u64(999);
@@ -963,7 +1031,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Create a reserve order with auto-replenish disabled
-        price_level.add_order(create_reserve_order(1, 10000, 50, 150, 20, false, None));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 50, 150, 20, false, None))
+            .expect("add_order should succeed");
 
         // Match the entire visible portion
         let taker_id = Id::from_u64(999);
@@ -994,7 +1064,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Create a reserve order with auto-replenish enabled
-        price_level.add_order(create_reserve_order(1, 10000, 50, 150, 20, true, None));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 50, 150, 20, true, None))
+            .expect("add_order should succeed");
 
         // Match the entire visible portion
         let taker_id = Id::from_u64(999);
@@ -1031,7 +1103,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Create a reserve order with auto-replenish disabled
-        price_level.add_order(create_reserve_order(1, 10000, 50, 150, 20, false, None));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 50, 150, 20, false, None))
+            .expect("add_order should succeed");
 
         // Match partially, but still above threshold
         let taker_id = Id::from_u64(999);
@@ -1078,15 +1152,17 @@ mod tests {
 
         // Create a reserve order with auto-replenish enabled and a custom replenishment amount
         let custom_amount = 50;
-        price_level.add_order(create_reserve_order(
-            1,
-            10000,
-            50,
-            150,
-            20,
-            true,
-            Some(custom_amount),
-        ));
+        price_level
+            .add_order(create_reserve_order(
+                1,
+                10000,
+                50,
+                150,
+                20,
+                true,
+                Some(custom_amount),
+            ))
+            .expect("add_order should succeed");
 
         // Match the entire visible portion
         let taker_id = Id::from_u64(999);
@@ -1117,7 +1193,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Create a reserve order with threshold 0 and auto-replenish enabled
-        price_level.add_order(create_reserve_order(1, 10000, 50, 150, 0, true, None));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 50, 150, 0, true, None))
+            .expect("add_order should succeed");
 
         // Match partially
         let taker_id = Id::from_u64(999);
@@ -1147,7 +1225,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Create a reserve order with threshold 0 and auto-replenish disabled
-        price_level.add_order(create_reserve_order(1, 10000, 50, 150, 0, false, None));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 50, 150, 0, false, None))
+            .expect("add_order should succeed");
 
         // Match the entire visible portion
         let taker_id = Id::from_u64(999);
@@ -1177,7 +1257,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Create a reserve order with threshold 1 and auto-replenish disabled
-        price_level.add_order(create_reserve_order(1, 10000, 50, 150, 1, false, None));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 50, 150, 1, false, None))
+            .expect("add_order should succeed");
 
         // Match the entire visible portion
         let taker_id = Id::from_u64(999);
@@ -1207,7 +1289,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Create a reserve order with threshold 20 and auto-replenish disabled
-        price_level.add_order(create_reserve_order(1, 10000, 50, 150, 20, false, None));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 50, 150, 20, false, None))
+            .expect("add_order should succeed");
 
         // Match part of the visible portion, but still above threshold
         let taker_id = Id::from_u64(999);
@@ -1256,7 +1340,9 @@ mod tests {
 
         // Create a reserve order with threshold 20, auto-replenish enabled
         // and default replenish amount (80)
-        price_level.add_order(create_reserve_order(1, 10000, 100, 100, 20, true, None));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 100, 100, 20, true, None))
+            .expect("add_order should succeed");
 
         // Match 80 units, which is above the replenish threshold
         let taker_id = Id::from_u64(999);
@@ -1357,7 +1443,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_post_only_order(1, 10000, 100));
+        price_level
+            .add_order(create_post_only_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Post-only orders behave like standard orders for matching
         let taker_id = Id::from_u64(999);
@@ -1382,7 +1470,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_trailing_stop_order(1, 10000, 100));
+        price_level
+            .add_order(create_trailing_stop_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Trailing stop orders behave like standard orders for matching
         let taker_id = Id::from_u64(999);
@@ -1407,7 +1497,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_pegged_order(1, 10000, 100));
+        price_level
+            .add_order(create_pegged_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Pegged orders behave like standard orders for matching
         let taker_id = Id::from_u64(999);
@@ -1432,7 +1524,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_market_to_limit_order(1, 10000, 100));
+        price_level
+            .add_order(create_market_to_limit_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Market-to-limit orders behave like standard orders for matching
         let taker_id = Id::from_u64(999);
@@ -1484,7 +1578,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_post_only_order(1, 10000, 100));
+        price_level
+            .add_order(create_post_only_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             60,
@@ -1512,7 +1608,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_post_only_order(1, 10000, 100));
+        price_level
+            .add_order(create_post_only_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -1545,7 +1643,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_post_only_order(1, 10000, 100));
+        price_level
+            .add_order(create_post_only_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             150,
@@ -1600,7 +1700,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_trailing_stop_order(1, 10000, 100));
+        price_level
+            .add_order(create_trailing_stop_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             40,
@@ -1629,7 +1731,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_trailing_stop_order(1, 10000, 100));
+        price_level
+            .add_order(create_trailing_stop_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -1660,7 +1764,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_trailing_stop_order(1, 10000, 80));
+        price_level
+            .add_order(create_trailing_stop_order(1, 10000, 80))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             120,
@@ -1713,7 +1819,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_pegged_order(1, 10000, 100));
+        price_level
+            .add_order(create_pegged_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             50,
@@ -1741,7 +1849,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_pegged_order(1, 10000, 100));
+        price_level
+            .add_order(create_pegged_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -1771,7 +1881,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_pegged_order(1, 10000, 90));
+        price_level
+            .add_order(create_pegged_order(1, 10000, 90))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             130,
@@ -1826,7 +1938,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_market_to_limit_order(1, 10000, 100));
+        price_level
+            .add_order(create_market_to_limit_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             70,
@@ -1854,7 +1968,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_market_to_limit_order(1, 10000, 100));
+        price_level
+            .add_order(create_market_to_limit_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -1885,7 +2001,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_market_to_limit_order(1, 10000, 60));
+        price_level
+            .add_order(create_market_to_limit_order(1, 10000, 60))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -1958,7 +2076,9 @@ mod tests {
         let level_price = maker.price().as_u128();
         let maker_id = maker.id();
         let price_level = PriceLevel::new(level_price);
-        price_level.add_order(maker);
+        price_level
+            .add_order(maker)
+            .expect("add_order should succeed");
 
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
@@ -2072,10 +2192,12 @@ mod tests {
         let level_price = front.price().as_u128();
         let front_id = front.id();
         let level = PriceLevel::new(level_price);
-        level.add_order(front);
+        level.add_order(front).expect("add_order should succeed");
         // A plain maker queued behind the resized one.
         let behind_id = Id::from_u64(778);
-        level.add_order(create_standard_order(778, level_price, 100));
+        level
+            .add_order(create_standard_order(778, level_price, 100))
+            .expect("add_order should succeed");
 
         let updated = level
             .update_order(OrderUpdate::UpdateQuantity {
@@ -2112,9 +2234,11 @@ mod tests {
         let level_price = front.price().as_u128();
         let front_id = front.id();
         let level = PriceLevel::new(level_price);
-        level.add_order(front);
+        level.add_order(front).expect("add_order should succeed");
         let behind_id = Id::from_u64(778);
-        level.add_order(create_standard_order(778, level_price, 100));
+        level
+            .add_order(create_standard_order(778, level_price, 100))
+            .expect("add_order should succeed");
 
         let updated = level
             .update_order(OrderUpdate::UpdateQuantity {
@@ -2192,8 +2316,12 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_post_only_order(2, 10000, 50));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_post_only_order(2, 10000, 50))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             0,
@@ -2225,7 +2353,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(
@@ -2253,7 +2383,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(
@@ -2294,8 +2426,12 @@ mod tests {
         // available (100) == incoming (100): on the fill side of the boundary.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_standard_order(1, 10000, 60));
-        price_level.add_order(create_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_standard_order(1, 10000, 60))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -2322,8 +2458,12 @@ mod tests {
         // exactly one unit. Zero trades, full remainder, queue untouched.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_standard_order(1, 10000, 60));
-        price_level.add_order(create_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_standard_order(1, 10000, 60))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             101,
@@ -2374,7 +2514,9 @@ mod tests {
         // taker of 50, so it fills rather than (wrongly) being killed.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_iceberg_order(1, 10000, 10, 40));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 10, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             50,
@@ -2399,8 +2541,12 @@ mod tests {
         // never enqueued; the level is emptied of makers.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_standard_order(1, 10000, 60));
-        price_level.add_order(create_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_standard_order(1, 10000, 60))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             150,
@@ -2430,7 +2576,9 @@ mod tests {
         // liquidity -> rejected: zero trades, full remainder, queue untouched.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             60,
@@ -2482,7 +2630,9 @@ mod tests {
         // it falls through to the vacuous-complete sweep.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             0,
@@ -2509,7 +2659,9 @@ mod tests {
         // book to convert/rest. At this layer it behaves like a standard taker.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             140,
@@ -2535,7 +2687,9 @@ mod tests {
         // available (100) == incoming (100): fully filled, no remainder.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -2560,7 +2714,9 @@ mod tests {
         // consumes it normally. (FOK is a taker-side policy.)
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_fill_or_kill_order(1, 10000, 100));
+        price_level
+            .add_order(create_fill_or_kill_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -2582,7 +2738,9 @@ mod tests {
         // partially consumes it and the remainder keeps resting.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_immediate_or_cancel_order(1, 10000, 100));
+        price_level
+            .add_order(create_immediate_or_cancel_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             50,
@@ -2604,7 +2762,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_good_till_date_order(1, 10000, 100, 1617000000000));
+        price_level
+            .add_order(create_good_till_date_order(1, 10000, 100, 1617000000000))
+            .expect("add_order should succeed");
 
         // GTD orders behave like standard orders for matching
         let taker_id = Id::from_u64(999);
@@ -2642,8 +2802,12 @@ mod tests {
         let trade_id_generator = UuidGenerator::new(namespace);
 
         // Total resting depth = 100 (two Buy makers).
-        price_level.add_order(create_standard_order(1, 10000, 60));
-        price_level.add_order(create_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_standard_order(1, 10000, 60))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
         assert_eq!(price_level.visible_quantity(), 100);
         assert_eq!(price_level.order_count(), 2);
 
@@ -2720,7 +2884,9 @@ mod tests {
             "fixture: the GTD maker is expired per TimeInForce::is_expired"
         );
 
-        price_level.add_order(create_good_till_date_order(1, 10000, 100, past_expiry));
+        price_level
+            .add_order(create_good_till_date_order(1, 10000, 100, past_expiry))
+            .expect("add_order should succeed");
 
         // Despite the expired maker, the match fills it like a standard order.
         let result = price_level.match_order(
@@ -2748,9 +2914,15 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 50));
-        price_level.add_order(create_standard_order(2, 10000, 75));
-        price_level.add_order(create_standard_order(3, 10000, 25));
+        price_level
+            .add_order(create_standard_order(1, 10000, 50))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 75))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(3, 10000, 25))
+            .expect("add_order should succeed");
 
         // Match first two orders completely and third partially
         let taker_id = Id::from_u64(999);
@@ -2803,8 +2975,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
 
         // Add some orders
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 50));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 50))
+            .expect("add_order should succeed");
 
         // Create a snapshot
         let snapshot = price_level.snapshot();
@@ -2833,7 +3009,9 @@ mod tests {
 
         // Add an order
         let order = create_standard_order(1, 10000, 100);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Update the price to a different value
         let update = OrderUpdate::UpdatePrice {
@@ -2855,7 +3033,9 @@ mod tests {
 
         // Test updating price to same value (should return error)
         let order = create_standard_order(2, 10000, 100);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         let same_price_update = OrderUpdate::UpdatePrice {
             order_id: Id::from_u64(2),
@@ -2876,7 +3056,9 @@ mod tests {
 
         // Add an order
         let order = create_standard_order(1, 10000, 100);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Update to increase quantity
         let update = OrderUpdate::UpdateQuantity {
@@ -2931,8 +3113,12 @@ mod tests {
 
         // Add makers A (id 1) then B (id 2) at the same price. A is ahead in
         // price-time priority.
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 100))
+            .expect("add_order should succeed");
 
         // Reduce A's quantity (decrease). A must keep its front position.
         let result = price_level.update_order(OrderUpdate::UpdateQuantity {
@@ -2971,8 +3157,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
 
         // Add makers A (id 1) then B (id 2) at the same price.
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 100))
+            .expect("add_order should succeed");
 
         // Increase A's quantity (Standard orders support resizing). This must
         // demote A to the back of the queue, behind B.
@@ -3011,9 +3201,15 @@ mod tests {
         let price_level = PriceLevel::new(10000);
 
         // Two standard makers plus an iceberg (so hidden_quantity is exercised).
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 100));
-        price_level.add_order(create_iceberg_order(3, 10000, 50, 200));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_iceberg_order(3, 10000, 50, 200))
+            .expect("add_order should succeed");
 
         // Decrease (in place) on a standard order.
         let _ = price_level
@@ -3061,7 +3257,9 @@ mod tests {
 
         // Add an order
         let order = create_standard_order(1, 10000, 100);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Update both price and quantity with different price
         let update = OrderUpdate::UpdatePriceAndQuantity {
@@ -3084,7 +3282,9 @@ mod tests {
 
         // Test with same price but different quantity
         let order = create_standard_order(2, 10000, 100);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         let update = OrderUpdate::UpdatePriceAndQuantity {
             order_id: Id::from_u64(2),
@@ -3111,7 +3311,9 @@ mod tests {
 
         // Add an order
         let order = create_standard_order(1, 10000, 100);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Replace with different price
         let update = OrderUpdate::Replace {
@@ -3135,7 +3337,9 @@ mod tests {
 
         // Test with same price but different quantity
         let order = create_standard_order(2, 10000, 100);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         let update = OrderUpdate::Replace {
             order_id: Id::from_u64(2),
@@ -3163,8 +3367,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
 
         // Add some orders
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 50));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 50))
+            .expect("add_order should succeed");
 
         // Convert to PriceLevelData
         let data: PriceLevelData = (&price_level).into();
@@ -3222,7 +3430,9 @@ mod tests {
     #[test]
     fn test_price_level_display() {
         let price_level = PriceLevel::new(10000);
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let display_str = format!("{price_level}");
 
@@ -3239,11 +3449,21 @@ mod tests {
     #[test]
     fn test_price_level_from_str() {
         let price_level = PriceLevel::new(10000);
-        price_level.add_order(create_standard_order(1, 10000, 50));
-        price_level.add_order(create_standard_order(2, 10000, 75));
-        price_level.add_order(create_good_till_date_order(3, 10000, 100, 1617000000000));
-        price_level.add_order(create_reserve_order(4, 10000, 100, 100, 20, true, None));
-        price_level.add_order(create_iceberg_order(5, 10000, 50, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 50))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 75))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_good_till_date_order(3, 10000, 100, 1617000000000))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_reserve_order(4, 10000, 100, 100, 20, true, None))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_iceberg_order(5, 10000, 50, 100))
+            .expect("add_order should succeed");
 
         let input = "PriceLevel:price=10000;visible_quantity=375;hidden_quantity=200;order_count=5;orders=[Standard:id=00000000-0000-0001-0000-000000000000;price=10000;quantity=50;side=BUY;timestamp=1616823000000;time_in_force=GTC,Standard:id=00000000-0000-0002-0000-000000000000;price=10000;quantity=75;side=BUY;timestamp=1616823000001;time_in_force=GTC,Standard:id=00000000-0000-0003-0000-000000000000;price=10000;quantity=100;side=BUY;timestamp=1616823000002;time_in_force=GTD-1617000000000,ReserveOrder:id=00000000-0000-0004-0000-000000000000;price=10000;visible_quantity=100;hidden_quantity=100;side=SELL;timestamp=1616823000003;time_in_force=GTC;replenish_threshold=20;replenish_amount=None;auto_replenish=true,IcebergOrder:id=00000000-0000-0005-0000-000000000000;price=10000;visible_quantity=50;hidden_quantity=100;side=SELL;timestamp=1616823000004;time_in_force=GTC]";
         let result = PriceLevel::from_str(input);
@@ -3274,7 +3494,9 @@ mod tests {
     #[test]
     fn test_price_level_serde() {
         let price_level = PriceLevel::new(10000);
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Serialize to JSON
         let serialized = serde_json::to_string(&price_level).unwrap();
@@ -3366,7 +3588,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Add orders with more quantity than we'll match
-        price_level.add_order(create_standard_order(1, 10000, 200));
+        price_level
+            .add_order(create_standard_order(1, 10000, 200))
+            .expect("add_order should succeed");
 
         // Match only part of what's available
         let match_result = price_level.match_order(
@@ -3389,7 +3613,9 @@ mod tests {
         let price_level = PriceLevel::new(10000);
 
         // Add an order
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Update to a different price (should remove from this level)
         let result = price_level.update_order(OrderUpdate::UpdatePrice {
@@ -3408,7 +3634,9 @@ mod tests {
         let price_level = PriceLevel::new(10000);
 
         // Add an order
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Update the quantity but keep the same price
         let result = price_level.update_order(OrderUpdate::UpdatePriceAndQuantity {
@@ -3429,8 +3657,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
 
         // Add some orders
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_iceberg_order(2, 10000, 50, 150));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_iceberg_order(2, 10000, 50, 150))
+            .expect("add_order should succeed");
 
         // Serialize to JSON
         let serialized = serde_json::to_string(&price_level).unwrap();
@@ -3465,7 +3697,9 @@ mod tests {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Try to update price to the same value
         let update = OrderUpdate::UpdatePrice {
@@ -3518,7 +3752,9 @@ mod tests {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Set up a test that simulates order removal by another thread
         // This can be done by modifying the OrderQueue's internal state directly
@@ -3564,7 +3800,9 @@ mod tests {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Update to increase quantity (old visible < new visible)
         let update = OrderUpdate::UpdateQuantity {
@@ -3597,7 +3835,9 @@ mod tests {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Verify initial quantities
         assert_eq!(price_level.visible_quantity(), 50);
@@ -3621,7 +3861,9 @@ mod tests {
             order_id: Id::from_u64(1),
         });
         assert!(result.is_ok());
-        price_level.add_order(new_order);
+        price_level
+            .add_order(new_order)
+            .expect("add_order should succeed");
 
         // Verify both visible and hidden quantities were updated
         assert_eq!(price_level.visible_quantity(), 40);
@@ -3644,7 +3886,9 @@ mod tests {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Update both price and quantity with same price
         let update = OrderUpdate::UpdatePriceAndQuantity {
@@ -3680,7 +3924,9 @@ mod tests {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order1);
+        price_level
+            .add_order(order1)
+            .expect("add_order should succeed");
 
         let order2 = OrderType::<()>::IcebergOrder {
             id: Id::from_u64(2),
@@ -3693,7 +3939,9 @@ mod tests {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order2);
+        price_level
+            .add_order(order2)
+            .expect("add_order should succeed");
 
         // Convert to PriceLevelData
         let data: PriceLevelData = (&price_level).into();
@@ -3751,8 +3999,12 @@ mod tests {
         let trade_ids = UuidGenerator::new(namespace);
 
         // A (id=1) arrives before B (id=2), both 100 @ 10000.
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 100))
+            .expect("add_order should succeed");
 
         // First aggressor partially fills A (60 of 100). A's residual = 40.
         let first = price_level.match_order(
@@ -3811,8 +4063,12 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_ids = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 100))
+            .expect("add_order should succeed");
         let total_before = match price_level.total_quantity() {
             Ok(q) => q,
             Err(e) => panic!("total_quantity failed: {e}"),
@@ -3844,9 +4100,13 @@ mod tests {
         let trade_ids = UuidGenerator::new(namespace);
 
         // Iceberg I (id=1) arrives first: visible 50, hidden 100.
-        price_level.add_order(create_iceberg_order(1, 10000, 50, 100));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 50, 100))
+            .expect("add_order should succeed");
         // O (id=2) arrives later: a plain 50 (iceberg with no hidden).
-        price_level.add_order(create_iceberg_order(2, 10000, 50, 0));
+        price_level
+            .add_order(create_iceberg_order(2, 10000, 50, 0))
+            .expect("add_order should succeed");
 
         // Aggressor consumes I's visible tip (50) → I refreshes from hidden and
         // moves to the tail. remaining hits 0, so this call stops there.
@@ -3886,8 +4146,12 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_ids = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 100))
+            .expect("add_order should succeed");
         let _ = price_level.match_order(
             60,
             Id::from_u64(901),
@@ -3990,14 +4254,18 @@ mod tests {
                     let base = (t * ORDERS_PER_THREAD + i) as u64;
                     let id = base * 2 + 1_000;
                     if i % 2 == 0 {
-                        level.add_order(create_standard_order(id, PRICE, 1 + (base % 7)));
+                        level
+                            .add_order(create_standard_order(id, PRICE, 1 + (base % 7)))
+                            .expect("add_order should succeed");
                     } else {
-                        level.add_order(create_iceberg_order(
-                            id,
-                            PRICE,
-                            1 + (base % 5),
-                            1 + (base % 11),
-                        ));
+                        level
+                            .add_order(create_iceberg_order(
+                                id,
+                                PRICE,
+                                1 + (base % 5),
+                                1 + (base % 11),
+                            ))
+                            .expect("add_order should succeed");
                     }
                 }
             }));
@@ -4182,7 +4450,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             40,
@@ -4211,8 +4481,12 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 60));
-        price_level.add_order(create_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_standard_order(1, 10000, 60))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -4238,8 +4512,12 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 30));
-        price_level.add_order(create_standard_order(2, 10000, 30));
+        price_level
+            .add_order(create_standard_order(1, 10000, 30))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 30))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -4266,9 +4544,15 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 40));
-        price_level.add_order(create_standard_order(2, 10000, 30));
-        price_level.add_order(create_standard_order(3, 10000, 50));
+        price_level
+            .add_order(create_standard_order(1, 10000, 40))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 30))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(3, 10000, 50))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             90,
@@ -4320,7 +4604,9 @@ mod tests {
         let trade_id_generator = UuidGenerator::new(namespace);
 
         // visible 50, hidden 200.
-        price_level.add_order(create_iceberg_order(1, 10000, 50, 200));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 50, 200))
+            .expect("add_order should succeed");
 
         // Consume the full visible tranche; the maker replenishes and keeps
         // resting, so it is not in filled_order_ids.
@@ -4350,7 +4636,9 @@ mod tests {
         let trade_id_generator = UuidGenerator::new(namespace);
 
         // visible 50, hidden 200, replenish threshold 10, auto-replenish on.
-        price_level.add_order(create_reserve_order(1, 10000, 50, 200, 10, true, Some(50)));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 50, 200, 10, true, Some(50)))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             50,
@@ -4392,7 +4680,9 @@ mod tests {
 
         let run = || {
             let price_level = PriceLevel::new(10000);
-            price_level.add_order(mk());
+            price_level
+                .add_order(mk())
+                .expect("add_order should succeed");
             let trade_id_generator = UuidGenerator::new(namespace);
             // Cross more than the visible tranche to force replenishment and a
             // multi-trade stream.
@@ -4457,8 +4747,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_iceberg_order(1, 10000, 0, 30));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 0, 30))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         // Counters reflect both orders: visible 0+40, hidden 30+0.
         assert_eq!(price_level.visible_quantity(), 40);
@@ -4498,8 +4792,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_iceberg_order(1, 10000, 0, 30));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 0, 30))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             70,
@@ -4531,8 +4829,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_iceberg_order(1, 10000, 0, 30));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 0, 30))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             71,
@@ -4559,8 +4861,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_iceberg_order(1, 10000, 0, 30));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 0, 30))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             200,
@@ -4593,8 +4899,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_iceberg_order(1, 10000, 0, 30));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 0, 30))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             10,
@@ -4624,7 +4934,9 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_iceberg_order(1, 10000, 0, 25));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 0, 25))
+            .expect("add_order should succeed");
 
         let rejected = price_level.match_order(
             5,
@@ -4667,8 +4979,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_reserve_order(1, 10000, 0, 50, 10, true, Some(20)));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 0, 50, 10, true, Some(20)))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         assert_eq!(price_level.visible_quantity(), 40);
         assert_eq!(price_level.hidden_quantity(), 50);
@@ -4706,8 +5022,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_reserve_order(1, 10000, 0, 50, 10, true, Some(20)));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 0, 50, 10, true, Some(20)))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             90,
@@ -4734,8 +5054,12 @@ mod tests {
         // And FOK of 91 (one over) must be killed with the queue intact.
         let price_level2 = PriceLevel::new(10000);
         let trade_gen2 = new_trade_id_generator();
-        price_level2.add_order(create_reserve_order(1, 10000, 0, 50, 10, true, Some(20)));
-        price_level2.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level2
+            .add_order(create_reserve_order(1, 10000, 0, 50, 10, true, Some(20)))
+            .expect("add_order should succeed");
+        price_level2
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
         let killed = price_level2.match_order(
             91,
             Id::from_u64(999),
@@ -4759,8 +5083,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_reserve_order(1, 10000, 0, 50, 10, false, Some(20)));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 0, 50, 10, false, Some(20)))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         assert_eq!(price_level.visible_quantity(), 40);
         assert_eq!(price_level.hidden_quantity(), 50);
@@ -4804,7 +5132,9 @@ mod tests {
         // FOK pre-check: 0 matchable depth -> killed, queue untouched.
         let fok_level = PriceLevel::new(10000);
         let fok_gen = new_trade_id_generator();
-        fok_level.add_order(create_reserve_order(1, 10000, 0, 50, 10, false, Some(20)));
+        fok_level
+            .add_order(create_reserve_order(1, 10000, 0, 50, 10, false, Some(20)))
+            .expect("add_order should succeed");
 
         let fok = fok_level.match_order(
             5,
@@ -4826,7 +5156,9 @@ mod tests {
         // counters consistent with the queue.
         let po_level = PriceLevel::new(10000);
         let po_gen = new_trade_id_generator();
-        po_level.add_order(create_reserve_order(1, 10000, 0, 50, 10, false, Some(20)));
+        po_level
+            .add_order(create_reserve_order(1, 10000, 0, 50, 10, false, Some(20)))
+            .expect("add_order should succeed");
 
         let post_only = po_level.match_order(
             5,
@@ -4861,8 +5193,12 @@ mod tests {
         let trade_gen = new_trade_id_generator();
 
         // Iceberg with 20 visible / 30 hidden, then a standard maker behind it.
-        price_level.add_order(create_iceberg_order(1, 10000, 20, 30));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 20, 30))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         // Reduce the iceberg's quantity to 0 (degenerate zero-visible state).
         price_level
@@ -4965,16 +5301,18 @@ mod tests {
             let maker_id_u64 = (iter as u64) * 4 + 1;
             let maker_id = Id::from_u64(maker_id_u64);
             // A sell maker so a buy taker crosses it.
-            level.add_order(OrderType::Standard {
-                id: maker_id,
-                price: Price::new(PRICE),
-                quantity: Quantity::new(MAKER_QTY),
-                side: Side::Sell,
-                user_id: Hash32::zero(),
-                timestamp: TimestampMs::new(1_600_000_000_000 + iter as u64),
-                time_in_force: TimeInForce::Gtc,
-                extra_fields: (),
-            });
+            level
+                .add_order(OrderType::Standard {
+                    id: maker_id,
+                    price: Price::new(PRICE),
+                    quantity: Quantity::new(MAKER_QTY),
+                    side: Side::Sell,
+                    user_id: Hash32::zero(),
+                    timestamp: TimestampMs::new(1_600_000_000_000 + iter as u64),
+                    time_in_force: TimeInForce::Gtc,
+                    extra_fields: (),
+                })
+                .expect("add_order should succeed");
 
             let barrier = Arc::new(Barrier::new(2));
             // Deterministic, per-iteration trade-id stream.
@@ -5094,16 +5432,18 @@ mod tests {
             // Add MAKERS sell makers with deterministic ids.
             let base = (iter as u64) * 1_000 + 1;
             for k in 0..MAKERS {
-                level.add_order(OrderType::Standard {
-                    id: Id::from_u64(base + k),
-                    price: Price::new(PRICE),
-                    quantity: Quantity::new(MAKER_QTY),
-                    side: Side::Sell,
-                    user_id: Hash32::zero(),
-                    timestamp: TimestampMs::new(1_600_000_000_000 + iter as u64 * 16 + k),
-                    time_in_force: TimeInForce::Gtc,
-                    extra_fields: (),
-                });
+                level
+                    .add_order(OrderType::Standard {
+                        id: Id::from_u64(base + k),
+                        price: Price::new(PRICE),
+                        quantity: Quantity::new(MAKER_QTY),
+                        side: Side::Sell,
+                        user_id: Hash32::zero(),
+                        timestamp: TimestampMs::new(1_600_000_000_000 + iter as u64 * 16 + k),
+                        time_in_force: TimeInForce::Gtc,
+                        extra_fields: (),
+                    })
+                    .expect("add_order should succeed");
             }
 
             // The matcher will consume the first ~2.5 makers; the canceller
@@ -5207,8 +5547,12 @@ mod tests {
 
         let level = PriceLevel::new(10_000);
         // Insert id 1 FIRST but with a LATER timestamp than id 2 (added second).
-        level.add_order(mk_buy(1, 2_000, 50));
-        level.add_order(mk_buy(2, 1_000, 50));
+        level
+            .add_order(mk_buy(1, 2_000, 50))
+            .expect("add_order should succeed");
+        level
+            .add_order(mk_buy(2, 1_000, 50))
+            .expect("add_order should succeed");
 
         let by_seq: Vec<Id> = level
             .snapshot_by_insertion_seq()
@@ -5259,9 +5603,15 @@ mod tests {
         let level = PriceLevel::new(10_000);
         // Three standard makers with monotonic timestamps (TIMESTAMP_COUNTER),
         // so insertion sequence and timestamp order initially agree.
-        level.add_order(create_standard_order(1, 10_000, 100));
-        level.add_order(create_standard_order(2, 10_000, 100));
-        level.add_order(create_standard_order(3, 10_000, 100));
+        level
+            .add_order(create_standard_order(1, 10_000, 100))
+            .expect("add_order should succeed");
+        level
+            .add_order(create_standard_order(2, 10_000, 100))
+            .expect("add_order should succeed");
+        level
+            .add_order(create_standard_order(3, 10_000, 100))
+            .expect("add_order should succeed");
 
         // Upsize maker 1 (Standard orders resize): total increases 100 -> 150,
         // so update_order takes the quantity-increase branch and demotes it to
@@ -5350,9 +5700,13 @@ mod tests {
         // front priority.
         let level = PriceLevel::new(10_000);
         // Iceberg maker (id 1, Sell) added first: visible 50 over hidden 100.
-        level.add_order(create_iceberg_order(1, 10_000, 50, 100));
+        level
+            .add_order(create_iceberg_order(1, 10_000, 50, 100))
+            .expect("add_order should succeed");
         // A plain Sell maker (id 2) rests behind it.
-        level.add_order(create_sell_standard_order(2, 10_000, 100));
+        level
+            .add_order(create_sell_standard_order(2, 10_000, 100))
+            .expect("add_order should succeed");
 
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let generator = UuidGenerator::new(namespace);
@@ -5453,7 +5807,9 @@ mod tests {
         // N resting standard makers with known ids 1..=N and initial quantity
         // 100 (monotonic timestamps via the shared counter).
         for id in 1..=N as u64 {
-            level.add_order(create_standard_order(id, 10_000, 100));
+            level
+                .add_order(create_standard_order(id, 10_000, 100))
+                .expect("add_order should succeed");
         }
 
         // Barrier aligns the single writer with the readers so the resequencing
@@ -5559,8 +5915,12 @@ mod tests {
     #[test]
     fn test_snapshot_by_insertion_seq_partial_fill_keeps_front() {
         let level = PriceLevel::new(10_000);
-        level.add_order(create_standard_order(1, 10_000, 100));
-        level.add_order(create_standard_order(2, 10_000, 50));
+        level
+            .add_order(create_standard_order(1, 10_000, 100))
+            .expect("add_order should succeed");
+        level
+            .add_order(create_standard_order(2, 10_000, 50))
+            .expect("add_order should succeed");
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let generator = UuidGenerator::new(namespace);
         // Small taker partially fills the front maker (id 1): KeepInPlace, same seq.
@@ -5588,9 +5948,13 @@ mod tests {
     fn test_snapshot_by_insertion_seq_replenished_maker_moves_to_tail() {
         let level = PriceLevel::new(10_000);
         // Iceberg (id 1, Sell) added first: visible 10 over hidden 40.
-        level.add_order(create_iceberg_order(1, 10_000, 10, 40));
+        level
+            .add_order(create_iceberg_order(1, 10_000, 10, 40))
+            .expect("add_order should succeed");
         // A plain Sell maker (id 2) rests behind it.
-        level.add_order(create_sell_standard_order(2, 10_000, 100));
+        level
+            .add_order(create_sell_standard_order(2, 10_000, 100))
+            .expect("add_order should succeed");
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let generator = UuidGenerator::new(namespace);
         // Fully consume the iceberg's visible tranche (10): it replenishes from
@@ -5623,9 +5987,15 @@ mod tests {
     #[test]
     fn test_snapshot_by_seq_into_matches_snapshot_by_insertion_seq() {
         let level = PriceLevel::new(10_000);
-        level.add_order(create_standard_order(1, 10_000, 100));
-        level.add_order(create_standard_order(2, 10_000, 50));
-        level.add_order(create_iceberg_order(3, 10_000, 20, 30));
+        level
+            .add_order(create_standard_order(1, 10_000, 100))
+            .expect("add_order should succeed");
+        level
+            .add_order(create_standard_order(2, 10_000, 50))
+            .expect("add_order should succeed");
+        level
+            .add_order(create_iceberg_order(3, 10_000, 20, 30))
+            .expect("add_order should succeed");
 
         let owned: Vec<Id> = level
             .snapshot_by_insertion_seq()
@@ -5655,16 +6025,21 @@ mod tests {
         // starts non-empty (proving `clear()` discards the prior contents
         // rather than appending to them).
         let big = PriceLevel::new(10_000);
-        big.add_order(create_standard_order(1, 10_000, 100));
-        big.add_order(create_standard_order(2, 10_000, 100));
-        big.add_order(create_standard_order(3, 10_000, 100));
+        big.add_order(create_standard_order(1, 10_000, 100))
+            .expect("add_order should succeed");
+        big.add_order(create_standard_order(2, 10_000, 100))
+            .expect("add_order should succeed");
+        big.add_order(create_standard_order(3, 10_000, 100))
+            .expect("add_order should succeed");
         let mut buf = big.snapshot_by_insertion_seq();
         assert_eq!(buf.len(), 3);
 
         // Reuse the same buffer on a SMALLER level: it must shrink to one entry
         // with no stale tail left over from the previous three.
         let small = PriceLevel::new(10_000);
-        small.add_order(create_standard_order(10, 10_000, 100));
+        small
+            .add_order(create_standard_order(10, 10_000, 100))
+            .expect("add_order should succeed");
         small.snapshot_by_seq_into(&mut buf);
         let ids: Vec<Id> = buf.iter().map(|o| o.id()).collect();
         assert_eq!(
@@ -5677,7 +6052,9 @@ mod tests {
         // exactly the new contents in insertion order.
         let bigger = PriceLevel::new(10_000);
         for id in [20_u64, 21, 22, 23] {
-            bigger.add_order(create_standard_order(id, 10_000, 100));
+            bigger
+                .add_order(create_standard_order(id, 10_000, 100))
+                .expect("add_order should succeed");
         }
         bigger.snapshot_by_seq_into(&mut buf);
         let ids: Vec<Id> = buf.iter().map(|o| o.id()).collect();
@@ -5699,8 +6076,12 @@ mod tests {
 
         // Plain makers: 100 + 50 = 150 of depth.
         let level = PriceLevel::new(10_000);
-        level.add_order(create_standard_order(1, 10_000, 100));
-        level.add_order(create_standard_order(2, 10_000, 50));
+        level
+            .add_order(create_standard_order(1, 10_000, 100))
+            .expect("add_order should succeed");
+        level
+            .add_order(create_standard_order(2, 10_000, 50))
+            .expect("add_order should succeed");
 
         assert_eq!(level.matchable_quantity(0), 0, "zero taker fills nothing");
         assert_eq!(level.matchable_quantity(120), 120, "taker below depth");
@@ -5728,7 +6109,8 @@ mod tests {
         // Iceberg replenish: visible 10 over hidden 40 = 50 of total depth, all
         // reachable across replenishment.
         let ice = PriceLevel::new(10_000);
-        ice.add_order(create_iceberg_order(1, 10_000, 10, 40));
+        ice.add_order(create_iceberg_order(1, 10_000, 10, 40))
+            .expect("add_order should succeed");
         let predicted_ice = ice.matchable_quantity(100);
         assert_eq!(
             predicted_ice, 50,
@@ -5760,7 +6142,9 @@ mod tests {
         // A deep level: 200 resting makers.
         let level = PriceLevel::new(10_000);
         for id in 1..=200_u64 {
-            level.add_order(create_standard_order(id, 10_000, 100));
+            level
+                .add_order(create_standard_order(id, 10_000, 100))
+                .expect("add_order should succeed");
         }
         assert_eq!(level.order_count(), 200, "level is deep");
 
@@ -5793,7 +6177,9 @@ mod tests {
         // A shallow level: 3 makers, 300 units of depth.
         let level = PriceLevel::new(10_000);
         for id in 1..=3_u64 {
-            level.add_order(create_standard_order(id, 10_000, 100));
+            level
+                .add_order(create_standard_order(id, 10_000, 100))
+                .expect("add_order should succeed");
         }
         assert_eq!(level.order_count(), 3, "level is shallow");
 
@@ -5816,6 +6202,229 @@ mod tests {
             "trade buffer must be bounded by order count (3), not the incoming \
              quantity (10000); was {}",
             result.trades().as_vec().capacity()
+        );
+    }
+    // ------------------------------------------------------------------
+    // Issue #111 — reject quantity overflow BEFORE mutating level state
+    // ------------------------------------------------------------------
+    //
+    // `order_count` overflow (usize::MAX resting orders) is not directly
+    // testable — it would require ~1.8e19 live orders. It is covered by the
+    // same checked `fetch_update` mechanism as the visible / hidden counters
+    // below; a unit test cannot reach it, so it is exercised structurally
+    // (identical code path) rather than by admitting that many orders.
+
+    #[test]
+    fn test_add_order_visible_quantity_overflow_rejected() {
+        let level = PriceLevel::new(10_000);
+        // Take the visible counter all the way to u64::MAX.
+        level
+            .add_order(create_standard_order(1, 10_000, u64::MAX))
+            .expect("first admission at u64::MAX visible must succeed");
+
+        // Capture the full level state before the failing admission.
+        let before_json = level
+            .snapshot_to_json()
+            .expect("snapshot before must serialize");
+        let before_visible = level.visible_quantity();
+        let before_hidden = level.hidden_quantity();
+        let before_count = level.order_count();
+
+        // Admitting even one more unit would overflow the visible counter.
+        match level.add_order(create_standard_order(2, 10_000, 1)) {
+            Err(PriceLevelError::InvalidOperation { message }) => {
+                assert!(
+                    message.contains("visible quantity overflow"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected visible-overflow InvalidOperation, got {other:?}"),
+        }
+
+        // Nothing mutated: counters, count, and a byte-identical snapshot.
+        assert_eq!(level.visible_quantity(), before_visible);
+        assert_eq!(level.hidden_quantity(), before_hidden);
+        assert_eq!(level.order_count(), before_count);
+        assert_eq!(before_count, 1);
+        let after_json = level
+            .snapshot_to_json()
+            .expect("snapshot after must serialize");
+        assert_eq!(
+            before_json, after_json,
+            "a rejected admission must leave the snapshot byte-identical"
+        );
+
+        // The snapshot still round-trips, and the rejected order is absent.
+        let restored =
+            PriceLevel::from_snapshot_json(&after_json).expect("snapshot must round-trip");
+        assert_eq!(restored.visible_quantity(), u64::MAX);
+        assert_eq!(restored.order_count(), 1);
+        let ids: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+        assert_eq!(ids, vec![Id::from_u64(1)]);
+    }
+
+    #[test]
+    fn test_add_order_hidden_quantity_overflow_rejected() {
+        let level = PriceLevel::new(10_000);
+        // Take the hidden counter to u64::MAX with a hidden-only iceberg.
+        level
+            .add_order(create_iceberg_order(1, 10_000, 0, u64::MAX))
+            .expect("first admission at u64::MAX hidden must succeed");
+
+        let before_visible = level.visible_quantity();
+        let before_hidden = level.hidden_quantity();
+        let before_count = level.order_count();
+
+        match level.add_order(create_iceberg_order(2, 10_000, 0, 1)) {
+            Err(PriceLevelError::InvalidOperation { message }) => {
+                assert!(
+                    message.contains("hidden quantity overflow"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected hidden-overflow InvalidOperation, got {other:?}"),
+        }
+
+        // The visible reservation the failing call briefly took is rolled back,
+        // so no counter drifts.
+        assert_eq!(level.visible_quantity(), before_visible);
+        assert_eq!(level.hidden_quantity(), before_hidden);
+        assert_eq!(level.order_count(), before_count);
+        assert_eq!(before_count, 1);
+        assert_eq!(level.hidden_quantity(), u64::MAX);
+    }
+
+    #[test]
+    fn test_add_order_boundary_sum_reaches_u64_max_succeeds() {
+        let level = PriceLevel::new(10_000);
+        // Two admissions whose visible quantities sum to EXACTLY u64::MAX must
+        // both succeed — the boundary is inclusive.
+        level
+            .add_order(create_standard_order(1, 10_000, u64::MAX - 10))
+            .expect("first admission must succeed");
+        level
+            .add_order(create_standard_order(2, 10_000, 10))
+            .expect("admission reaching exactly u64::MAX must succeed");
+
+        assert_eq!(level.visible_quantity(), u64::MAX);
+        assert_eq!(level.order_count(), 2);
+
+        // Counter == snapshot aggregate == sum over the queue contents.
+        let snapshot = level.snapshot();
+        assert_eq!(snapshot.visible_quantity().as_u64(), u64::MAX);
+        let queue_sum = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .try_fold(0u64, |acc, o| {
+                acc.checked_add(o.visible_quantity().as_u64())
+            })
+            .expect("boundary sum is exactly u64::MAX, no overflow");
+        assert_eq!(queue_sum, u64::MAX);
+    }
+
+    #[test]
+    fn test_reserve_replenish_overflow_no_trade_maker_preserved() {
+        // A reserve whose visible + hidden exceed u64::MAX is admissible (the
+        // two are separate u64 counters). A partial match that would replenish
+        // it computes `new_visible + replenish_qty`, which overflows u64. The
+        // match step must fail atomically: no trade, maker unchanged, no panic
+        // (this test runs under debug assertions, where an unchecked `+` would
+        // panic).
+        let level = PriceLevel::new(10_000);
+        level
+            .add_order(create_reserve_order(
+                1,
+                10_000,
+                u64::MAX,       // visible
+                u64::MAX,       // hidden
+                u64::MAX,       // threshold: any partial fill falls below -> replenish
+                true,           // auto_replenish
+                Some(u64::MAX), // replenish amount: draws the full hidden
+            ))
+            .expect("reserve with separately-valid u64 components must admit");
+
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let generator = UuidGenerator::new(namespace);
+        // A tiny taker triggers a partial fill and the overflowing replenish.
+        let result = level.match_order(
+            1,
+            Id::from_u64(999),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(1_700_000_000_000),
+            &generator,
+        );
+
+        // No trade emitted and the taker is left fully unconsumed.
+        assert_eq!(
+            result.trades().len(),
+            0,
+            "an overflowing replenish must emit no trade"
+        );
+        assert_eq!(
+            result.remaining_quantity().as_u64(),
+            1,
+            "the taker must be left fully unconsumed"
+        );
+
+        // The maker is still resting, unchanged.
+        let resting = level.snapshot_by_insertion_seq();
+        assert_eq!(resting.len(), 1, "the maker must still rest");
+        assert_eq!(resting[0].id(), Id::from_u64(1));
+        assert_eq!(
+            resting[0].visible_quantity().as_u64(),
+            u64::MAX,
+            "maker visible quantity must be unchanged"
+        );
+        assert_eq!(
+            resting[0].hidden_quantity().as_u64(),
+            u64::MAX,
+            "maker hidden quantity must be unchanged"
+        );
+    }
+
+    #[test]
+    fn test_add_order_normal_flow_fifo_unchanged() {
+        // Sanity: the now-fallible add_order preserves normal admission and
+        // strict FIFO consumption for in-range quantities.
+        let level = PriceLevel::new(10_000);
+        level
+            .add_order(create_standard_order(1, 10_000, 30))
+            .expect("admission ok");
+        level
+            .add_order(create_standard_order(2, 10_000, 20))
+            .expect("admission ok");
+        level
+            .add_order(create_standard_order(3, 10_000, 50))
+            .expect("admission ok");
+
+        assert_eq!(level.visible_quantity(), 100);
+        assert_eq!(level.order_count(), 3);
+
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let generator = UuidGenerator::new(namespace);
+        let result = level.match_order(
+            100,
+            Id::from_u64(999),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(1_700_000_000_000),
+            &generator,
+        );
+        let makers: Vec<Id> = result
+            .trades()
+            .as_vec()
+            .iter()
+            .map(|t| t.maker_order_id())
+            .collect();
+        assert_eq!(
+            makers,
+            vec![Id::from_u64(1), Id::from_u64(2), Id::from_u64(3)],
+            "FIFO consumption order must be unchanged"
         );
     }
 }

--- a/tests/proptest/properties.rs
+++ b/tests/proptest/properties.rs
@@ -39,7 +39,9 @@ fn build_level(makers: &[Maker]) -> PriceLevel {
     let level = PriceLevel::new(LEVEL_PRICE);
     for maker in makers {
         // `OrderType<()>` is `Copy`, so this rests a copy of the maker order.
-        let _ = level.add_order(maker.order);
+        let _ = level
+            .add_order(maker.order)
+            .expect("add_order should succeed");
     }
     level
 }
@@ -474,7 +476,7 @@ proptest! {
                 extra_fields: (),
             }
         };
-        let _ = level.add_order(order);
+        let _ = level.add_order(order).expect("add_order should succeed");
         let generator = trade_ids();
 
         let total_before = level

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -36,8 +36,12 @@ fn partial_fill_keeps_price_time_priority_across_calls() {
     let trade_ids = UuidGenerator::new(namespace);
 
     // A (id=1) rests before B (id=2); both 100 @ 10_000.
-    level.add_order(standard_buy(1, 10_000, 100, 1_000));
-    level.add_order(standard_buy(2, 10_000, 100, 1_001));
+    level
+        .add_order(standard_buy(1, 10_000, 100, 1_000))
+        .expect("add_order should succeed");
+    level
+        .add_order(standard_buy(2, 10_000, 100, 1_001))
+        .expect("add_order should succeed");
 
     // Partially fill A.
     let first = level.match_order(


### PR DESCRIPTION
## Summary

`add_order` published the order to the queue and then `fetch_add`-ed the
counters, so near `u64::MAX` the counters wrapped while the queue held the
admitted order. Reserve partial matching computed `new_visible +
replenish_qty` with a bare add — panic in debug, wrap in release. Admission
now validates before mutating, and the replenish add is checked.

## Stack

- **Stack:** #118 → #114 → #116 → #111 → #113 → #120 → #119 → #115 → #117 → #112 (**this is 4/10**)
- **Base branch:** `stack/3-116-validated-decode`
- **Stacked on:** #123 — **the diff vs `main` is cumulative**; review against the base branch.

## Changes

- **BREAKING:** `PriceLevel::add_order` returns `Result<Arc<OrderType<()>>,
  PriceLevelError>`. Capacity is reserved on the three advisory counters
  *before* queue publication via `fetch_update(checked_add)` CAS loops (no
  check-then-add TOCTOU); on overflow the call rolls back its own reservations
  and returns `InvalidOperation` with the level completely unchanged.
- Reserve replenishment overflow is checked and surfaces as the existing
  no-progress sentinel — handled identically by the real sweep (`SetAside`)
  and the FOK dry run (drop from pending), so they cannot diverge; no trade,
  maker and taker preserved.
- Migration guide entry in `lib.rs`; `README.md` regenerated via `make
  readme`; ~274 call sites migrated across tests / examples / benches.

## Technical decisions

- Counters now transiently *lead* the queue (previously lagged) — safe because
  `snapshot()` folds all aggregates from the materialized queue (the #109
  invariant) and the bare accessors are documented advisory. Verified by
  `concurrency-auditor`: rollback underflow impossible (every decrement
  elsewhere is keyed off orders actually removed under the per-entry lock),
  `Relaxed` orderings correct for advisory counters, commit safe with 0 P1/P2.
- The auditor also confirmed a **pre-existing** unchecked counter-delta in
  `update_order` (level counter can wrap on extreme upsize) — deliberately
  deferred to #115 in this same stack, whose charter is the `UpdateQuantity`
  redesign.

## Public API impact

- `PriceLevel::add_order` signature change (breaking). Migration guide updated
  in `src/lib.rs`; `README.md` regenerated. No re-export changes.

## Testing

- [x] Boundary tests: visible / hidden overflow rejected with the level
  byte-identical before and after (including snapshot JSON round-trip);
  admissions summing exactly to `u64::MAX` succeed with counter == snapshot ==
  queue sum
- [x] Reserve replenish overflow: no trade, taker unconsumed, maker unchanged,
  no panic under debug assertions
- [x] FIFO sanity for normal flows
- [x] Pre-push checks clean locally

472 tests passed; 0 failed (453 lib + 9 + 1 + 9 doctests).

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic — no `saturating_*` / `wrapping_*`
- [x] Non-`SeqCst` orderings justified (advisory counters, issue #68 contract)
- [x] No new production `unsafe`, no new dependencies
- [x] Migration guide + README updated for the breaking signature

Closes #111


- **Blocks:** #125
