### PR TITLE
Reject duplicate order ids atomically (#113)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pricelevel"
-version = "0.8.5"
+version = "0.9.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."

--- a/README.md
+++ b/README.md
@@ -498,6 +498,21 @@ before; the snapshot format version is **not** bumped and the SHA-256
 checksum over an unchanged payload still validates. Existing snapshot JSON
 restores without migration.
 
+### Migration Guide (`PriceLevel::add_order` is now checked — breaking)
+
+[`PriceLevel::add_order`] now returns
+`Result<Arc<OrderType<()>>, PriceLevelError>` instead of
+`Arc<OrderType<()>>`. It reserves the order's visible / hidden quantity and
+its count slot on the level's atomic counters (with checked `fetch_update`)
+**before** publishing the order to the queue, and returns
+[`PriceLevelError::InvalidOperation`] if any counter would overflow `u64` —
+leaving the level completely unchanged rather than wrapping a counter while
+the queue already holds the admitted order. Callers must handle the
+`Result` — propagate with `level.add_order(order)?` (test fixtures and
+binaries may prefer `.expect(...)`); the returned `Arc` is unchanged on
+success. Admissions that stay within `u64` (all normal use) behave exactly
+as before.
+
 
  ## Setup Instructions
 

--- a/README.md
+++ b/README.md
@@ -513,6 +513,16 @@ binaries may prefer `.expect(...)`); the returned `Arc` is unchanged on
 success. Admissions that stay within `u64` (all normal use) behave exactly
 as before.
 
+`add_order` also now **rejects a duplicate id**: publishing is an
+insert-if-absent, so reusing the id of an order already resting at the level
+returns the new [`PriceLevelError::DuplicateOrderId`] variant (again leaving
+the level unchanged) instead of overwriting the live order and leaving the
+id-keyed map and the ordered index disagreeing. Snapshot restore
+([`PriceLevel::from_snapshot`] and the JSON / package forms) likewise
+rejects an orders vector that repeats an id rather than silently
+overwriting. Submitting genuinely distinct ids (all normal use) is
+unaffected.
+
 
  ## Setup Instructions
 

--- a/README.md
+++ b/README.md
@@ -523,6 +523,29 @@ rejects an orders vector that repeats an id rather than silently
 overwriting. Submitting genuinely distinct ids (all normal use) is
 unaffected.
 
+### Migration Guide (v0.9 — duplicate-id safety on restore + queue surface)
+
+Three intentional breaking changes remove infallible / overwriting paths
+that could desync a level's counters from its queue:
+
+- **`impl From<&PriceLevelSnapshot> for PriceLevel` is removed; use
+  [`TryFrom`].** The old `From` swallowed aggregate-overflow errors and built
+  the queue keep-first, so a snapshot repeating an id restored counters
+  computed over every copy while the queue kept one. Replace
+  `PriceLevel::from(&snapshot)` / `let lvl: PriceLevel = (&snapshot).into();`
+  with `PriceLevel::try_from(&snapshot)?` (or `.expect(...)` in tests). It
+  delegates to [`PriceLevel::from_snapshot`], returning
+  [`PriceLevelError::DuplicateOrderId`] on a repeated id and the
+  per-order / level aggregate-overflow errors instead of hiding them.
+- **`OrderQueue::push` is now `pub(crate)`.** Unconditional overwriting
+  publication is never safe for an external caller (reusing a live id would
+  silently replace the resting order and strand its old index entry).
+  Admission goes through `add_order` (or, at the queue layer, the
+  insert-if-absent `try_push`); there is no public overwriting insert.
+- **`OrderQueue::from_vec` is now `pub(crate)`.** It is a keep-first
+  constructor that drops duplicates silently; the public restore path is
+  [`PriceLevel::from_snapshot`], which rejects them.
+
 
  ## Setup Instructions
 

--- a/benches/concurrent/contention.rs
+++ b/benches/concurrent/contention.rs
@@ -64,7 +64,9 @@ fn measure_read_write_contention(
     // Pre-populate with orders to read/match against
     for i in 0..500 {
         let order = create_standard_order(i, 10000, 10);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     let mut handles = Vec::with_capacity(thread_count);
@@ -102,7 +104,9 @@ fn measure_read_write_contention(
                             // Add a new order
                             let base_id = thread_id as u64 * 1_000_000 + i;
                             let order = create_standard_order(base_id, 10000, 10);
-                            thread_price_level.add_order(order);
+                            thread_price_level
+                                .add_order(order)
+                                .expect("add_order should succeed");
                         }
                         1 => {
                             // Match against existing orders
@@ -164,13 +168,17 @@ fn measure_hot_spot_contention(
     // First 20 orders are the "hot spot" that may be contended
     for i in 0..20 {
         let order = create_standard_order(i, 10000, 10);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     // Additional 980 orders for the non-hot spot operations
     for i in 20..1000 {
         let order = create_standard_order(i, 10000, 10);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     let mut handles = Vec::with_capacity(thread_count);
@@ -212,7 +220,9 @@ fn measure_hot_spot_contention(
                         // Add a new order to replace canceled ones
                         let base_id = order_idx;
                         let order = create_standard_order(base_id, 10000, 10);
-                        thread_price_level.add_order(order);
+                        thread_price_level
+                            .add_order(order)
+                            .expect("add_order should succeed");
                     }
                     2 => {
                         // Update quantity

--- a/benches/concurrent/register.rs
+++ b/benches/concurrent/register.rs
@@ -26,7 +26,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
                             // Each thread adds orders with unique IDs
                             let base_id = thread_id as u64 * 1_000_000 + iteration;
                             let order = create_standard_order(base_id, 10000, 100);
-                            price_level.add_order(order);
+                            price_level
+                                .add_order(order)
+                                .expect("add_order should succeed");
                         },
                     )
                 });
@@ -51,7 +53,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
                                 3 => create_reserve_order(base_id, 10000, 50, 150, 10, true, None),
                                 _ => create_pegged_order(base_id, 10000, 100),
                             };
-                            price_level.add_order(order);
+                            price_level
+                                .add_order(order)
+                                .expect("add_order should succeed");
                         },
                     )
                 });
@@ -231,7 +235,9 @@ where
         for i in 0..100 {
             let order_id = thread_id as u64 * 100 + i;
             let order = create_standard_order(order_id, 10000, 10);
-            initial_price_level.add_order(order);
+            initial_price_level
+                .add_order(order)
+                .expect("add_order should succeed");
         }
     }
 
@@ -288,7 +294,9 @@ fn measure_concurrent_mixed_operations(thread_count: usize, iterations: u64) -> 
     // Pre-populate with some orders
     for i in 0..200 {
         let order = create_standard_order(i, 10000, 10);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     let mut handles = Vec::with_capacity(thread_count);
@@ -309,7 +317,9 @@ fn measure_concurrent_mixed_operations(thread_count: usize, iterations: u64) -> 
                         // Add a new order
                         let base_id = thread_id as u64 * 1_000_000 + i;
                         let order = create_standard_order(base_id, 10000, 10);
-                        thread_price_level.add_order(order);
+                        thread_price_level
+                            .add_order(order)
+                            .expect("add_order should succeed");
                     }
                     1 => {
                         // Match against existing orders
@@ -462,7 +472,9 @@ fn setup_standard_orders(order_count: u64) -> PriceLevel {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     price_level

--- a/benches/price_level/add_orders.rs
+++ b/benches/price_level/add_orders.rs
@@ -15,7 +15,11 @@ pub fn register_benchmarks(c: &mut Criterion) {
             let price_level = PriceLevel::new(10000);
             for i in 0..100 {
                 let order = create_standard_order(i, 10000, 100);
-                black_box(price_level.add_order(order));
+                black_box(
+                    price_level
+                        .add_order(order)
+                        .expect("add_order should succeed"),
+                );
             }
         })
     });
@@ -26,7 +30,11 @@ pub fn register_benchmarks(c: &mut Criterion) {
             let price_level = PriceLevel::new(10000);
             for i in 0..100 {
                 let order = create_iceberg_order(i, 10000, 50, 150);
-                black_box(price_level.add_order(order));
+                black_box(
+                    price_level
+                        .add_order(order)
+                        .expect("add_order should succeed"),
+                );
             }
         })
     });
@@ -37,7 +45,11 @@ pub fn register_benchmarks(c: &mut Criterion) {
             let price_level = PriceLevel::new(10000);
             for i in 0..100 {
                 let order = create_reserve_order(i, 10000, 50, 150, 10, true, None);
-                black_box(price_level.add_order(order));
+                black_box(
+                    price_level
+                        .add_order(order)
+                        .expect("add_order should succeed"),
+                );
             }
         })
     });
@@ -54,7 +66,11 @@ pub fn register_benchmarks(c: &mut Criterion) {
                     3 => create_reserve_order(i, 10000, 50, 150, 10, true, None),
                     _ => create_pegged_order(i, 10000, 100),
                 };
-                black_box(price_level.add_order(order));
+                black_box(
+                    price_level
+                        .add_order(order)
+                        .expect("add_order should succeed"),
+                );
             }
         })
     });
@@ -69,7 +85,11 @@ pub fn register_benchmarks(c: &mut Criterion) {
                     let price_level = PriceLevel::new(10000);
                     for i in 0..order_count {
                         let order = create_standard_order(i, 10000, 100);
-                        black_box(price_level.add_order(order));
+                        black_box(
+                            price_level
+                                .add_order(order)
+                                .expect("add_order should succeed"),
+                        );
                     }
                 })
             },

--- a/benches/price_level/checked_arithmetic.rs
+++ b/benches/price_level/checked_arithmetic.rs
@@ -133,16 +133,18 @@ pub fn register_benchmarks(c: &mut Criterion) {
 fn setup_standard_level(order_count: u64) -> PriceLevel {
     let level = PriceLevel::new(10000);
     for i in 0..order_count {
-        level.add_order(OrderType::Standard {
-            id: Id::from_u64(i),
-            price: Price::new(10000),
-            quantity: Quantity::new(10),
-            side: Side::Buy,
-            user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(1_616_823_000_000 + i),
-            time_in_force: TimeInForce::Gtc,
-            extra_fields: (),
-        });
+        level
+            .add_order(OrderType::Standard {
+                id: Id::from_u64(i),
+                price: Price::new(10000),
+                quantity: Quantity::new(10),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_616_823_000_000 + i),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
     }
     level
 }
@@ -188,7 +190,7 @@ fn setup_mixed_level(order_count: u64) -> PriceLevel {
                 extra_fields: (),
             },
         };
-        level.add_order(order);
+        level.add_order(order).expect("add_order should succeed");
     }
     level
 }

--- a/benches/price_level/iter_orders.rs
+++ b/benches/price_level/iter_orders.rs
@@ -63,7 +63,9 @@ fn setup_level(order_count: u64) -> PriceLevel {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
     price_level
 }

--- a/benches/price_level/lifecycle.rs
+++ b/benches/price_level/lifecycle.rs
@@ -20,7 +20,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
 
             // Phase 1: Add 100 orders
             for i in 0..100_u64 {
-                level.add_order(create_standard_order(i, 10000, 50));
+                level
+                    .add_order(create_standard_order(i, 10000, 50))
+                    .expect("add_order should succeed");
             }
 
             // Phase 2: Update quantity on 20 orders
@@ -76,7 +78,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
                     ));
                 } else {
                     // Add order
-                    level.add_order(create_standard_order(i, 10000, 20));
+                    level
+                        .add_order(create_standard_order(i, 10000, 20))
+                        .expect("add_order should succeed");
                 }
             }
             black_box(level.order_count());
@@ -90,7 +94,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
 
             // Add 200 orders
             for i in 0..200_u64 {
-                level.add_order(create_standard_order(i, 10000, 10));
+                level
+                    .add_order(create_standard_order(i, 10000, 10))
+                    .expect("add_order should succeed");
             }
 
             // Cancel 150 of them
@@ -112,7 +118,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
 
             // Add 100 orders with quantity 10 each = 1000 total
             for i in 0..100_u64 {
-                level.add_order(create_standard_order(i, 10000, 10));
+                level
+                    .add_order(create_standard_order(i, 10000, 10))
+                    .expect("add_order should succeed");
             }
 
             // Drain completely
@@ -136,7 +144,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
 
             // Add 100 orders
             for i in 0..100_u64 {
-                level.add_order(create_standard_order(i, 10000, 50));
+                level
+                    .add_order(create_standard_order(i, 10000, 50))
+                    .expect("add_order should succeed");
             }
 
             // Replace 50 orders (same price = quantity update)
@@ -169,7 +179,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
             let level = PriceLevel::new(10000);
 
             for i in 0..100_u64 {
-                level.add_order(create_standard_order(i, 10000, 20));
+                level
+                    .add_order(create_standard_order(i, 10000, 20))
+                    .expect("add_order should succeed");
 
                 // Query stats every 10 adds
                 if i % 10 == 0 {

--- a/benches/price_level/match_orders.rs
+++ b/benches/price_level/match_orders.rs
@@ -189,7 +189,9 @@ fn setup_standard_orders(order_count: u64) -> PriceLevel {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     price_level
@@ -211,7 +213,9 @@ fn setup_iceberg_orders(order_count: u64) -> PriceLevel {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     price_level
@@ -236,7 +240,9 @@ fn setup_reserve_orders(order_count: u64) -> PriceLevel {
             auto_replenish: true,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     price_level
@@ -284,7 +290,9 @@ fn setup_mixed_orders(order_count: u64) -> PriceLevel {
                 extra_fields: (),
             },
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     price_level

--- a/benches/price_level/mixed_operations.rs
+++ b/benches/price_level/mixed_operations.rs
@@ -25,7 +25,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
                     7..=8 => create_iceberg_order(i, 10000, 5, 15),
                     _ => create_reserve_order(i, 10000, 5, 15, 2, true, None),
                 };
-                price_level.add_order(order);
+                price_level
+                    .add_order(order)
+                    .expect("add_order should succeed");
             }
 
             // Phase 2: Execute some matches
@@ -61,7 +63,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
                     7..=8 => create_iceberg_order(i, 10000, 5, 15),
                     _ => create_reserve_order(i, 10000, 5, 15, 2, true, None),
                 };
-                price_level.add_order(order);
+                price_level
+                    .add_order(order)
+                    .expect("add_order should succeed");
             }
 
             // Phase 5: Execute final matches
@@ -88,7 +92,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
             // Add initial orders
             for i in 0..200 {
                 let order = create_standard_order(i, 10000, 5);
-                price_level.add_order(order);
+                price_level
+                    .add_order(order)
+                    .expect("add_order should succeed");
             }
 
             // Execute many small matches interspersed with new orders and cancellations
@@ -105,7 +111,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
 
                 // Add a new order
                 let order = create_standard_order(200 + i, 10000, 5);
-                price_level.add_order(order);
+                price_level
+                    .add_order(order)
+                    .expect("add_order should succeed");
 
                 // Cancel an order
                 if i % 10 == 0 {
@@ -127,7 +135,9 @@ pub fn register_benchmarks(c: &mut Criterion) {
             // Add a large number of small orders
             for i in 0..500 {
                 let order = create_standard_order(i, 10000, 2);
-                price_level.add_order(order);
+                price_level
+                    .add_order(order)
+                    .expect("add_order should succeed");
             }
 
             // Execute a few large matches
@@ -240,7 +250,9 @@ fn setup_mixed_orders(order_count: u64) -> PriceLevel {
             1 => create_iceberg_order(i, 10000, 5, 15),
             _ => create_reserve_order(i, 10000, 5, 15, 2, true, None),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     price_level

--- a/benches/price_level/serialization.rs
+++ b/benches/price_level/serialization.rs
@@ -134,16 +134,18 @@ pub fn register_benchmarks(c: &mut Criterion) {
 fn setup_standard_level(order_count: u64) -> PriceLevel {
     let level = PriceLevel::new(10000);
     for i in 0..order_count {
-        level.add_order(OrderType::Standard {
-            id: Id::from_u64(i),
-            price: Price::new(10000),
-            quantity: Quantity::new(10),
-            side: Side::Buy,
-            user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(1_616_823_000_000 + i),
-            time_in_force: TimeInForce::Gtc,
-            extra_fields: (),
-        });
+        level
+            .add_order(OrderType::Standard {
+                id: Id::from_u64(i),
+                price: Price::new(10000),
+                quantity: Quantity::new(10),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_616_823_000_000 + i),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
     }
     level
 }

--- a/benches/price_level/snapshot_recovery.rs
+++ b/benches/price_level/snapshot_recovery.rs
@@ -124,7 +124,9 @@ fn setup_mixed_level(order_count: u64) -> PriceLevel {
                 extra_fields: (),
             },
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
     price_level
 }

--- a/benches/price_level/special_orders.rs
+++ b/benches/price_level/special_orders.rs
@@ -116,16 +116,18 @@ pub fn register_benchmarks(c: &mut Criterion) {
 fn setup_post_only_level(order_count: u64) -> PriceLevel {
     let level = PriceLevel::new(10000);
     for i in 0..order_count {
-        level.add_order(OrderType::PostOnly {
-            id: Id::from_u64(i),
-            price: Price::new(10000),
-            quantity: Quantity::new(10),
-            side: Side::Buy,
-            user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(1_616_823_000_000 + i),
-            time_in_force: TimeInForce::Gtc,
-            extra_fields: (),
-        });
+        level
+            .add_order(OrderType::PostOnly {
+                id: Id::from_u64(i),
+                price: Price::new(10000),
+                quantity: Quantity::new(10),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_616_823_000_000 + i),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
     }
     level
 }
@@ -134,18 +136,20 @@ fn setup_post_only_level(order_count: u64) -> PriceLevel {
 fn setup_trailing_stop_level(order_count: u64) -> PriceLevel {
     let level = PriceLevel::new(10000);
     for i in 0..order_count {
-        level.add_order(OrderType::TrailingStop {
-            id: Id::from_u64(i),
-            price: Price::new(10000),
-            quantity: Quantity::new(10),
-            side: Side::Buy,
-            user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(1_616_823_000_000 + i),
-            time_in_force: TimeInForce::Gtc,
-            trail_amount: Quantity::new(100),
-            last_reference_price: Price::new(10100),
-            extra_fields: (),
-        });
+        level
+            .add_order(OrderType::TrailingStop {
+                id: Id::from_u64(i),
+                price: Price::new(10000),
+                quantity: Quantity::new(10),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_616_823_000_000 + i),
+                time_in_force: TimeInForce::Gtc,
+                trail_amount: Quantity::new(100),
+                last_reference_price: Price::new(10100),
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
     }
     level
 }
@@ -154,18 +158,20 @@ fn setup_trailing_stop_level(order_count: u64) -> PriceLevel {
 fn setup_pegged_level(order_count: u64) -> PriceLevel {
     let level = PriceLevel::new(10000);
     for i in 0..order_count {
-        level.add_order(OrderType::PeggedOrder {
-            id: Id::from_u64(i),
-            price: Price::new(10000),
-            quantity: Quantity::new(10),
-            side: Side::Buy,
-            user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(1_616_823_000_000 + i),
-            time_in_force: TimeInForce::Gtc,
-            reference_price_offset: -50,
-            reference_price_type: PegReferenceType::BestAsk,
-            extra_fields: (),
-        });
+        level
+            .add_order(OrderType::PeggedOrder {
+                id: Id::from_u64(i),
+                price: Price::new(10000),
+                quantity: Quantity::new(10),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_616_823_000_000 + i),
+                time_in_force: TimeInForce::Gtc,
+                reference_price_offset: -50,
+                reference_price_type: PegReferenceType::BestAsk,
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
     }
     level
 }
@@ -174,16 +180,18 @@ fn setup_pegged_level(order_count: u64) -> PriceLevel {
 fn setup_market_to_limit_level(order_count: u64) -> PriceLevel {
     let level = PriceLevel::new(10000);
     for i in 0..order_count {
-        level.add_order(OrderType::MarketToLimit {
-            id: Id::from_u64(i),
-            price: Price::new(10000),
-            quantity: Quantity::new(10),
-            side: Side::Buy,
-            user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(1_616_823_000_000 + i),
-            time_in_force: TimeInForce::Gtc,
-            extra_fields: (),
-        });
+        level
+            .add_order(OrderType::MarketToLimit {
+                id: Id::from_u64(i),
+                price: Price::new(10000),
+                quantity: Quantity::new(10),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_616_823_000_000 + i),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
     }
     level
 }
@@ -238,7 +246,7 @@ fn setup_all_special_mixed(order_count: u64) -> PriceLevel {
                 extra_fields: (),
             },
         };
-        level.add_order(order);
+        level.add_order(order).expect("add_order should succeed");
     }
     level
 }

--- a/benches/price_level/update_orders.rs
+++ b/benches/price_level/update_orders.rs
@@ -119,7 +119,9 @@ fn setup_standard_orders(order_count: u64) -> PriceLevel {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     price_level
@@ -141,7 +143,9 @@ fn setup_iceberg_orders(order_count: u64) -> PriceLevel {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     price_level

--- a/examples/src/bin/contention_test.rs
+++ b/examples/src/bin/contention_test.rs
@@ -100,12 +100,15 @@ fn test_read_write_ratio() {
                         // Write operation
                         match local_counter % 3 {
                             0 => {
-                                // Add a new order
+                                // Add a new order. Ids overlap across threads
+                                // once a counter exceeds 10000 (see the taker
+                                // comment below) and across ratio phases, so
+                                // since issue #113 a rejected duplicate is an
+                                // expected outcome here — deliberately ignored
+                                // to keep the write pressure going.
                                 let order_id = thread_id as u64 * 10000 + local_counter;
                                 let order = create_standard_order(order_id, 10000, 10);
-                                thread_price_level
-                                    .add_order(order)
-                                    .expect("add_order should succeed");
+                                let _ = thread_price_level.add_order(order);
                             }
                             1 => {
                                 // Match order. Takers live in a disjoint high id
@@ -304,11 +307,12 @@ fn test_hot_spot_contention() {
                     // Perform an operation based on iteration
                     match local_counter % 3 {
                         0 => {
-                            // Add a new order with same ID (this will likely fail, but creates contention)
+                            // Add a new order with same ID. Since issue #113 a
+                            // duplicate id is rejected with DuplicateOrderId —
+                            // an expected outcome in this contention pattern,
+                            // so the result is deliberately ignored.
                             let order = create_standard_order(order_idx, 10000, 10);
-                            thread_price_level
-                                .add_order(order)
-                                .expect("add_order should succeed");
+                            let _ = thread_price_level.add_order(order);
                         }
                         1 => {
                             // Cancel an order

--- a/examples/src/bin/contention_test.rs
+++ b/examples/src/bin/contention_test.rs
@@ -103,7 +103,9 @@ fn test_read_write_ratio() {
                                 // Add a new order
                                 let order_id = thread_id as u64 * 10000 + local_counter;
                                 let order = create_standard_order(order_id, 10000, 10);
-                                thread_price_level.add_order(order);
+                                thread_price_level
+                                    .add_order(order)
+                                    .expect("add_order should succeed");
                             }
                             1 => {
                                 // Match order. Takers live in a disjoint high id
@@ -198,7 +200,9 @@ fn setup_orders_for_read_write_test(price_level: &PriceLevel) {
     // Add 500 orders
     for i in 0..500 {
         let order = create_standard_order(i, 10000, 10);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 }
 
@@ -226,7 +230,9 @@ fn setup_orders_for_hot_spot_test(price_level: &PriceLevel) {
     // Add 1000 orders (first 20 are hot spot)
     for i in 0..1000 {
         let order = create_standard_order(i, 10000, 10);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 }
 
@@ -300,7 +306,9 @@ fn test_hot_spot_contention() {
                         0 => {
                             // Add a new order with same ID (this will likely fail, but creates contention)
                             let order = create_standard_order(order_idx, 10000, 10);
-                            thread_price_level.add_order(order);
+                            thread_price_level
+                                .add_order(order)
+                                .expect("add_order should succeed");
                         }
                         1 => {
                             // Cancel an order

--- a/examples/src/bin/hft_simulation.rs
+++ b/examples/src/bin/hft_simulation.rs
@@ -138,8 +138,18 @@ fn main() {
 
             let mut local_counter = 0;
             while thread_running.load(Ordering::Relaxed) {
-                // Generate a unique taker order ID
-                let taker_id = Id::from_u64((thread_id as u64) * 1_000_000 + local_counter);
+                // Generate a unique taker order ID in a DISJOINT high range so a
+                // taker id can never collide with a resting maker id. Makers use
+                // `(thread_id + 1) * 1_000_000 + counter`, so taker thread 10's
+                // base (`10 * 1_000_000`) would otherwise land exactly on maker
+                // thread 9's base (`(9 + 1) * 1_000_000`). A taker sharing a
+                // resting maker's id is a self-fill — impossible for a real
+                // order and caught by match_order's debug-only self-fill
+                // assertion. Offsetting by `1 << 40` (~1.1e12, far above any
+                // reachable maker id) keeps the two id spaces apart, matching
+                // contention_test.
+                let taker_id =
+                    Id::from_u64((1u64 << 40) + (thread_id as u64) * 1_000_000 + local_counter);
 
                 // Match varying quantities
                 let quantity = (local_counter % 5) + 1; // Match 1-5 units

--- a/examples/src/bin/hft_simulation.rs
+++ b/examples/src/bin/hft_simulation.rs
@@ -82,7 +82,10 @@ fn main() {
             let mut local_counter = 0;
             while thread_running.load(Ordering::Relaxed) {
                 // Generate a unique order ID
-                let order_id = (thread_id as u64) * 1_000_000 + local_counter;
+                // +1 offset keeps maker ids clear of the 0..initial_order_count
+                // seed range: admission now rejects a duplicate id (issue
+                // #113) instead of silently overwriting.
+                let order_id = (thread_id as u64 + 1) * 1_000_000 + local_counter;
 
                 // Create and add an order
                 let order_type = match local_counter % 5 {

--- a/examples/src/bin/hft_simulation.rs
+++ b/examples/src/bin/hft_simulation.rs
@@ -93,7 +93,9 @@ fn main() {
                     _ => create_pegged_order(order_id),
                 };
 
-                thread_price_level.add_order(order_type);
+                thread_price_level
+                    .add_order(order_type)
+                    .expect("add_order should succeed");
                 local_counter += 1;
 
                 // Update global counter periodically to reduce contention
@@ -321,7 +323,9 @@ fn setup_initial_orders(price_level: &PriceLevel, count: u64) {
             _ => create_reserve_order(i),
         };
 
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 }
 

--- a/examples/src/bin/integration_basic_lifecycle.rs
+++ b/examples/src/bin/integration_basic_lifecycle.rs
@@ -34,7 +34,9 @@ fn main() {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     assert_eq_or_exit(price_level.order_count(), 10, "order_count after add");

--- a/examples/src/bin/integration_checked_arithmetic.rs
+++ b/examples/src/bin/integration_checked_arithmetic.rs
@@ -33,28 +33,32 @@ fn test_total_quantity_checked() {
     println!("[total_quantity] Checked addition...");
 
     let level = PriceLevel::new(10_000);
-    level.add_order(OrderType::Standard {
-        id: Id::from_u64(1),
-        price: Price::new(10_000),
-        quantity: Quantity::new(500),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(1_000_000),
-        time_in_force: TimeInForce::Gtc,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::Standard {
+            id: Id::from_u64(1),
+            price: Price::new(10_000),
+            quantity: Quantity::new(500),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_000_000),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
-    level.add_order(OrderType::IcebergOrder {
-        id: Id::from_u64(2),
-        price: Price::new(10_000),
-        visible_quantity: Quantity::new(100),
-        hidden_quantity: Quantity::new(400),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(1_000_001),
-        time_in_force: TimeInForce::Gtc,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::IcebergOrder {
+            id: Id::from_u64(2),
+            price: Price::new(10_000),
+            visible_quantity: Quantity::new(100),
+            hidden_quantity: Quantity::new(400),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_000_001),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     let total = level
         .total_quantity()
@@ -73,16 +77,18 @@ fn test_executed_quantity_and_value(id_gen: &UuidGenerator) {
     let level = PriceLevel::new(5_000);
 
     for i in 1..=3_u64 {
-        level.add_order(OrderType::Standard {
-            id: Id::from_u64(i),
-            price: Price::new(5_000),
-            quantity: Quantity::new(100),
-            side: Side::Buy,
-            user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(1_000_000 + i),
-            time_in_force: TimeInForce::Gtc,
-            extra_fields: (),
-        });
+        level
+            .add_order(OrderType::Standard {
+                id: Id::from_u64(i),
+                price: Price::new(5_000),
+                quantity: Quantity::new(100),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_000_000 + i),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
     }
 
     let result = level.match_order(
@@ -130,16 +136,18 @@ fn test_average_price(id_gen: &UuidGenerator) {
     println!("[average_price] Computation...");
 
     let level = PriceLevel::new(7_500);
-    level.add_order(OrderType::Standard {
-        id: Id::from_u64(50),
-        price: Price::new(7_500),
-        quantity: Quantity::new(200),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(2_000_000),
-        time_in_force: TimeInForce::Gtc,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::Standard {
+            id: Id::from_u64(50),
+            price: Price::new(7_500),
+            quantity: Quantity::new(200),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(2_000_000),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     let result = level.match_order(
         100,
@@ -246,16 +254,18 @@ fn test_match_result_display_fromstr(id_gen: &UuidGenerator) {
     println!("[MatchResult] Display/FromStr with checked fields...");
 
     let level = PriceLevel::new(3_000);
-    level.add_order(OrderType::Standard {
-        id: Id::from_u64(77),
-        price: Price::new(3_000),
-        quantity: Quantity::new(50),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(3_000_000),
-        time_in_force: TimeInForce::Gtc,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::Standard {
+            id: Id::from_u64(77),
+            price: Price::new(3_000),
+            quantity: Quantity::new(50),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(3_000_000),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     let result = level.match_order(
         30,

--- a/examples/src/bin/integration_snapshot_recovery.rs
+++ b/examples/src/bin/integration_snapshot_recovery.rs
@@ -22,48 +22,54 @@ fn main() {
 
     // Standard orders
     for i in 1..=5_u64 {
-        original.add_order(OrderType::Standard {
-            id: Id::from_u64(i),
+        original
+            .add_order(OrderType::Standard {
+                id: Id::from_u64(i),
+                price: Price::new(10_000),
+                quantity: Quantity::new(100),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(ts),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
+        ts += 1;
+    }
+
+    // Iceberg order
+    original
+        .add_order(OrderType::IcebergOrder {
+            id: Id::from_u64(10),
             price: Price::new(10_000),
-            quantity: Quantity::new(100),
+            visible_quantity: Quantity::new(20),
+            hidden_quantity: Quantity::new(80),
             side: Side::Buy,
             user_id: Hash32::zero(),
             timestamp: TimestampMs::new(ts),
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
-        });
-        ts += 1;
-    }
-
-    // Iceberg order
-    original.add_order(OrderType::IcebergOrder {
-        id: Id::from_u64(10),
-        price: Price::new(10_000),
-        visible_quantity: Quantity::new(20),
-        hidden_quantity: Quantity::new(80),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(ts),
-        time_in_force: TimeInForce::Gtc,
-        extra_fields: (),
-    });
+        })
+        .expect("add_order should succeed");
     ts += 1;
 
     // Reserve order
-    original.add_order(OrderType::ReserveOrder {
-        id: Id::from_u64(11),
-        price: Price::new(10_000),
-        visible_quantity: Quantity::new(15),
-        hidden_quantity: Quantity::new(60),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(ts),
-        time_in_force: TimeInForce::Gtc,
-        replenish_threshold: Quantity::new(5),
-        replenish_amount: NonZeroU64::new(10),
-        auto_replenish: true,
-        extra_fields: (),
-    });
+    original
+        .add_order(OrderType::ReserveOrder {
+            id: Id::from_u64(11),
+            price: Price::new(10_000),
+            visible_quantity: Quantity::new(15),
+            hidden_quantity: Quantity::new(60),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(ts),
+            time_in_force: TimeInForce::Gtc,
+            replenish_threshold: Quantity::new(5),
+            replenish_amount: NonZeroU64::new(10),
+            auto_replenish: true,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     let orig_order_count = original.order_count();
     let orig_visible = original.visible_quantity();

--- a/examples/src/bin/integration_special_orders.rs
+++ b/examples/src/bin/integration_special_orders.rs
@@ -34,17 +34,19 @@ fn test_iceberg_order(id_gen: &UuidGenerator) {
     println!("[Iceberg] Visible/hidden quantity tracking...");
     let level = PriceLevel::new(10_000);
 
-    level.add_order(OrderType::IcebergOrder {
-        id: Id::from_u64(1),
-        price: Price::new(10_000),
-        visible_quantity: Quantity::new(10),
-        hidden_quantity: Quantity::new(90),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(1_000_000),
-        time_in_force: TimeInForce::Gtc,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::IcebergOrder {
+            id: Id::from_u64(1),
+            price: Price::new(10_000),
+            visible_quantity: Quantity::new(10),
+            hidden_quantity: Quantity::new(90),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_000_000),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     assert_eq_or_exit(level.visible_quantity(), 10, "iceberg visible_qty");
     assert_eq_or_exit(level.hidden_quantity(), 90, "iceberg hidden_qty");
@@ -81,20 +83,22 @@ fn test_reserve_order(id_gen: &UuidGenerator) {
     println!("[Reserve] Auto-replenish behavior...");
     let level = PriceLevel::new(10_000);
 
-    level.add_order(OrderType::ReserveOrder {
-        id: Id::from_u64(2),
-        price: Price::new(10_000),
-        visible_quantity: Quantity::new(10),
-        hidden_quantity: Quantity::new(50),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(1_000_001),
-        time_in_force: TimeInForce::Gtc,
-        replenish_threshold: Quantity::new(2),
-        replenish_amount: NonZeroU64::new(10),
-        auto_replenish: true,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::ReserveOrder {
+            id: Id::from_u64(2),
+            price: Price::new(10_000),
+            visible_quantity: Quantity::new(10),
+            hidden_quantity: Quantity::new(50),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_000_001),
+            time_in_force: TimeInForce::Gtc,
+            replenish_threshold: Quantity::new(2),
+            replenish_amount: NonZeroU64::new(10),
+            auto_replenish: true,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     assert_eq_or_exit(level.visible_quantity(), 10, "reserve visible_qty");
     assert_eq_or_exit(level.hidden_quantity(), 50, "reserve hidden_qty");
@@ -134,16 +138,18 @@ fn test_post_only_order(id_gen: &UuidGenerator) {
     println!("[PostOnly] Add and match behavior...");
     let level = PriceLevel::new(10_000);
 
-    level.add_order(OrderType::PostOnly {
-        id: Id::from_u64(3),
-        price: Price::new(10_000),
-        quantity: Quantity::new(50),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(1_000_002),
-        time_in_force: TimeInForce::Gtc,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::PostOnly {
+            id: Id::from_u64(3),
+            price: Price::new(10_000),
+            quantity: Quantity::new(50),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_000_002),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     assert_eq_or_exit(level.visible_quantity(), 50, "postonly visible_qty");
     assert_eq_or_exit(level.order_count(), 1, "postonly order_count");
@@ -181,18 +187,20 @@ fn test_trailing_stop_order(id_gen: &UuidGenerator) {
     println!("[TrailingStop] Add and match behavior...");
     let level = PriceLevel::new(10_000);
 
-    level.add_order(OrderType::TrailingStop {
-        id: Id::from_u64(4),
-        price: Price::new(10_000),
-        quantity: Quantity::new(30),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(1_000_003),
-        time_in_force: TimeInForce::Gtc,
-        trail_amount: Quantity::new(100),
-        last_reference_price: Price::new(10_100),
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::TrailingStop {
+            id: Id::from_u64(4),
+            price: Price::new(10_000),
+            quantity: Quantity::new(30),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_000_003),
+            time_in_force: TimeInForce::Gtc,
+            trail_amount: Quantity::new(100),
+            last_reference_price: Price::new(10_100),
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     assert_eq_or_exit(level.visible_quantity(), 30, "trailing visible_qty");
 
@@ -221,18 +229,20 @@ fn test_pegged_order(id_gen: &UuidGenerator) {
     println!("[Pegged] Add and match behavior...");
     let level = PriceLevel::new(10_000);
 
-    level.add_order(OrderType::PeggedOrder {
-        id: Id::from_u64(5),
-        price: Price::new(10_000),
-        quantity: Quantity::new(25),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(1_000_004),
-        time_in_force: TimeInForce::Gtc,
-        reference_price_offset: 50,
-        reference_price_type: PegReferenceType::MidPrice,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::PeggedOrder {
+            id: Id::from_u64(5),
+            price: Price::new(10_000),
+            quantity: Quantity::new(25),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_000_004),
+            time_in_force: TimeInForce::Gtc,
+            reference_price_offset: 50,
+            reference_price_type: PegReferenceType::MidPrice,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     assert_eq_or_exit(level.visible_quantity(), 25, "pegged visible_qty");
 
@@ -261,16 +271,18 @@ fn test_market_to_limit_order(id_gen: &UuidGenerator) {
     println!("[MarketToLimit] Add and match behavior...");
     let level = PriceLevel::new(10_000);
 
-    level.add_order(OrderType::MarketToLimit {
-        id: Id::from_u64(6),
-        price: Price::new(10_000),
-        quantity: Quantity::new(40),
-        side: Side::Buy,
-        user_id: Hash32::zero(),
-        timestamp: TimestampMs::new(1_000_005),
-        time_in_force: TimeInForce::Gtc,
-        extra_fields: (),
-    });
+    level
+        .add_order(OrderType::MarketToLimit {
+            id: Id::from_u64(6),
+            price: Price::new(10_000),
+            quantity: Quantity::new(40),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1_000_005),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        })
+        .expect("add_order should succeed");
 
     assert_eq_or_exit(level.visible_quantity(), 40, "m2l visible_qty");
 

--- a/examples/src/bin/integration_trade_roundtrip.rs
+++ b/examples/src/bin/integration_trade_roundtrip.rs
@@ -119,16 +119,18 @@ fn main() {
     println!("[Phase 5] MatchResult from real matching...");
     let price_level = PriceLevel::new(10_000);
     for i in 1..=5_u64 {
-        price_level.add_order(OrderType::Standard {
-            id: Id::from_u64(i),
-            price: Price::new(10_000),
-            quantity: Quantity::new(20),
-            side: Side::Buy,
-            user_id: Hash32::zero(),
-            timestamp: TimestampMs::new(1_616_823_000_000 + i),
-            time_in_force: TimeInForce::Gtc,
-            extra_fields: (),
-        });
+        price_level
+            .add_order(OrderType::Standard {
+                id: Id::from_u64(i),
+                price: Price::new(10_000),
+                quantity: Quantity::new(20),
+                side: Side::Buy,
+                user_id: Hash32::zero(),
+                timestamp: TimestampMs::new(1_616_823_000_000 + i),
+                time_in_force: TimeInForce::Gtc,
+                extra_fields: (),
+            })
+            .expect("add_order should succeed");
     }
 
     let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8")

--- a/examples/src/bin/simple.rs
+++ b/examples/src/bin/simple.rs
@@ -52,7 +52,10 @@ fn main() {
                     thread_barrier.wait(); // Wait for all threads to be ready
 
                     for i in 0..50 {
-                        let order_id = thread_id as u64 * 1000 + i;
+                        // Offset past the ids seeded by setup_initial_orders
+                        // (0..240): admission now rejects a duplicate id
+                        // (issue #113) instead of silently overwriting.
+                        let order_id = 10_000 + thread_id as u64 * 1000 + i;
                         let order = create_order(thread_id, order_id);
                         thread_price_level
                             .add_order(order)

--- a/examples/src/bin/simple.rs
+++ b/examples/src/bin/simple.rs
@@ -54,7 +54,9 @@ fn main() {
                     for i in 0..50 {
                         let order_id = thread_id as u64 * 1000 + i;
                         let order = create_order(thread_id, order_id);
-                        thread_price_level.add_order(order);
+                        thread_price_level
+                            .add_order(order)
+                            .expect("add_order should succeed");
 
                         // Simulate some work
                         thread::sleep(Duration::from_millis(1));
@@ -214,7 +216,9 @@ fn setup_initial_orders(price_level: &PriceLevel) {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     // Add some iceberg orders
@@ -230,7 +234,9 @@ fn setup_initial_orders(price_level: &PriceLevel) {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 
     // Add some reserve orders
@@ -249,7 +255,9 @@ fn setup_initial_orders(price_level: &PriceLevel) {
             auto_replenish: true,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
     }
 }
 

--- a/src/errors/tests/types.rs
+++ b/src/errors/tests/types.rs
@@ -60,6 +60,7 @@ mod tests {
             PriceLevelError::InvalidFormat,
             PriceLevelError::UnknownOrderType("TestOrder".to_string()),
             PriceLevelError::MissingField("id".to_string()),
+            PriceLevelError::DuplicateOrderId("42".to_string()),
             PriceLevelError::InvalidFieldValue {
                 field: "side".to_string(),
                 value: "MIDDLE".to_string(),

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -45,6 +45,14 @@ pub enum PriceLevelError {
     /// The string parameter specifies which field is missing.
     MissingField(String),
 
+    /// Error indicating an order id already rests at the price level.
+    ///
+    /// Admission (or a duplicate-bearing restore) is rejected atomically rather
+    /// than overwriting the live order, which would leave the level's id-keyed
+    /// map and its ordered index disagreeing (two sequences for one id) and its
+    /// counters double-counted. The string parameter is the offending id.
+    DuplicateOrderId(String),
+
     /// Error indicating a field has an invalid value.
     ///
     /// This error occurs when a field's value is present but doesn't meet validation criteria.
@@ -96,6 +104,7 @@ impl Display for PriceLevelError {
                 write!(f, "Unknown order type: {order_type}")
             }
             PriceLevelError::MissingField(field) => write!(f, "Missing field: {field}"),
+            PriceLevelError::DuplicateOrderId(id) => write!(f, "Duplicate order id: {id}"),
             PriceLevelError::InvalidFieldValue { field, value } => {
                 write!(f, "Invalid value for field {field}: {value}")
             }
@@ -128,6 +137,7 @@ impl Debug for PriceLevelError {
                 write!(f, "Unknown order type: {order_type}")
             }
             PriceLevelError::MissingField(field) => write!(f, "Missing field: {field}"),
+            PriceLevelError::DuplicateOrderId(id) => write!(f, "Duplicate order id: {id}"),
             PriceLevelError::InvalidFieldValue { field, value } => {
                 write!(f, "Invalid value for field {field}: {value}")
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,6 +505,16 @@
 //! success. Admissions that stay within `u64` (all normal use) behave exactly
 //! as before.
 //!
+//! `add_order` also now **rejects a duplicate id**: publishing is an
+//! insert-if-absent, so reusing the id of an order already resting at the level
+//! returns the new [`PriceLevelError::DuplicateOrderId`] variant (again leaving
+//! the level unchanged) instead of overwriting the live order and leaving the
+//! id-keyed map and the ordered index disagreeing. Snapshot restore
+//! ([`PriceLevel::from_snapshot`] and the JSON / package forms) likewise
+//! rejects an orders vector that repeats an id rather than silently
+//! overwriting. Submitting genuinely distinct ids (all normal use) is
+//! unaffected.
+//!
 
 mod orders;
 mod price_level;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,6 +515,29 @@
 //! overwriting. Submitting genuinely distinct ids (all normal use) is
 //! unaffected.
 //!
+//! ## Migration Guide (v0.9 — duplicate-id safety on restore + queue surface)
+//!
+//! Three intentional breaking changes remove infallible / overwriting paths
+//! that could desync a level's counters from its queue:
+//!
+//! - **`impl From<&PriceLevelSnapshot> for PriceLevel` is removed; use
+//!   [`TryFrom`].** The old `From` swallowed aggregate-overflow errors and built
+//!   the queue keep-first, so a snapshot repeating an id restored counters
+//!   computed over every copy while the queue kept one. Replace
+//!   `PriceLevel::from(&snapshot)` / `let lvl: PriceLevel = (&snapshot).into();`
+//!   with `PriceLevel::try_from(&snapshot)?` (or `.expect(...)` in tests). It
+//!   delegates to [`PriceLevel::from_snapshot`], returning
+//!   [`PriceLevelError::DuplicateOrderId`] on a repeated id and the
+//!   per-order / level aggregate-overflow errors instead of hiding them.
+//! - **`OrderQueue::push` is now `pub(crate)`.** Unconditional overwriting
+//!   publication is never safe for an external caller (reusing a live id would
+//!   silently replace the resting order and strand its old index entry).
+//!   Admission goes through `add_order` (or, at the queue layer, the
+//!   insert-if-absent `try_push`); there is no public overwriting insert.
+//! - **`OrderQueue::from_vec` is now `pub(crate)`.** It is a keep-first
+//!   constructor that drops duplicates silently; the public restore path is
+//!   [`PriceLevel::from_snapshot`], which rejects them.
+//!
 
 mod orders;
 mod price_level;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,6 +490,21 @@
 //! checksum over an unchanged payload still validates. Existing snapshot JSON
 //! restores without migration.
 //!
+//! ## Migration Guide (`PriceLevel::add_order` is now checked — breaking)
+//!
+//! [`PriceLevel::add_order`] now returns
+//! `Result<Arc<OrderType<()>>, PriceLevelError>` instead of
+//! `Arc<OrderType<()>>`. It reserves the order's visible / hidden quantity and
+//! its count slot on the level's atomic counters (with checked `fetch_update`)
+//! **before** publishing the order to the queue, and returns
+//! [`PriceLevelError::InvalidOperation`] if any counter would overflow `u64` —
+//! leaving the level completely unchanged rather than wrapping a counter while
+//! the queue already holds the admitted order. Callers must handle the
+//! `Result` — propagate with `level.add_order(order)?` (test fixtures and
+//! binaries may prefer `.expect(...)`); the returned `Arc` is unchanged on
+//! success. Admissions that stay within `u64` (all normal use) behave exactly
+//! as before.
+//!
 
 mod orders;
 mod price_level;

--- a/src/orders/order_type.rs
+++ b/src/orders/order_type.rs
@@ -660,6 +660,19 @@ impl<T: Clone> OrderType<T> {
     /// - Optionally, an updated version of this order (if partially filled)
     /// - The quantity that was reduced from hidden portion (for iceberg/reserve orders)
     /// - The remaining quantity of the incoming order
+    ///
+    /// # Overflow
+    ///
+    /// The only quantity *addition* on any match path is a reserve order's
+    /// partial-fill replenishment (`new_visible + replenish_qty`). If that sum
+    /// would overflow `u64` — reachable only for a pathological reserve whose
+    /// visible + hidden already exceeds `u64::MAX` — this returns the
+    /// no-progress sentinel `(0, Some(self.clone()), 0, incoming_quantity)`
+    /// instead of panicking or wrapping. The caller's sweep (and the
+    /// fill-or-kill dry run) already treat that sentinel as "set this maker
+    /// aside", so the step fails atomically: no trade, maker and taker
+    /// unchanged. Every other path uses only subtraction / `min`, which cannot
+    /// overflow.
     #[must_use]
     pub fn match_against(&self, incoming_quantity: u64) -> (u64, Option<Self>, u64, u64) {
         match self {
@@ -853,7 +866,22 @@ impl<T: Clone> OrderType<T> {
                         && hidden_quantity.as_u64() > 0
                         && *auto_replenish
                     {
-                        // Restore from the hidden quantity
+                        // Refreshed visible is `new_visible + replenish_qty`.
+                        // Guard the sum with `checked_add`: a reserve whose
+                        // visible + hidden exceeds `u64::MAX` is admissible (the
+                        // two are separate `u64` components) yet would panic in
+                        // debug / wrap in release here. On overflow make NO
+                        // progress — hand the maker back unchanged with
+                        // `consumed == 0` and `remaining` untouched. That is the
+                        // no-progress sentinel both the real sweep and the
+                        // fill-or-kill dry run already detect and set aside, so
+                        // the match step fails atomically: no trade emitted, and
+                        // maker + taker state preserved. Never a partial or a
+                        // manufactured (wrapped) fill.
+                        let Some(refreshed_visible) = new_visible.checked_add(replenish_qty) else {
+                            return (0, Some(self.clone()), 0, incoming_quantity);
+                        };
+                        // Restore from the hidden quantity.
                         let new_hidden = hidden_quantity.as_u64() - replenish_qty;
 
                         (
@@ -861,7 +889,7 @@ impl<T: Clone> OrderType<T> {
                             Some(Self::ReserveOrder {
                                 id: *id,
                                 price: *price,
-                                visible_quantity: Quantity::new(new_visible + replenish_qty),
+                                visible_quantity: Quantity::new(refreshed_visible),
                                 hidden_quantity: Quantity::new(new_hidden),
                                 side: *side,
                                 user_id: *user_id,

--- a/src/orders/order_type.rs
+++ b/src/orders/order_type.rs
@@ -867,17 +867,22 @@ impl<T: Clone> OrderType<T> {
                         && *auto_replenish
                     {
                         // Refreshed visible is `new_visible + replenish_qty`.
-                        // Guard the sum with `checked_add`: a reserve whose
-                        // visible + hidden exceeds `u64::MAX` is admissible (the
-                        // two are separate `u64` components) yet would panic in
-                        // debug / wrap in release here. On overflow make NO
-                        // progress — hand the maker back unchanged with
-                        // `consumed == 0` and `remaining` untouched. That is the
+                        // This sum is provably `<= u64::MAX` for any order the
+                        // level admits: `new_visible <= visible_quantity`,
+                        // `replenish_qty` is capped by `.min(hidden_quantity)`
+                        // above, and `PriceLevel::add_order` /
+                        // `PriceLevelSnapshot::refresh_aggregates` reject any
+                        // order whose own `visible + hidden` overflows `u64`,
+                        // so `new_visible + replenish_qty <= visible + hidden
+                        // <= u64::MAX`. The `checked_add` is therefore kept as
+                        // defense-in-depth against an unadmitted / internally
+                        // constructed order (e.g. a direct `match_against` unit
+                        // test): on the unreachable overflow it makes NO progress
+                        // — the maker is handed back unchanged with
+                        // `consumed == 0` and `remaining` untouched, the
                         // no-progress sentinel both the real sweep and the
-                        // fill-or-kill dry run already detect and set aside, so
-                        // the match step fails atomically: no trade emitted, and
-                        // maker + taker state preserved. Never a partial or a
-                        // manufactured (wrapped) fill.
+                        // fill-or-kill dry run detect and set aside — never a
+                        // partial or a manufactured (wrapped) fill.
                         let Some(refreshed_visible) = new_visible.checked_add(replenish_qty) else {
                             return (0, Some(self.clone()), 0, incoming_quantity);
                         };

--- a/src/orders/tests/order_type.rs
+++ b/src/orders/tests/order_type.rs
@@ -449,6 +449,56 @@ mod tests {
     }
 
     #[test]
+    fn test_match_against_reserve_replenish_overflow_sentinel_no_progress() {
+        // Defense-in-depth sentinel for a state `PriceLevel::add_order` /
+        // `refresh_aggregates` now REJECT at admission: a reserve whose own
+        // visible + hidden overflows `u64`. Such an order can never rest at a
+        // level, but `match_against` is a pure function that can still be handed
+        // one directly (as here), so it must not panic in debug / wrap in
+        // release when the replenish add `new_visible + replenish_qty` overflows.
+        // It must make NO progress: consumed 0, remaining untouched, maker handed
+        // back byte-identical, no hidden drawn — the no-progress sentinel the
+        // sweep and the fill-or-kill dry run both detect.
+        let order = OrderType::<()>::ReserveOrder {
+            id: Id::from_u64(200),
+            price: Price::new(10000),
+            visible_quantity: Quantity::new(u64::MAX),
+            hidden_quantity: Quantity::new(u64::MAX),
+            side: Side::Sell,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(1616823000000),
+            time_in_force: TimeInForce::Gtc,
+            // Any partial fill leaves visible below threshold -> replenish.
+            replenish_threshold: Quantity::new(u64::MAX),
+            replenish_amount: Some(nz(u64::MAX)),
+            auto_replenish: true,
+            extra_fields: (),
+        };
+
+        // A one-unit taker triggers a partial fill: new_visible = u64::MAX - 1,
+        // replenish_qty = min(u64::MAX, u64::MAX) = u64::MAX, and their sum
+        // overflows u64 -> the sentinel fires.
+        let (consumed, updated, hidden_reduced, remaining) = order.match_against(1);
+        assert_eq!(consumed, 0, "overflowing replenish must consume nothing");
+        assert_eq!(
+            hidden_reduced, 0,
+            "overflowing replenish must draw no hidden"
+        );
+        assert_eq!(remaining, 1, "the taker's remaining must be untouched");
+        match updated {
+            Some(OrderType::<()>::ReserveOrder {
+                visible_quantity,
+                hidden_quantity,
+                ..
+            }) => {
+                assert_eq!(visible_quantity, Quantity::new(u64::MAX));
+                assert_eq!(hidden_quantity, Quantity::new(u64::MAX));
+            }
+            _ => panic!("Expected the maker handed back unchanged"),
+        }
+    }
+
+    #[test]
     fn test_from_str_standard() {
         let order_str = "Standard:id=00000000-0000-007b-0000-000000000000;price=10000;quantity=5;side=BUY;timestamp=1616823000000;time_in_force=GTC";
         let order: OrderType<()> = OrderType::from_str(order_str).unwrap();

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -218,37 +218,41 @@ impl PriceLevel {
 
     /// Add an order to this price level.
     ///
-    /// Reserves the order's visible / hidden quantity and one count slot on the
-    /// atomic counters **before** publishing it to the queue, so an admission
-    /// that would overflow any counter — or that reuses the id of an order
-    /// already resting here — is rejected with nothing mutated: the queue, the
-    /// counters, the statistics, and therefore any snapshot are left exactly as
-    /// they were. On success the returned `Arc` is the admitted order.
+    /// Decides the order's id IDENTITY first, then reserves its visible /
+    /// hidden quantity and one count slot on the atomic counters **atomically
+    /// with publishing** it to the queue, so an admission that reuses the id of
+    /// an order already resting here — or that would overflow any counter — is
+    /// rejected with nothing mutated: the queue, the counters, the statistics,
+    /// and therefore any snapshot are left exactly as they were. On success the
+    /// returned `Arc` is the admitted order.
     ///
     /// # Duplicate ids
     ///
-    /// The publish step is an insert-if-absent
-    /// ([`OrderQueue::try_push`](crate::price_level::OrderQueue::try_push))
-    /// under the id-keyed map's per-shard lock, so several concurrent
-    /// submissions of the same id resolve to exactly one admission; the rest
-    /// return [`PriceLevelError::DuplicateOrderId`]. A rejected duplicate never
-    /// overwrites the live order (which would leave the map and the ordered
-    /// index disagreeing) and its reserved counter capacity is rolled back
-    /// exactly as an overflow's is.
+    /// Publication goes through
+    /// [`OrderQueue::try_push_with`](crate::price_level::OrderQueue) under the
+    /// id-keyed map's per-shard lock, which decides the id is free **before**
+    /// the counter reservation runs. Several concurrent submissions of the same
+    /// id therefore resolve to exactly one admission; the rest return
+    /// [`PriceLevelError::DuplicateOrderId`] **without touching any counter** —
+    /// a rejected duplicate never overwrites the live order (which would leave
+    /// the map and the ordered index disagreeing) and never transiently inflates
+    /// a level counter.
     ///
-    /// # Overflow safety
+    /// # Error precedence
     ///
-    /// Each counter is bumped with a checked [`AtomicU64::fetch_update`] /
-    /// [`AtomicUsize::fetch_update`] (`checked_add`), which is an atomic
-    /// compare-exchange loop and therefore free of the check-then-`fetch_add`
-    /// TOCTOU race two concurrent admissions near `u64::MAX` would otherwise
-    /// hit. Capacity is reserved in the order visible → hidden → count; if a
-    /// later reservation overflows, the earlier ones are rolled back (by the
-    /// exact delta this call added — a commutative, concurrency-safe undo on
-    /// these advisory counters) before returning, so no counter is ever left
-    /// drifted. Only once all three are reserved is the order published to the
-    /// queue, so the queue can never hold an order whose admission overflowed a
-    /// counter — the invariant this method now upholds.
+    /// The order's own `visible + hidden` overflow is checked first (a pure
+    /// property of the order). Then, under the shard lock, a **duplicate id is
+    /// decided before any counter is touched**: an admission that both reuses a
+    /// live id and would overflow a counter reports
+    /// [`PriceLevelError::DuplicateOrderId`], never the overflow. Only for a
+    /// free id is capacity reserved, visible → hidden → count, each with a
+    /// checked [`AtomicU64::fetch_update`] / [`AtomicUsize::fetch_update`]
+    /// (`checked_add`) — an atomic compare-exchange loop, free of the
+    /// check-then-`fetch_add` TOCTOU race two admissions near `u64::MAX` would
+    /// hit. If a later reservation overflows, the earlier ones are rolled back
+    /// (by the exact delta this call added — a commutative, concurrency-safe
+    /// undo on these advisory counters), so `try_push_with` publishes nothing
+    /// and no counter is left drifted.
     ///
     /// # Errors
     ///
@@ -256,8 +260,8 @@ impl PriceLevel {
     /// visible + hidden total overflows `u64`, or if admitting it would
     /// overflow the level's visible-quantity, hidden-quantity, or order-count
     /// counter, or [`PriceLevelError::DuplicateOrderId`] if an order with the
-    /// same id already rests at this level. In every case the level is
-    /// unchanged.
+    /// same id already rests at this level. A duplicate id takes precedence over
+    /// a counter overflow. In every case the level is unchanged.
     pub fn add_order(&self, order: OrderType<()>) -> Result<Arc<OrderType<()>>, PriceLevelError> {
         // Calculate quantities.
         let visible_qty = order.visible_quantity().as_u64();
@@ -280,71 +284,75 @@ impl PriceLevel {
             });
         }
 
-        // Reserve capacity on each counter BEFORE publishing, using a checked
-        // `fetch_update` (an atomic CAS loop). `Relaxed` on both the success and
-        // failure orderings: these are the advisory counters (issue #68); the
-        // queue publication below carries the real happens-before for a
-        // concurrent reader, so the counters are not a synchronization channel.
-        if self
-            .visible_quantity
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
-                c.checked_add(visible_qty)
-            })
-            .is_err()
-        {
-            return Err(PriceLevelError::InvalidOperation {
-                message: "price level visible quantity overflow on admission".to_string(),
-            });
-        }
-
-        if self
-            .hidden_quantity
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
-                c.checked_add(hidden_qty)
-            })
-            .is_err()
-        {
-            // Roll back the visible reservation this call made.
-            self.visible_quantity
-                .fetch_sub(visible_qty, Ordering::Relaxed);
-            return Err(PriceLevelError::InvalidOperation {
-                message: "price level hidden quantity overflow on admission".to_string(),
-            });
-        }
-
-        if self
-            .order_count
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| c.checked_add(1))
-            .is_err()
-        {
-            // Roll back the visible + hidden reservations this call made.
-            self.visible_quantity
-                .fetch_sub(visible_qty, Ordering::Relaxed);
-            self.hidden_quantity
-                .fetch_sub(hidden_qty, Ordering::Relaxed);
-            return Err(PriceLevelError::InvalidOperation {
-                message: "price level order count overflow on admission".to_string(),
-            });
-        }
-
-        // All capacity reserved; now try to publish the order, rejecting a
-        // duplicate id atomically (insert-if-absent under the DashMap shard
-        // lock — exactly one of several concurrent submissions of the same id
-        // wins). On a duplicate, roll back the exact reservations this call
-        // made (the same undo as an overflow) so the level is left unchanged
-        // and no counter drifts, then surface the rejection. A concurrent
-        // reader can briefly see the reserved count before the order rests (the
-        // advisory-counter window), but never the reverse overflow the
-        // reservation just ruled out.
+        // Publish through `try_push_with`, which decides id IDENTITY FIRST under
+        // the DashMap shard lock and only then runs the counter reservation
+        // below — atomically with the publication. Consequences:
+        //
+        // * A duplicate id is rejected with `DuplicateOrderId` and NOTHING
+        //   touched: the reservation closure never runs, so a rejected duplicate
+        //   cannot transiently inflate a counter, and a duplicate submitted at
+        //   counter capacity reports `DuplicateOrderId` (identity) rather than a
+        //   spurious overflow (the error precedence documented above).
+        // * The reservation runs only once the id is known free; the queue then
+        //   publishes the order into the map + index while holding the shard
+        //   lock, so a concurrent cancel + readmission can never split this id
+        //   across two index entries.
+        //
+        // Inside the closure, capacity is reserved visible → hidden → count with
+        // checked `fetch_update` (an atomic CAS loop, free of the
+        // check-then-`fetch_add` TOCTOU race two admissions near `u64::MAX`
+        // would hit). `Relaxed` throughout: these are the advisory counters
+        // (issue #68); the queue publication carries the real happens-before,
+        // not these RMWs. If a later reservation overflows, the earlier ones are
+        // rolled back by the exact delta this call added — a commutative,
+        // concurrency-safe undo — before returning `Err`, so `try_push_with`
+        // publishes nothing and no counter is left drifted.
         let order_arc = Arc::new(order);
-        if let Err(err) = self.orders.try_push(order_arc.clone()) {
-            self.visible_quantity
-                .fetch_sub(visible_qty, Ordering::Relaxed);
-            self.hidden_quantity
-                .fetch_sub(hidden_qty, Ordering::Relaxed);
-            self.order_count.fetch_sub(1, Ordering::Relaxed);
-            return Err(err);
-        }
+        self.orders.try_push_with(order_arc.clone(), || {
+            if self
+                .visible_quantity
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
+                    c.checked_add(visible_qty)
+                })
+                .is_err()
+            {
+                return Err(PriceLevelError::InvalidOperation {
+                    message: "price level visible quantity overflow on admission".to_string(),
+                });
+            }
+
+            if self
+                .hidden_quantity
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
+                    c.checked_add(hidden_qty)
+                })
+                .is_err()
+            {
+                // Roll back the visible reservation this call made.
+                self.visible_quantity
+                    .fetch_sub(visible_qty, Ordering::Relaxed);
+                return Err(PriceLevelError::InvalidOperation {
+                    message: "price level hidden quantity overflow on admission".to_string(),
+                });
+            }
+
+            if self
+                .order_count
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| c.checked_add(1))
+                .is_err()
+            {
+                // Roll back the visible + hidden reservations this call made.
+                self.visible_quantity
+                    .fetch_sub(visible_qty, Ordering::Relaxed);
+                self.hidden_quantity
+                    .fetch_sub(hidden_qty, Ordering::Relaxed);
+                return Err(PriceLevelError::InvalidOperation {
+                    message: "price level order count overflow on admission".to_string(),
+                });
+            }
+
+            Ok(())
+        })?;
 
         // Update statistics only after a committed admission.
         self.stats.record_order_added();
@@ -1380,27 +1388,28 @@ impl From<&PriceLevel> for PriceLevelData {
     }
 }
 
-impl From<&PriceLevelSnapshot> for PriceLevel {
-    fn from(value: &PriceLevelSnapshot) -> Self {
-        let mut snapshot = value.clone();
-        let _ = snapshot.refresh_aggregates();
+impl TryFrom<&PriceLevelSnapshot> for PriceLevel {
+    type Error = PriceLevelError;
 
-        let order_count = snapshot.orders().len();
-        let visible_quantity = snapshot.visible_quantity().as_u64();
-        let hidden_quantity = snapshot.hidden_quantity().as_u64();
-        let price = snapshot.price().as_u128();
-        // Preserve the persisted statistics instead of resetting them.
-        let stats = (*snapshot.statistics()).clone();
-        let queue = OrderQueue::from(snapshot.into_orders());
-
-        Self {
-            price,
-            visible_quantity: AtomicU64::new(visible_quantity),
-            hidden_quantity: AtomicU64::new(hidden_quantity),
-            order_count: AtomicUsize::new(order_count),
-            orders: queue,
-            stats: Arc::new(stats),
-        }
+    /// Rebuilds a price level from a borrowed snapshot.
+    ///
+    /// Fallible on purpose (this replaced an infallible `From` in v0.9): the old
+    /// `From` swallowed [`PriceLevelSnapshot::refresh_aggregates`] errors and
+    /// built the queue with keep-first duplicate handling, so a snapshot whose
+    /// orders repeated an id would restore counters computed over every copy
+    /// while the queue kept only one — a level whose counters silently disagreed
+    /// with its contents. This clones the snapshot and delegates to
+    /// [`PriceLevel::from_snapshot`], which rejects a repeated id and propagates
+    /// the aggregate-overflow / per-order-total errors instead of hiding them.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::DuplicateOrderId`] if the snapshot's orders
+    /// vector repeats an id, or [`PriceLevelError::InvalidOperation`] if a
+    /// per-order or level aggregate overflows `u64` — see
+    /// [`PriceLevel::from_snapshot`].
+    fn try_from(value: &PriceLevelSnapshot) -> Result<Self, Self::Error> {
+        PriceLevel::from_snapshot(value.clone())
     }
 }
 

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -50,9 +50,26 @@ impl PriceLevel {
     /// Returns [`PriceLevelError::InvalidOperation`] if any restored order's own
     /// visible + hidden total overflows `u64`, or if recomputing the snapshot's
     /// level aggregates overflows `u64` — the same per-order and per-level
-    /// invariants [`Self::add_order`] enforces at admission.
+    /// invariants [`Self::add_order`] enforces at admission — or
+    /// [`PriceLevelError::DuplicateOrderId`] if the snapshot's orders vector
+    /// repeats an order id.
     pub fn from_snapshot(mut snapshot: PriceLevelSnapshot) -> Result<Self, PriceLevelError> {
         snapshot.refresh_aggregates()?;
+
+        // Reject a snapshot whose orders vector repeats an id. Building the
+        // queue would drop the duplicate (keep-first), but the reconstructed
+        // counters are taken from the snapshot's own aggregates / order count,
+        // so a silently-dropped duplicate would leave the restored level's
+        // counters disagreeing with its queue. Fail deterministically instead.
+        {
+            let orders = snapshot.orders();
+            let mut seen = std::collections::HashSet::with_capacity(orders.len());
+            for order in orders {
+                if !seen.insert(order.id()) {
+                    return Err(PriceLevelError::DuplicateOrderId(order.id().to_string()));
+                }
+            }
+        }
 
         let order_count = snapshot.orders().len();
         let visible_quantity = snapshot.visible_quantity().as_u64();
@@ -99,8 +116,10 @@ impl PriceLevel {
     /// valid snapshot-package JSON document, [`PriceLevelError::ChecksumMismatch`]
     /// if the decoded package's SHA-256 checksum does not match its payload,
     /// [`PriceLevelError::SerializationError`] if re-encoding the payload to
-    /// recompute that checksum fails, and [`PriceLevelError::InvalidOperation`]
-    /// on an unsupported snapshot format version.
+    /// recompute that checksum fails, [`PriceLevelError::InvalidOperation`]
+    /// on an unsupported snapshot format version, and
+    /// [`PriceLevelError::DuplicateOrderId`] if the decoded snapshot's orders
+    /// vector repeats an order id.
     pub fn from_snapshot_json(data: &str) -> Result<Self, PriceLevelError> {
         let package = PriceLevelSnapshotPackage::from_json(data)?;
         Self::from_snapshot_package(package)
@@ -201,10 +220,21 @@ impl PriceLevel {
     ///
     /// Reserves the order's visible / hidden quantity and one count slot on the
     /// atomic counters **before** publishing it to the queue, so an admission
-    /// that would overflow any counter is rejected with nothing mutated: the
-    /// queue, the counters, the statistics, and therefore any snapshot are left
-    /// exactly as they were. On success the returned `Arc` is the admitted
-    /// order.
+    /// that would overflow any counter — or that reuses the id of an order
+    /// already resting here — is rejected with nothing mutated: the queue, the
+    /// counters, the statistics, and therefore any snapshot are left exactly as
+    /// they were. On success the returned `Arc` is the admitted order.
+    ///
+    /// # Duplicate ids
+    ///
+    /// The publish step is an insert-if-absent
+    /// ([`OrderQueue::try_push`](crate::price_level::OrderQueue::try_push))
+    /// under the id-keyed map's per-shard lock, so several concurrent
+    /// submissions of the same id resolve to exactly one admission; the rest
+    /// return [`PriceLevelError::DuplicateOrderId`]. A rejected duplicate never
+    /// overwrites the live order (which would leave the map and the ordered
+    /// index disagreeing) and its reserved counter capacity is rolled back
+    /// exactly as an overflow's is.
     ///
     /// # Overflow safety
     ///
@@ -225,7 +255,9 @@ impl PriceLevel {
     /// Returns [`PriceLevelError::InvalidOperation`] if the order's own
     /// visible + hidden total overflows `u64`, or if admitting it would
     /// overflow the level's visible-quantity, hidden-quantity, or order-count
-    /// counter. In every case the level is unchanged.
+    /// counter, or [`PriceLevelError::DuplicateOrderId`] if an order with the
+    /// same id already rests at this level. In every case the level is
+    /// unchanged.
     pub fn add_order(&self, order: OrderType<()>) -> Result<Arc<OrderType<()>>, PriceLevelError> {
         // Calculate quantities.
         let visible_qty = order.visible_quantity().as_u64();
@@ -295,12 +327,24 @@ impl PriceLevel {
             });
         }
 
-        // All capacity reserved; publish the order to the queue. A concurrent
-        // reader can briefly see the reserved count before the order rests
-        // (the advisory-counter window), but never the reverse overflow the
+        // All capacity reserved; now try to publish the order, rejecting a
+        // duplicate id atomically (insert-if-absent under the DashMap shard
+        // lock — exactly one of several concurrent submissions of the same id
+        // wins). On a duplicate, roll back the exact reservations this call
+        // made (the same undo as an overflow) so the level is left unchanged
+        // and no counter drifts, then surface the rejection. A concurrent
+        // reader can briefly see the reserved count before the order rests (the
+        // advisory-counter window), but never the reverse overflow the
         // reservation just ruled out.
         let order_arc = Arc::new(order);
-        self.orders.push(order_arc.clone());
+        if let Err(err) = self.orders.try_push(order_arc.clone()) {
+            self.visible_quantity
+                .fetch_sub(visible_qty, Ordering::Relaxed);
+            self.hidden_quantity
+                .fetch_sub(hidden_qty, Ordering::Relaxed);
+            self.order_count.fetch_sub(1, Ordering::Relaxed);
+            return Err(err);
+        }
 
         // Update statistics only after a committed admission.
         self.stats.record_order_added();

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -195,38 +195,97 @@ impl PriceLevel {
         self.stats.clone()
     }
 
-    /// Add an order to this price level
-    pub fn add_order(&self, order: OrderType<()>) -> Arc<OrderType<()>> {
-        // Calculate quantities
+    /// Add an order to this price level.
+    ///
+    /// Reserves the order's visible / hidden quantity and one count slot on the
+    /// atomic counters **before** publishing it to the queue, so an admission
+    /// that would overflow any counter is rejected with nothing mutated: the
+    /// queue, the counters, the statistics, and therefore any snapshot are left
+    /// exactly as they were. On success the returned `Arc` is the admitted
+    /// order.
+    ///
+    /// # Overflow safety
+    ///
+    /// Each counter is bumped with a checked [`AtomicU64::fetch_update`] /
+    /// [`AtomicUsize::fetch_update`] (`checked_add`), which is an atomic
+    /// compare-exchange loop and therefore free of the check-then-`fetch_add`
+    /// TOCTOU race two concurrent admissions near `u64::MAX` would otherwise
+    /// hit. Capacity is reserved in the order visible → hidden → count; if a
+    /// later reservation overflows, the earlier ones are rolled back (by the
+    /// exact delta this call added — a commutative, concurrency-safe undo on
+    /// these advisory counters) before returning, so no counter is ever left
+    /// drifted. Only once all three are reserved is the order published to the
+    /// queue, so the queue can never hold an order whose admission overflowed a
+    /// counter — the invariant this method now upholds.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::InvalidOperation`] if admitting the order
+    /// would overflow the level's visible-quantity, hidden-quantity, or
+    /// order-count counter. In that case the level is unchanged.
+    pub fn add_order(&self, order: OrderType<()>) -> Result<Arc<OrderType<()>>, PriceLevelError> {
+        // Calculate quantities.
         let visible_qty = order.visible_quantity().as_u64();
         let hidden_qty = order.hidden_quantity().as_u64();
 
-        // On this path, publish to the queue FIRST, then bump the counters, so a
-        // concurrent reader of this add tends to see the order resting before it
-        // is counted rather than the reverse. This is a local ordering choice,
-        // not a cross-method guarantee (other paths, e.g. iceberg replenishment
-        // in `match_order`, adjust counters before pushing). The bare counters
-        // are advisory under concurrency; `snapshot()` is the mutually-consistent
-        // view (see `visible_quantity`).
+        // Reserve capacity on each counter BEFORE publishing, using a checked
+        // `fetch_update` (an atomic CAS loop). `Relaxed` on both the success and
+        // failure orderings: these are the advisory counters (issue #68); the
+        // queue publication below carries the real happens-before for a
+        // concurrent reader, so the counters are not a synchronization channel.
+        if self
+            .visible_quantity
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
+                c.checked_add(visible_qty)
+            })
+            .is_err()
+        {
+            return Err(PriceLevelError::InvalidOperation {
+                message: "price level visible quantity overflow on admission".to_string(),
+            });
+        }
+
+        if self
+            .hidden_quantity
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
+                c.checked_add(hidden_qty)
+            })
+            .is_err()
+        {
+            // Roll back the visible reservation this call made.
+            self.visible_quantity
+                .fetch_sub(visible_qty, Ordering::Relaxed);
+            return Err(PriceLevelError::InvalidOperation {
+                message: "price level hidden quantity overflow on admission".to_string(),
+            });
+        }
+
+        if self
+            .order_count
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| c.checked_add(1))
+            .is_err()
+        {
+            // Roll back the visible + hidden reservations this call made.
+            self.visible_quantity
+                .fetch_sub(visible_qty, Ordering::Relaxed);
+            self.hidden_quantity
+                .fetch_sub(hidden_qty, Ordering::Relaxed);
+            return Err(PriceLevelError::InvalidOperation {
+                message: "price level order count overflow on admission".to_string(),
+            });
+        }
+
+        // All capacity reserved; publish the order to the queue. A concurrent
+        // reader can briefly see the reserved count before the order rests
+        // (the advisory-counter window), but never the reverse overflow the
+        // reservation just ruled out.
         let order_arc = Arc::new(order);
         self.orders.push(order_arc.clone());
 
-        // Update atomic counters. `Relaxed` on all three: these are the
-        // advisory counters (issue #68). The queue publication above (the
-        // `push` into `OrderQueue`'s `SkipMap` / `DashMap`) carries the actual
-        // happens-before for a concurrent reader; the counters are not a
-        // synchronization channel, so a release here would publish nothing a
-        // reader relies on. The RMWs only need to be atomic, not ordered.
-        self.visible_quantity
-            .fetch_add(visible_qty, Ordering::Relaxed);
-        self.hidden_quantity
-            .fetch_add(hidden_qty, Ordering::Relaxed);
-        self.order_count.fetch_add(1, Ordering::Relaxed);
-
-        // Update statistics
+        // Update statistics only after a committed admission.
         self.stats.record_order_added();
 
-        order_arc
+        Ok(order_arc)
     }
 
     /// Creates a non-allocating iterator over current orders in this level.
@@ -1192,9 +1251,10 @@ impl TryFrom<PriceLevelData> for PriceLevel {
     fn try_from(data: PriceLevelData) -> Result<Self, Self::Error> {
         let price_level = PriceLevel::new(data.price);
 
-        // Add orders to the price level
+        // Add orders to the price level. Propagate an admission overflow rather
+        // than panicking while reconstructing from external data.
         for order in data.orders {
-            price_level.add_order(order);
+            price_level.add_order(order)?;
         }
 
         Ok(price_level)
@@ -1281,7 +1341,7 @@ impl FromStr for PriceLevel {
                                 message: format!("Order parse error: {e}"),
                             }
                         })?;
-                        price_level.add_order(order);
+                        price_level.add_order(order)?;
                         last_split = i + 1;
                     }
                     _ => {}
@@ -1295,7 +1355,7 @@ impl FromStr for PriceLevel {
                         message: format!("Order parse error: {e}"),
                     }
                 })?;
-                price_level.add_order(order);
+                price_level.add_order(order)?;
             }
         }
 

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -47,8 +47,10 @@ impl PriceLevel {
     ///
     /// # Errors
     ///
-    /// Returns [`PriceLevelError::InvalidOperation`] if recomputing the snapshot
-    /// aggregates overflows `u64`.
+    /// Returns [`PriceLevelError::InvalidOperation`] if any restored order's own
+    /// visible + hidden total overflows `u64`, or if recomputing the snapshot's
+    /// level aggregates overflows `u64` — the same per-order and per-level
+    /// invariants [`Self::add_order`] enforces at admission.
     pub fn from_snapshot(mut snapshot: PriceLevelSnapshot) -> Result<Self, PriceLevelError> {
         snapshot.refresh_aggregates()?;
 
@@ -220,13 +222,31 @@ impl PriceLevel {
     ///
     /// # Errors
     ///
-    /// Returns [`PriceLevelError::InvalidOperation`] if admitting the order
-    /// would overflow the level's visible-quantity, hidden-quantity, or
-    /// order-count counter. In that case the level is unchanged.
+    /// Returns [`PriceLevelError::InvalidOperation`] if the order's own
+    /// visible + hidden total overflows `u64`, or if admitting it would
+    /// overflow the level's visible-quantity, hidden-quantity, or order-count
+    /// counter. In every case the level is unchanged.
     pub fn add_order(&self, order: OrderType<()>) -> Result<Arc<OrderType<()>>, PriceLevelError> {
         // Calculate quantities.
         let visible_qty = order.visible_quantity().as_u64();
         let hidden_qty = order.hidden_quantity().as_u64();
+
+        // Reject an order whose OWN visible + hidden total is not representable
+        // in `u64`, before touching any counter. The level tracks visible and
+        // hidden in two independent `u64` counters, so an order with, say,
+        // visible `u64::MAX` and hidden `u64::MAX` would clear the per-counter
+        // reservations below yet leave the level holding an order whose total
+        // quantity overflows. Worse, the match sweep's reserve replenishment
+        // computes `new_visible + drawn_hidden` (see `OrderType::match_against`),
+        // where `drawn_hidden` is capped by the order's hidden tranche; that sum
+        // is `<= visible + hidden`, so it can only overflow `u64` when the
+        // order's own total already does. Enforcing the invariant here makes that
+        // replenish add provably overflow-free for every admitted order.
+        if visible_qty.checked_add(hidden_qty).is_none() {
+            return Err(PriceLevelError::InvalidOperation {
+                message: "order total quantity overflows u64".to_string(),
+            });
+        }
 
         // Reserve capacity on each counter BEFORE publishing, using a checked
         // `fetch_update` (an atomic CAS loop). `Relaxed` on both the success and
@@ -643,14 +663,28 @@ impl PriceLevel {
             new_remaining: u64,
         }
 
-        // Either the maker progressed (carrying `StepData`) or it was parked by
-        // the no-progress guard (`SetAside`). The parked variant threads the
-        // maker's id and insertion seq OUT of the locked decision closure so the
-        // no-progress `warn!` can name the parked maker without logging inside
-        // the per-entry lock.
+        // Either the maker progressed (carrying `StepData`), was parked by the
+        // no-progress guard (`SetAside`), or forced the sweep to abort because
+        // committing its replenishment would overflow the level's visible
+        // counter (`Abort`). The parked / abort variants thread the maker's id
+        // (and, for `SetAside`, its insertion seq) OUT of the locked decision
+        // closure so the `warn!` / `error!` can name the maker without logging
+        // inside the per-entry lock.
         enum StepResult {
             Progressed(StepData),
-            SetAside { maker_id: Id, seq: u64 },
+            SetAside {
+                maker_id: Id,
+                seq: u64,
+            },
+            /// The FIFO-front maker would replenish, but moving the drawn hidden
+            /// tranche into the level's visible counter would take it past
+            /// `u64::MAX` — a depth the level cannot represent. The maker is left
+            /// byte-identical (the queue action is `SetAside`, a pure no-op that
+            /// mutates nothing) and the sweep terminates immediately, so no
+            /// younger maker trades past this front and no counter wraps.
+            Abort {
+                maker_id: Id,
+            },
         }
 
         while remaining > 0 {
@@ -717,6 +751,35 @@ impl PriceLevel {
                     None => FrontAction::Remove,
                     Some(updated) => {
                         if hidden_reduced > 0 {
+                            // Replenishment: a fresh tranche moves from hidden
+                            // into visible, so the level's visible counter takes
+                            // the net delta `hidden_reduced - consumed` (the
+                            // `fetch_sub(consumed)` + `fetch_add(hidden_reduced)`
+                            // applied after this closure returns). Even when every
+                            // resting order's own total fits `u64`, the level's
+                            // visible SUM can exceed `u64::MAX` once hidden depth
+                            // is converted to visible — a state the counter (and
+                            // the true queue visible sum) cannot represent.
+                            //
+                            // Pre-validate that net delta against the LIVE visible
+                            // counter with checked arithmetic BEFORE committing:
+                            // read the counter (the same reserve-before-commit
+                            // pattern used under the entry lock), and if
+                            // `current - consumed + hidden_reduced` would not fit
+                            // `u64`, ABORT. The abort leaves the maker
+                            // byte-identical (`SetAside` mutates nothing), emits
+                            // no trade, and terminates the sweep, so no younger
+                            // maker trades past this FIFO front and the counter
+                            // never wraps. The stuck depth is unreachable until a
+                            // cancel / downsize frees headroom.
+                            let current_visible = self.visible_quantity.load(Ordering::Relaxed);
+                            let fits = current_visible
+                                .checked_sub(consumed)
+                                .and_then(|v| v.checked_add(hidden_reduced))
+                                .is_some();
+                            if !fits {
+                                return (FrontAction::SetAside, StepResult::Abort { maker_id });
+                            }
                             // Replenishment: refreshed tranche loses priority.
                             FrontAction::ReplaceAtTail(Arc::new(updated))
                         } else {
@@ -746,6 +809,25 @@ impl PriceLevel {
                                 "match sweep: front maker made no progress; set aside to avoid re-pop"
                             );
                             continue;
+                        }
+                        StepResult::Abort { maker_id } => {
+                            // The FIFO-front maker's replenishment would overflow
+                            // the level's visible counter. The queue committed a
+                            // no-op (`SetAside`), so the maker rests unchanged and
+                            // no counter moved. Terminate the sweep here WITHOUT
+                            // decrementing `remaining`: no trade is emitted for
+                            // this maker, and stopping (rather than advancing to a
+                            // younger maker) preserves strict FIFO — liquidity
+                            // behind this front stays unreachable until a cancel /
+                            // downsize frees enough headroom to represent the
+                            // replenished depth.
+                            tracing::error!(
+                                price = self.price,
+                                remaining,
+                                order_id = %maker_id,
+                                "match sweep aborted: replenishment would overflow the level visible counter; front maker left intact, sweep terminated"
+                            );
+                            break;
                         }
                         StepResult::Progressed(data) => data,
                     };
@@ -956,8 +1038,10 @@ impl PriceLevel {
     ///
     /// Returns [`PriceLevelError::InvalidOperation`] if an
     /// [`OrderUpdate::UpdatePrice`] / [`OrderUpdate::Replace`] would not move
-    /// the order to a different price level, or if computing an order's total
-    /// quantity overflows `u64`.
+    /// the order to a different price level, if computing an order's total
+    /// quantity overflows `u64`, or if applying a quantity update's counter
+    /// delta would take the level's visible- or hidden-quantity counter past
+    /// `u64::MAX` (rejected with the queue and counters untouched).
     #[must_use = "the updated order (or None when the order is absent) must be handled"]
     pub fn update_order(
         &self,
@@ -1035,6 +1119,37 @@ impl PriceLevel {
                         message: "order total quantity overflow".to_string(),
                     }
                 })?;
+
+                // Pre-validate the LEVEL counter deltas before mutating the
+                // queue: an upsize (or a visible/hidden reshuffle) whose delta
+                // would take a level counter past `u64::MAX` must be rejected
+                // with the queue and counters untouched, never committed and then
+                // wrapped by the raw `fetch_add` below. Project each counter from
+                // its live value using the pre-read order's components as `old`;
+                // if either projection does not fit `u64`, reject.
+                //
+                // This uses the pre-read `order` (not the value the queue mutation
+                // will actually replace), so a concurrent update of the same id
+                // could make the projection stale (TOCTOU) — strictly better than
+                // the unchecked wrap it replaces, and #115 closes the window
+                // exactly by reserving under the entry lock.
+                let old_visible_pre = order.visible_quantity().as_u64();
+                let old_hidden_pre = order.hidden_quantity().as_u64();
+                let projects = |counter: &AtomicU64, old: u64, new: u64| -> bool {
+                    let cur = counter.load(Ordering::Relaxed);
+                    if new >= old {
+                        cur.checked_add(new - old).is_some()
+                    } else {
+                        cur.checked_sub(old - new).is_some()
+                    }
+                };
+                if !projects(&self.visible_quantity, old_visible_pre, new_visible)
+                    || !projects(&self.hidden_quantity, old_hidden_pre, new_hidden)
+                {
+                    return Err(PriceLevelError::InvalidOperation {
+                        message: "price level quantity counter overflow on update".to_string(),
+                    });
+                }
 
                 let new_order_arc = Arc::new(new_order);
 

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -97,7 +97,13 @@ impl OrderQueue {
     /// id may collide with a live order, use [`OrderQueue::try_push`], which
     /// rejects the duplicate instead of overwriting it (leaving the id-keyed map
     /// and the ordered index disagreeing).
-    pub fn push(&self, order: Arc<OrderType<()>>) {
+    ///
+    /// `pub(crate)`: overwriting publication is never safe to expose — a caller
+    /// that reused a live id would silently replace the resting order and strand
+    /// its old index entry. Admission goes through [`OrderQueue::try_push`] /
+    /// [`OrderQueue::try_push_with`]; this stays available only to the in-crate
+    /// upsize re-insert, whose id is provably absent at the call site.
+    pub(crate) fn push(&self, order: Arc<OrderType<()>>) {
         // `Relaxed` is sufficient: only the uniqueness and monotonicity of the
         // counter matter. The happens-before ordering between concurrent
         // producers/consumers is provided by the lock-free `index`/`orders`
@@ -111,20 +117,12 @@ impl OrderQueue {
     /// Insert an order only if its id is not already present — the admission
     /// primitive.
     ///
-    /// Uses the `DashMap` entry API so the insert-if-absent decision is atomic
-    /// under the per-shard lock: given several concurrent submissions of the
-    /// same id, exactly one observes `Vacant` and inserts; every other observes
-    /// `Occupied` and is rejected with
-    /// [`PriceLevelError::DuplicateOrderId`], leaving the map value, the index,
-    /// and the sequence counter untouched. A duplicate admitted through this
-    /// method therefore can never produce the two-sequences-for-one-id state
-    /// that a blind [`OrderQueue::push`] would. (The quantity-increase update
-    /// path still vacates the id across its remove-then-push re-insert; that
-    /// residual window is closed by the atomic re-sequencing work in #119.)
-    ///
-    /// The insertion sequence is minted **inside** the `Vacant` arm, so a
-    /// rejected duplicate does not consume a sequence (no gaps) and the index
-    /// entry is added only for the order that actually landed in the map.
+    /// Thin wrapper over the crate-internal `try_push_with` with a no-op
+    /// reservation: the id-uniqueness, held-lock publication, and
+    /// no-sequence-gap guarantees documented there all apply. Use this when
+    /// publication has no side effects to commit atomically with it; the
+    /// reservation-hook form commits a caller-side reservation (e.g. the level's
+    /// atomic counters) under the same shard lock that decides the id is free.
     ///
     /// # Errors
     ///
@@ -132,15 +130,82 @@ impl OrderQueue {
     /// id already rests in the queue.
     #[must_use = "a rejected duplicate must be handled, not ignored"]
     pub fn try_push(&self, order: Arc<OrderType<()>>) -> Result<(), PriceLevelError> {
+        self.try_push_with(order, || Ok(()))
+    }
+
+    /// Insert an order only if its id is absent, committing a caller-supplied
+    /// `reserve` step **atomically with the publication** — the admission
+    /// primitive with a reservation hook.
+    ///
+    /// The `DashMap` entry API makes the whole operation atomic under the
+    /// per-shard lock:
+    ///
+    /// 1. **Identity is decided first.** An `Occupied` entry means the id
+    ///    already rests here: return [`PriceLevelError::DuplicateOrderId`]
+    ///    with **nothing touched** — `reserve` is never run, no sequence is
+    ///    minted, no counter moves. This is why a duplicate can never leave a
+    ///    transient side effect (e.g. an inflated level counter) for another
+    ///    thread to observe, and why a duplicate at counter capacity reports
+    ///    `DuplicateOrderId` rather than a spurious overflow.
+    /// 2. **Then `reserve` runs**, still under the shard lock, now that the id
+    ///    is known free. If it returns `Err`, propagate it with nothing
+    ///    inserted — the caller is responsible for leaving its own state
+    ///    unchanged on `Err` (e.g. rolling back a partial multi-counter
+    ///    reservation before returning).
+    /// 3. **Then publish, holding the shard lock across the index insert.** The
+    ///    map value is inserted (its returned guard keeps the shard write lock),
+    ///    the `seq -> id` index entry is added while that guard is still held,
+    ///    and only then is the guard dropped. Holding the lock across both
+    ///    publications closes the window where the lock released after the map
+    ///    insert but before the index insert: a concurrent cancel + same-id
+    ///    readmission could otherwise land its own entries and let this call's
+    ///    stale index insert produce two index entries for one id. This is the
+    ///    same held-lock shape [`OrderQueue::match_front`]'s `ReplaceAtTail`
+    ///    uses. `self.index` is a separate structure (`SkipMap`), so inserting
+    ///    into it under the `DashMap` shard lock cannot deadlock.
+    ///
+    /// The insertion sequence is minted **inside** the `Vacant` arm, after
+    /// `reserve` succeeds, so neither a rejected duplicate nor a failed
+    /// reservation consumes a sequence (no gaps) and the index entry is added
+    /// only for the order that actually landed in the map.
+    ///
+    /// `reserve` runs while the shard lock is held, so it MUST NOT call back
+    /// into this queue (that would deadlock on the same shard) and MUST NOT
+    /// block; the level's counter reservations (plain atomic RMWs) satisfy both.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::DuplicateOrderId`] if an order with the same
+    /// id already rests in the queue, or whatever error `reserve` returns.
+    #[must_use = "a rejected admission must be handled, not ignored"]
+    pub(crate) fn try_push_with<F>(
+        &self,
+        order: Arc<OrderType<()>>,
+        reserve: F,
+    ) -> Result<(), PriceLevelError>
+    where
+        F: FnOnce() -> Result<(), PriceLevelError>,
+    {
         let order_id = order.id();
         match self.orders.entry(order_id) {
             Entry::Occupied(_) => Err(PriceLevelError::DuplicateOrderId(order_id.to_string())),
             Entry::Vacant(slot) => {
-                // Mint the sequence only now that we know the id is free, so a
-                // rejected duplicate leaves the counter (and the index) alone.
+                // Identity is already decided (this arm means the id is free).
+                // Run the caller's reservation before publishing; on failure
+                // nothing has been inserted and no sequence minted, so the
+                // level stays byte-identical once the caller unwinds its own
+                // partial reservation.
+                reserve()?;
+                // Mint the sequence only now that the id is free and the
+                // reservation committed, so neither a rejected duplicate nor a
+                // failed reservation leaves a gap in the sequence.
                 let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
-                slot.insert((seq, order));
+                // Hold the shard lock across BOTH publications: the map insert
+                // returns a guard that keeps the lock, the index entry is added
+                // while it is held, and only then is the guard dropped.
+                let guard = slot.insert((seq, order));
                 self.index.insert(seq, order_id);
+                drop(guard);
                 Ok(())
             }
         }
@@ -387,6 +452,31 @@ impl OrderQueue {
         Some(order)
     }
 
+    /// Test-only invariant check: the id-keyed map and the ordered index are
+    /// **1:1**. Must be called only at quiescence (no concurrent mutation), when
+    /// every in-flight operation has completed.
+    ///
+    /// Verifies there are exactly as many index entries as map entries and that
+    /// every index entry `seq -> id` points to a map entry whose stored sequence
+    /// is exactly `seq`. A split index entry (two sequences for one id — the
+    /// publication-race bug closed by [`OrderQueue::try_push_with`] holding the
+    /// shard lock across both publications) makes the index longer than the map,
+    /// so this returns `false`.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn debug_map_index_consistent(&self) -> bool {
+        if self.index.len() != self.orders.len() {
+            return false;
+        }
+        self.index.iter().all(|entry| {
+            let seq = *entry.key();
+            let id = *entry.value();
+            self.orders
+                .get(&id)
+                .is_some_and(|slot| slot.value().0 == seq)
+        })
+    }
+
     /// Iterate through current orders without materializing an intermediate vector.
     pub fn iter_orders(&self) -> impl Iterator<Item = Arc<OrderType<()>>> + '_ {
         self.orders.iter().map(|entry| entry.value().1.clone())
@@ -495,9 +585,16 @@ impl OrderQueue {
     /// ordered index always stay 1:1. Callers that must *reject* a
     /// duplicate-bearing vector (e.g. snapshot restore) validate uniqueness
     /// upstream where a `Result` can be returned.
+    ///
+    /// `pub(crate)`: a keep-first constructor that silently drops duplicates is
+    /// not a safe public entry point (a caller could restore counters computed
+    /// over a copy the queue then discards). The public path is
+    /// [`PriceLevel::from_snapshot`](crate::price_level::PriceLevel), which
+    /// rejects duplicates; this stays crate-internal for tests and the
+    /// upstream-validated restore.
     #[allow(dead_code)]
     #[must_use]
-    pub fn from_vec(orders: Vec<Arc<OrderType<()>>>) -> Self {
+    pub(crate) fn from_vec(orders: Vec<Arc<OrderType<()>>>) -> Self {
         let queue = OrderQueue::new();
         for order in orders {
             // Keep-first on a duplicate id: the index must stay 1:1.

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -88,7 +88,15 @@ impl OrderQueue {
         }
     }
 
-    /// Add an order to the tail of the queue (newest time priority).
+    /// Add an order to the tail of the queue (newest time priority),
+    /// **unconditionally overwriting** any existing entry for the same id.
+    ///
+    /// This is the re-insert primitive for a maker that was just removed and is
+    /// being put back under a fresh sequence (the upsize `remove` + `push`
+    /// demotion), where the id is guaranteed absent. For *admission*, where the
+    /// id may collide with a live order, use [`OrderQueue::try_push`], which
+    /// rejects the duplicate instead of overwriting it (leaving the id-keyed map
+    /// and the ordered index disagreeing).
     pub fn push(&self, order: Arc<OrderType<()>>) {
         // `Relaxed` is sufficient: only the uniqueness and monotonicity of the
         // counter matter. The happens-before ordering between concurrent
@@ -98,6 +106,44 @@ impl OrderQueue {
         let order_id = order.id();
         self.orders.insert(order_id, (seq, order));
         self.index.insert(seq, order_id);
+    }
+
+    /// Insert an order only if its id is not already present — the admission
+    /// primitive.
+    ///
+    /// Uses the `DashMap` entry API so the insert-if-absent decision is atomic
+    /// under the per-shard lock: given several concurrent submissions of the
+    /// same id, exactly one observes `Vacant` and inserts; every other observes
+    /// `Occupied` and is rejected with
+    /// [`PriceLevelError::DuplicateOrderId`], leaving the map value, the index,
+    /// and the sequence counter untouched. A duplicate admitted through this
+    /// method therefore can never produce the two-sequences-for-one-id state
+    /// that a blind [`OrderQueue::push`] would. (The quantity-increase update
+    /// path still vacates the id across its remove-then-push re-insert; that
+    /// residual window is closed by the atomic re-sequencing work in #119.)
+    ///
+    /// The insertion sequence is minted **inside** the `Vacant` arm, so a
+    /// rejected duplicate does not consume a sequence (no gaps) and the index
+    /// entry is added only for the order that actually landed in the map.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::DuplicateOrderId`] if an order with the same
+    /// id already rests in the queue.
+    #[must_use = "a rejected duplicate must be handled, not ignored"]
+    pub fn try_push(&self, order: Arc<OrderType<()>>) -> Result<(), PriceLevelError> {
+        let order_id = order.id();
+        match self.orders.entry(order_id) {
+            Entry::Occupied(_) => Err(PriceLevelError::DuplicateOrderId(order_id.to_string())),
+            Entry::Vacant(slot) => {
+                // Mint the sequence only now that we know the id is free, so a
+                // rejected duplicate leaves the counter (and the index) alone.
+                let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
+                slot.insert((seq, order));
+                self.index.insert(seq, order_id);
+                Ok(())
+            }
+        }
     }
 
     /// Pop the front (oldest) order together with its insertion sequence,
@@ -444,12 +490,18 @@ impl OrderQueue {
     ///
     /// A new `OrderQueue` instance containing all the orders from the input vector.
     ///
+    /// Note: this infallible constructor drops later orders that repeat an id
+    /// already inserted (keep-first), so the queue's id-keyed map and its
+    /// ordered index always stay 1:1. Callers that must *reject* a
+    /// duplicate-bearing vector (e.g. snapshot restore) validate uniqueness
+    /// upstream where a `Result` can be returned.
     #[allow(dead_code)]
     #[must_use]
     pub fn from_vec(orders: Vec<Arc<OrderType<()>>>) -> Self {
         let queue = OrderQueue::new();
         for order in orders {
-            queue.push(order);
+            // Keep-first on a duplicate id: the index must stay 1:1.
+            let _ = queue.try_push(order);
         }
         queue
     }
@@ -520,7 +572,8 @@ impl FromStr for OrderQueue {
                     OrderType::from_str(order_str).map_err(|e| PriceLevelError::ParseError {
                         message: format!("Order parse error: {e}"),
                     })?;
-                queue.push(Arc::new(order));
+                // Reject a repeated id rather than overwriting it.
+                queue.try_push(Arc::new(order))?;
             }
         }
 
@@ -544,10 +597,13 @@ impl Display for OrderQueue {
 }
 
 impl From<Vec<Arc<OrderType<()>>>> for OrderQueue {
+    /// Infallible conversion: a repeated id is dropped (keep-first) so the map
+    /// and index stay 1:1. Restore paths that must reject duplicates validate
+    /// uniqueness upstream (see [`crate::price_level::PriceLevel::from_snapshot`]).
     fn from(orders: Vec<Arc<OrderType<()>>>) -> Self {
         let queue = OrderQueue::new();
         for order in orders {
-            queue.push(order);
+            let _ = queue.try_push(order);
         }
         queue
     }
@@ -579,9 +635,12 @@ impl<'de> Visitor<'de> for OrderQueueVisitor {
     {
         let queue = OrderQueue::new();
 
-        // Deserialize each order and add it to the queue
+        // Deserialize each order and add it to the queue, rejecting a repeated
+        // id rather than silently overwriting it.
         while let Some(order) = seq.next_element::<OrderType<()>>()? {
-            queue.push(Arc::new(order));
+            queue
+                .try_push(Arc::new(order))
+                .map_err(serde::de::Error::custom)?;
         }
 
         Ok(queue)

--- a/src/price_level/snapshot.rs
+++ b/src/price_level/snapshot.rs
@@ -215,8 +215,9 @@ impl PriceLevelSnapshot {
     ///
     /// # Errors
     ///
-    /// Returns [`PriceLevelError::InvalidOperation`] if summing the per-order
-    /// visible or hidden quantities overflows `u64`.
+    /// Returns [`PriceLevelError::InvalidOperation`] if any single order's own
+    /// visible + hidden total overflows `u64`, or if summing the per-order
+    /// visible or hidden quantities across the level overflows `u64`.
     pub fn refresh_aggregates(&mut self) -> Result<(), PriceLevelError> {
         self.order_count = self.orders.len();
 
@@ -224,6 +225,22 @@ impl PriceLevelSnapshot {
         let mut hidden_total: u64 = 0;
 
         for order in &self.orders {
+            // Reject any order whose OWN visible + hidden total is not
+            // representable in `u64`. `PriceLevel::add_order` enforces this same
+            // per-order invariant at admission, and the match sweep's reserve
+            // replenishment relies on it (a refreshed tranche is
+            // `new_visible + drawn_hidden <= visible + hidden`, which overflows
+            // only if the order's own total already does). Restoring such an
+            // order would smuggle in a state admission rejects, so the restore
+            // path validates it too rather than trusting the serialized bytes.
+            order
+                .visible_quantity()
+                .as_u64()
+                .checked_add(order.hidden_quantity().as_u64())
+                .ok_or_else(|| PriceLevelError::InvalidOperation {
+                    message: "order total quantity overflows u64".to_string(),
+                })?;
+
             visible_total = visible_total
                 .checked_add(order.visible_quantity().as_u64())
                 .ok_or_else(|| PriceLevelError::InvalidOperation {

--- a/src/price_level/tests/entry.rs
+++ b/src/price_level/tests/entry.rs
@@ -134,7 +134,7 @@ mod tests {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        level.add_order(order);
+        level.add_order(order).expect("add_order should succeed");
 
         // Serialize the entry
         let json = serde_json::to_string(&entry).unwrap();
@@ -227,7 +227,9 @@ mod tests_order_book_entry {
             extra_fields: (),
         };
 
-        level1.add_order(order_type);
+        level1
+            .add_order(order_type)
+            .expect("add_order should succeed");
         assert_eq!(entry1.order_count(), 1);
 
         // Add another order
@@ -242,7 +244,9 @@ mod tests_order_book_entry {
             extra_fields: (),
         };
 
-        level1.add_order(order_type2);
+        level1
+            .add_order(order_type2)
+            .expect("add_order should succeed");
         assert_eq!(entry1.order_count(), 2);
     }
 
@@ -373,7 +377,9 @@ mod tests_order_book_entry {
             time_in_force: crate::orders::TimeInForce::Gtc,
             extra_fields: (),
         };
-        level.add_order(standard_order);
+        level
+            .add_order(standard_order)
+            .expect("add_order should succeed");
 
         // Check quantities after adding order
         assert_eq!(entry.visible_quantity(), 10);
@@ -391,7 +397,9 @@ mod tests_order_book_entry {
             time_in_force: crate::orders::TimeInForce::Gtc,
             extra_fields: (),
         };
-        level.add_order(iceberg_order);
+        level
+            .add_order(iceberg_order)
+            .expect("add_order should succeed");
 
         // Check quantities after adding iceberg order
         assert_eq!(entry.visible_quantity(), 15); // 10 + 5

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -6327,29 +6327,123 @@ mod tests {
     }
 
     #[test]
-    fn test_reserve_replenish_overflow_no_trade_maker_preserved() {
-        // A reserve whose visible + hidden exceed u64::MAX is admissible (the
-        // two are separate u64 counters). A partial match that would replenish
-        // it computes `new_visible + replenish_qty`, which overflows u64. The
-        // match step must fail atomically: no trade, maker unchanged, no panic
-        // (this test runs under debug assertions, where an unchecked `+` would
-        // panic).
+    fn test_reserve_own_total_overflow_rejected_at_admission() {
+        // A reserve whose OWN visible + hidden overflows u64 is now rejected at
+        // admission (issue #111 follow-up): the level cannot hold an order whose
+        // total quantity is not representable, and the match sweep's replenish
+        // add relies on that invariant. Nothing is mutated on rejection.
+        let level = PriceLevel::new(10_000);
+        match level.add_order(create_reserve_order(
+            1,
+            10_000,
+            u64::MAX,       // visible
+            u64::MAX,       // hidden -> visible + hidden overflows u64
+            u64::MAX,       // threshold
+            true,           // auto_replenish
+            Some(u64::MAX), // replenish amount
+        )) {
+            Err(PriceLevelError::InvalidOperation { message }) => {
+                assert!(
+                    message.contains("order total quantity overflows u64"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected order-total-overflow InvalidOperation, got {other:?}"),
+        }
+
+        // The level is untouched: no counters, no order, no stats moved.
+        assert_eq!(level.visible_quantity(), 0);
+        assert_eq!(level.hidden_quantity(), 0);
+        assert_eq!(level.order_count(), 0);
+        assert_eq!(level.snapshot_by_insertion_seq().len(), 0);
+    }
+
+    #[test]
+    fn test_iceberg_own_total_overflow_rejected_at_admission() {
+        // Same per-order invariant for an iceberg: visible + hidden must fit u64.
+        let level = PriceLevel::new(10_000);
+        match level.add_order(create_iceberg_order(1, 10_000, u64::MAX, u64::MAX)) {
+            Err(PriceLevelError::InvalidOperation { message }) => {
+                assert!(
+                    message.contains("order total quantity overflows u64"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected order-total-overflow InvalidOperation, got {other:?}"),
+        }
+
+        assert_eq!(level.visible_quantity(), 0);
+        assert_eq!(level.hidden_quantity(), 0);
+        assert_eq!(level.order_count(), 0);
+        assert_eq!(level.snapshot_by_insertion_seq().len(), 0);
+    }
+
+    #[test]
+    fn test_from_snapshot_rejects_order_own_total_overflow() {
+        // The restore path admits orders too, so it enforces the SAME per-order
+        // total invariant as add_order: a snapshot carrying an order whose own
+        // visible + hidden overflows u64 is rejected (via the topology scan in
+        // `refresh_aggregates`, shared by `from_snapshot` and the checksum
+        // package path) rather than smuggled in.
+        let overflowing = create_iceberg_order(1, 10_000, u64::MAX, u64::MAX);
+        let snapshot = crate::price_level::PriceLevelSnapshot::from_raw_parts(
+            Price::new(10_000),
+            // Stored aggregates are recomputed by `refresh_aggregates`; the
+            // per-order scan rejects the order before they matter.
+            Quantity::new(0),
+            Quantity::new(0),
+            1,
+            vec![std::sync::Arc::new(overflowing)],
+        );
+
+        match PriceLevel::from_snapshot(snapshot) {
+            Err(PriceLevelError::InvalidOperation { message }) => {
+                assert!(
+                    message.contains("order total quantity overflows u64"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => {
+                panic!("expected order-total-overflow InvalidOperation on restore, got {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn test_replenish_would_wrap_level_counter_aborts_sweep_no_trade() {
+        // Issue #111 follow-up, finding 2: even when every order's OWN total
+        // fits u64, converting hidden depth to visible can push the LEVEL visible
+        // counter (and the true queue visible sum) past u64::MAX. The sweep must
+        // abort at the FIFO front rather than wrap the counter or trade a younger
+        // maker.
+        //
+        // auto-reserve(visible 1, hidden 100, replenish 100) admitted FIRST
+        // (own total 101, fits) + standard(visible u64::MAX - 1) admitted second
+        // (own total fits). Level visible counter = 1 + (u64::MAX - 1) = u64::MAX.
         let level = PriceLevel::new(10_000);
         level
             .add_order(create_reserve_order(
                 1,
                 10_000,
-                u64::MAX,       // visible
-                u64::MAX,       // hidden
-                u64::MAX,       // threshold: any partial fill falls below -> replenish
-                true,           // auto_replenish
-                Some(u64::MAX), // replenish amount: draws the full hidden
+                1,
+                100,
+                100,
+                true,
+                Some(100),
             ))
-            .expect("reserve with separately-valid u64 components must admit");
+            .expect("reserve own total fits u64");
+        level
+            .add_order(create_standard_order(2, 10_000, u64::MAX - 1))
+            .expect("standard own total fits u64");
+        assert_eq!(level.visible_quantity(), u64::MAX);
+
+        let before_json = level.snapshot_to_json().expect("snapshot serializes");
 
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let generator = UuidGenerator::new(namespace);
-        // A tiny taker triggers a partial fill and the overflowing replenish.
+        // A one-unit taker: consuming the reserve's visible 1 IS representable,
+        // but the +100 replenish would take the level visible counter to
+        // u64::MAX + 99 -> the sweep aborts at the reserve.
         let result = level.match_order(
             1,
             Id::from_u64(999),
@@ -6359,31 +6453,82 @@ mod tests {
             &generator,
         );
 
-        // No trade emitted and the taker is left fully unconsumed.
-        assert_eq!(
-            result.trades().len(),
-            0,
-            "an overflowing replenish must emit no trade"
-        );
+        // Zero trades, taker remainder full: the reserve's 1-unit fill was NOT
+        // emitted because it is inseparable from the overflowing replenish.
+        assert_eq!(result.trades().len(), 0, "aborted sweep must emit no trade");
         assert_eq!(
             result.remaining_quantity().as_u64(),
             1,
             "the taker must be left fully unconsumed"
         );
 
-        // The maker is still resting, unchanged.
-        let resting = level.snapshot_by_insertion_seq();
-        assert_eq!(resting.len(), 1, "the maker must still rest");
-        assert_eq!(resting[0].id(), Id::from_u64(1));
+        // NO wrap: the level visible counter is still exactly u64::MAX.
         assert_eq!(
-            resting[0].visible_quantity().as_u64(),
+            level.visible_quantity(),
             u64::MAX,
-            "maker visible quantity must be unchanged"
+            "the level visible counter must not have wrapped"
         );
+        assert_eq!(level.hidden_quantity(), 100, "hidden counter unchanged");
+        assert_eq!(level.order_count(), 2, "both makers still rest");
+
+        // Both makers are byte-identical, and FIFO is preserved: the younger
+        // standard maker did NOT trade and the reserve is untouched.
+        let resting = level.snapshot_by_insertion_seq();
+        assert_eq!(resting.len(), 2);
+        assert_eq!(resting[0].id(), Id::from_u64(1));
+        assert_eq!(resting[0].visible_quantity().as_u64(), 1);
+        assert_eq!(resting[0].hidden_quantity().as_u64(), 100);
+        assert_eq!(resting[1].id(), Id::from_u64(2));
+        assert_eq!(resting[1].visible_quantity().as_u64(), u64::MAX - 1);
+
+        // counters == queue == snapshot: the snapshot is byte-identical to the
+        // pre-match one, proving no counter drifted from the queue.
+        let after_json = level.snapshot_to_json().expect("snapshot serializes");
         assert_eq!(
-            resting[0].hidden_quantity().as_u64(),
-            u64::MAX,
-            "maker hidden quantity must be unchanged"
+            before_json, after_json,
+            "an aborted sweep must leave the level byte-identical"
+        );
+    }
+
+    #[test]
+    fn test_update_order_upsize_wrapping_level_counter_rejected() {
+        // update_order must reject a quantity update whose counter delta would
+        // wrap the level visible counter, leaving the level unchanged and
+        // deterministic. Fill the visible counter to u64::MAX with a standard
+        // maker, add a tiny second maker, then try to upsize the tiny one — its
+        // +delta would take the counter past u64::MAX.
+        let level = PriceLevel::new(10_000);
+        level
+            .add_order(create_standard_order(1, 10_000, u64::MAX - 5))
+            .expect("first admission ok");
+        level
+            .add_order(create_standard_order(2, 10_000, 5))
+            .expect("second admission reaches exactly u64::MAX");
+        assert_eq!(level.visible_quantity(), u64::MAX);
+
+        let before_json = level.snapshot_to_json().expect("snapshot serializes");
+
+        // Upsize maker 2 from 5 to 10: delta +5 would wrap the level counter.
+        match level.update_order(OrderUpdate::UpdateQuantity {
+            order_id: Id::from_u64(2),
+            new_quantity: Quantity::new(10),
+        }) {
+            Err(PriceLevelError::InvalidOperation { message }) => {
+                assert!(
+                    message.contains("price level quantity counter overflow on update"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected counter-overflow InvalidOperation, got {other:?}"),
+        }
+
+        // Nothing mutated: counters, order sizes, and a byte-identical snapshot.
+        assert_eq!(level.visible_quantity(), u64::MAX);
+        assert_eq!(level.order_count(), 2);
+        let after_json = level.snapshot_to_json().expect("snapshot serializes");
+        assert_eq!(
+            before_json, after_json,
+            "a rejected update must leave the level byte-identical"
         );
     }
 

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -36,8 +36,12 @@ mod tests {
     #[test]
     fn test_price_level_snapshot_roundtrip() {
         let price_level = PriceLevel::new(10000);
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_iceberg_order(2, 10000, 50, 200));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_iceberg_order(2, 10000, 50, 200))
+            .expect("add_order should succeed");
 
         let package = price_level
             .snapshot_package()
@@ -73,7 +77,9 @@ mod tests {
     #[test]
     fn test_price_level_snapshot_checksum_failure() {
         let price_level = PriceLevel::new(20000);
-        price_level.add_order(create_standard_order(1, 20000, 100));
+        price_level
+            .add_order(create_standard_order(1, 20000, 100))
+            .expect("add_order should succeed");
 
         let package = price_level
             .snapshot_package()
@@ -109,9 +115,15 @@ mod tests {
 
         // Rest several makers so we accumulate non-trivial waiting-time and
         // arrival aggregates, then partially match them to drive every counter.
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 100));
-        price_level.add_order(create_standard_order(3, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(3, 10000, 100))
+            .expect("add_order should succeed");
 
         // Execution timestamp is comfortably after the order arrival timestamps
         // (TIMESTAMP_COUNTER starts at 1_616_823_000_000), so waiting times are
@@ -190,7 +202,9 @@ mod tests {
         // with a clear version mismatch (InvalidOperation), not a checksum error
         // and not a panic.
         let price_level = PriceLevel::new(10000);
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let json = price_level
             .snapshot_to_json()
@@ -225,10 +239,18 @@ mod tests {
     #[test]
     fn test_price_level_from_snapshot_preserves_order_positions() {
         let price_level = PriceLevel::new(15000);
-        price_level.add_order(create_standard_order(1, 15000, 100));
-        price_level.add_order(create_iceberg_order(2, 15000, 40, 120));
-        price_level.add_order(create_post_only_order(3, 15000, 60));
-        price_level.add_order(create_reserve_order(4, 15000, 30, 90, 15, true, Some(20)));
+        price_level
+            .add_order(create_standard_order(1, 15000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_iceberg_order(2, 15000, 40, 120))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_post_only_order(3, 15000, 60))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_reserve_order(4, 15000, 30, 90, 15, true, Some(20)))
+            .expect("add_order should succeed");
 
         let snapshot = price_level.snapshot();
         let restored = PriceLevel::from(&snapshot);
@@ -258,10 +280,18 @@ mod tests {
     #[test]
     fn test_price_level_from_snapshot_package_preserves_order_positions() {
         let price_level = PriceLevel::new(17500);
-        price_level.add_order(create_standard_order(10, 17500, 80));
-        price_level.add_order(create_trailing_stop_order(11, 17500, 50));
-        price_level.add_order(create_pegged_order(12, 17500, 40));
-        price_level.add_order(create_market_to_limit_order(13, 17500, 70));
+        price_level
+            .add_order(create_standard_order(10, 17500, 80))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_trailing_stop_order(11, 17500, 50))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_pegged_order(12, 17500, 40))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_market_to_limit_order(13, 17500, 70))
+            .expect("add_order should succeed");
 
         let package = price_level
             .snapshot_package()
@@ -460,7 +490,9 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let order = create_standard_order(1, 10000, 100);
 
-        let order_arc = price_level.add_order(order);
+        let order_arc = price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         assert_eq!(price_level.visible_quantity(), 100);
         assert_eq!(price_level.hidden_quantity(), 0);
@@ -481,7 +513,9 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let order = create_iceberg_order(2, 10000, 50, 200);
 
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         assert_eq!(price_level.visible_quantity(), 50);
         assert_eq!(price_level.hidden_quantity(), 200);
@@ -494,10 +528,18 @@ mod tests {
         let price_level = PriceLevel::new(10000);
 
         // Add different order types
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_iceberg_order(2, 10000, 50, 200));
-        price_level.add_order(create_post_only_order(3, 10000, 75));
-        price_level.add_order(create_reserve_order(4, 10000, 25, 100, 100, true, None));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_iceberg_order(2, 10000, 50, 200))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_post_only_order(3, 10000, 75))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_reserve_order(4, 10000, 25, 100, 100, true, None))
+            .expect("add_order should succeed");
 
         assert_eq!(price_level.visible_quantity(), 250); // 100 + 50 + 75 + 25
         assert_eq!(price_level.hidden_quantity(), 300); // 0 + 200 + 0 + 100
@@ -512,8 +554,12 @@ mod tests {
     fn test_update_order_cancel() {
         let price_level = PriceLevel::new(10000);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_iceberg_order(2, 10000, 50, 200));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_iceberg_order(2, 10000, 50, 200))
+            .expect("add_order should succeed");
 
         // Cancel the standard order using OrderUpdate
         let result = price_level.update_order(OrderUpdate::Cancel {
@@ -557,8 +603,12 @@ mod tests {
     fn test_iter_orders() {
         let price_level = PriceLevel::new(10000);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_iceberg_order(2, 10000, 50, 200));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_iceberg_order(2, 10000, 50, 200))
+            .expect("add_order should succeed");
 
         let orders = price_level.snapshot_orders();
 
@@ -576,7 +626,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Match the entire order
         let taker_id = Id::from_u64(999); // market order ID
@@ -640,9 +692,15 @@ mod tests {
         // the last maker) so the trade stream has multiple entries.
         let run = || {
             let price_level = PriceLevel::new(10000);
-            price_level.add_order(mk(1, 40));
-            price_level.add_order(mk(2, 30));
-            price_level.add_order(mk(3, 50));
+            price_level
+                .add_order(mk(1, 40))
+                .expect("add_order should succeed");
+            price_level
+                .add_order(mk(2, 30))
+                .expect("add_order should succeed");
+            price_level
+                .add_order(mk(3, 50))
+                .expect("add_order should succeed");
 
             let trade_id_generator = UuidGenerator::new(namespace);
             price_level.match_order(
@@ -682,7 +740,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Match part of the order
         let taker_id = Id::from_u64(999);
@@ -725,7 +785,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Match with quantity exceeding available
         let taker_id = Id::from_u64(999);
@@ -768,7 +830,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Add a new iceberg order with a visible quantity of 50 and a hidden quantity of 100.
-        price_level.add_order(create_iceberg_order(1, 10000, 50, 100));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 50, 100))
+            .expect("add_order should succeed");
 
         // Match the visible portion of the iceberg order.
         let taker_id = Id::from_u64(999);
@@ -849,7 +913,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Add a new iceberg order with a visible quantity of 50 and a hidden quantity of 100.
-        price_level.add_order(create_iceberg_order(1, 10000, 100, 100));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 100, 100))
+            .expect("add_order should succeed");
 
         // Match the visible portion of the iceberg order.
         let taker_id = Id::from_u64(999);
@@ -931,7 +997,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_iceberg_order(1, 10000, 50, 150));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 50, 150))
+            .expect("add_order should succeed");
 
         // Match part of the visible portion
         let taker_id = Id::from_u64(999);
@@ -963,7 +1031,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Create a reserve order with auto-replenish disabled
-        price_level.add_order(create_reserve_order(1, 10000, 50, 150, 20, false, None));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 50, 150, 20, false, None))
+            .expect("add_order should succeed");
 
         // Match the entire visible portion
         let taker_id = Id::from_u64(999);
@@ -994,7 +1064,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Create a reserve order with auto-replenish enabled
-        price_level.add_order(create_reserve_order(1, 10000, 50, 150, 20, true, None));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 50, 150, 20, true, None))
+            .expect("add_order should succeed");
 
         // Match the entire visible portion
         let taker_id = Id::from_u64(999);
@@ -1031,7 +1103,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Create a reserve order with auto-replenish disabled
-        price_level.add_order(create_reserve_order(1, 10000, 50, 150, 20, false, None));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 50, 150, 20, false, None))
+            .expect("add_order should succeed");
 
         // Match partially, but still above threshold
         let taker_id = Id::from_u64(999);
@@ -1078,15 +1152,17 @@ mod tests {
 
         // Create a reserve order with auto-replenish enabled and a custom replenishment amount
         let custom_amount = 50;
-        price_level.add_order(create_reserve_order(
-            1,
-            10000,
-            50,
-            150,
-            20,
-            true,
-            Some(custom_amount),
-        ));
+        price_level
+            .add_order(create_reserve_order(
+                1,
+                10000,
+                50,
+                150,
+                20,
+                true,
+                Some(custom_amount),
+            ))
+            .expect("add_order should succeed");
 
         // Match the entire visible portion
         let taker_id = Id::from_u64(999);
@@ -1117,7 +1193,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Create a reserve order with threshold 0 and auto-replenish enabled
-        price_level.add_order(create_reserve_order(1, 10000, 50, 150, 0, true, None));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 50, 150, 0, true, None))
+            .expect("add_order should succeed");
 
         // Match partially
         let taker_id = Id::from_u64(999);
@@ -1147,7 +1225,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Create a reserve order with threshold 0 and auto-replenish disabled
-        price_level.add_order(create_reserve_order(1, 10000, 50, 150, 0, false, None));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 50, 150, 0, false, None))
+            .expect("add_order should succeed");
 
         // Match the entire visible portion
         let taker_id = Id::from_u64(999);
@@ -1177,7 +1257,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Create a reserve order with threshold 1 and auto-replenish disabled
-        price_level.add_order(create_reserve_order(1, 10000, 50, 150, 1, false, None));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 50, 150, 1, false, None))
+            .expect("add_order should succeed");
 
         // Match the entire visible portion
         let taker_id = Id::from_u64(999);
@@ -1207,7 +1289,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Create a reserve order with threshold 20 and auto-replenish disabled
-        price_level.add_order(create_reserve_order(1, 10000, 50, 150, 20, false, None));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 50, 150, 20, false, None))
+            .expect("add_order should succeed");
 
         // Match part of the visible portion, but still above threshold
         let taker_id = Id::from_u64(999);
@@ -1256,7 +1340,9 @@ mod tests {
 
         // Create a reserve order with threshold 20, auto-replenish enabled
         // and default replenish amount (80)
-        price_level.add_order(create_reserve_order(1, 10000, 100, 100, 20, true, None));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 100, 100, 20, true, None))
+            .expect("add_order should succeed");
 
         // Match 80 units, which is above the replenish threshold
         let taker_id = Id::from_u64(999);
@@ -1357,7 +1443,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_post_only_order(1, 10000, 100));
+        price_level
+            .add_order(create_post_only_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Post-only orders behave like standard orders for matching
         let taker_id = Id::from_u64(999);
@@ -1382,7 +1470,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_trailing_stop_order(1, 10000, 100));
+        price_level
+            .add_order(create_trailing_stop_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Trailing stop orders behave like standard orders for matching
         let taker_id = Id::from_u64(999);
@@ -1407,7 +1497,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_pegged_order(1, 10000, 100));
+        price_level
+            .add_order(create_pegged_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Pegged orders behave like standard orders for matching
         let taker_id = Id::from_u64(999);
@@ -1432,7 +1524,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_market_to_limit_order(1, 10000, 100));
+        price_level
+            .add_order(create_market_to_limit_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Market-to-limit orders behave like standard orders for matching
         let taker_id = Id::from_u64(999);
@@ -1484,7 +1578,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_post_only_order(1, 10000, 100));
+        price_level
+            .add_order(create_post_only_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             60,
@@ -1512,7 +1608,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_post_only_order(1, 10000, 100));
+        price_level
+            .add_order(create_post_only_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -1545,7 +1643,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_post_only_order(1, 10000, 100));
+        price_level
+            .add_order(create_post_only_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             150,
@@ -1600,7 +1700,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_trailing_stop_order(1, 10000, 100));
+        price_level
+            .add_order(create_trailing_stop_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             40,
@@ -1629,7 +1731,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_trailing_stop_order(1, 10000, 100));
+        price_level
+            .add_order(create_trailing_stop_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -1660,7 +1764,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_trailing_stop_order(1, 10000, 80));
+        price_level
+            .add_order(create_trailing_stop_order(1, 10000, 80))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             120,
@@ -1713,7 +1819,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_pegged_order(1, 10000, 100));
+        price_level
+            .add_order(create_pegged_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             50,
@@ -1741,7 +1849,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_pegged_order(1, 10000, 100));
+        price_level
+            .add_order(create_pegged_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -1771,7 +1881,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_pegged_order(1, 10000, 90));
+        price_level
+            .add_order(create_pegged_order(1, 10000, 90))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             130,
@@ -1826,7 +1938,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_market_to_limit_order(1, 10000, 100));
+        price_level
+            .add_order(create_market_to_limit_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             70,
@@ -1854,7 +1968,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_market_to_limit_order(1, 10000, 100));
+        price_level
+            .add_order(create_market_to_limit_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -1885,7 +2001,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_market_to_limit_order(1, 10000, 60));
+        price_level
+            .add_order(create_market_to_limit_order(1, 10000, 60))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -1958,7 +2076,9 @@ mod tests {
         let level_price = maker.price().as_u128();
         let maker_id = maker.id();
         let price_level = PriceLevel::new(level_price);
-        price_level.add_order(maker);
+        price_level
+            .add_order(maker)
+            .expect("add_order should succeed");
 
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
@@ -2072,10 +2192,12 @@ mod tests {
         let level_price = front.price().as_u128();
         let front_id = front.id();
         let level = PriceLevel::new(level_price);
-        level.add_order(front);
+        level.add_order(front).expect("add_order should succeed");
         // A plain maker queued behind the resized one.
         let behind_id = Id::from_u64(778);
-        level.add_order(create_standard_order(778, level_price, 100));
+        level
+            .add_order(create_standard_order(778, level_price, 100))
+            .expect("add_order should succeed");
 
         let updated = level
             .update_order(OrderUpdate::UpdateQuantity {
@@ -2112,9 +2234,11 @@ mod tests {
         let level_price = front.price().as_u128();
         let front_id = front.id();
         let level = PriceLevel::new(level_price);
-        level.add_order(front);
+        level.add_order(front).expect("add_order should succeed");
         let behind_id = Id::from_u64(778);
-        level.add_order(create_standard_order(778, level_price, 100));
+        level
+            .add_order(create_standard_order(778, level_price, 100))
+            .expect("add_order should succeed");
 
         let updated = level
             .update_order(OrderUpdate::UpdateQuantity {
@@ -2192,8 +2316,12 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_post_only_order(2, 10000, 50));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_post_only_order(2, 10000, 50))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             0,
@@ -2225,7 +2353,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(
@@ -2253,7 +2383,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let taker_id = Id::from_u64(999);
         let match_result = price_level.match_order(
@@ -2294,8 +2426,12 @@ mod tests {
         // available (100) == incoming (100): on the fill side of the boundary.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_standard_order(1, 10000, 60));
-        price_level.add_order(create_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_standard_order(1, 10000, 60))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -2322,8 +2458,12 @@ mod tests {
         // exactly one unit. Zero trades, full remainder, queue untouched.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_standard_order(1, 10000, 60));
-        price_level.add_order(create_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_standard_order(1, 10000, 60))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             101,
@@ -2374,7 +2514,9 @@ mod tests {
         // taker of 50, so it fills rather than (wrongly) being killed.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_iceberg_order(1, 10000, 10, 40));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 10, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             50,
@@ -2399,8 +2541,12 @@ mod tests {
         // never enqueued; the level is emptied of makers.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_standard_order(1, 10000, 60));
-        price_level.add_order(create_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_standard_order(1, 10000, 60))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             150,
@@ -2430,7 +2576,9 @@ mod tests {
         // liquidity -> rejected: zero trades, full remainder, queue untouched.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             60,
@@ -2482,7 +2630,9 @@ mod tests {
         // it falls through to the vacuous-complete sweep.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             0,
@@ -2509,7 +2659,9 @@ mod tests {
         // book to convert/rest. At this layer it behaves like a standard taker.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             140,
@@ -2535,7 +2687,9 @@ mod tests {
         // available (100) == incoming (100): fully filled, no remainder.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -2560,7 +2714,9 @@ mod tests {
         // consumes it normally. (FOK is a taker-side policy.)
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_fill_or_kill_order(1, 10000, 100));
+        price_level
+            .add_order(create_fill_or_kill_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -2582,7 +2738,9 @@ mod tests {
         // partially consumes it and the remainder keeps resting.
         let price_level = PriceLevel::new(10000);
         let trade_gen = fok_namespace_gen();
-        price_level.add_order(create_immediate_or_cancel_order(1, 10000, 100));
+        price_level
+            .add_order(create_immediate_or_cancel_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             50,
@@ -2604,7 +2762,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_good_till_date_order(1, 10000, 100, 1617000000000));
+        price_level
+            .add_order(create_good_till_date_order(1, 10000, 100, 1617000000000))
+            .expect("add_order should succeed");
 
         // GTD orders behave like standard orders for matching
         let taker_id = Id::from_u64(999);
@@ -2642,8 +2802,12 @@ mod tests {
         let trade_id_generator = UuidGenerator::new(namespace);
 
         // Total resting depth = 100 (two Buy makers).
-        price_level.add_order(create_standard_order(1, 10000, 60));
-        price_level.add_order(create_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_standard_order(1, 10000, 60))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
         assert_eq!(price_level.visible_quantity(), 100);
         assert_eq!(price_level.order_count(), 2);
 
@@ -2720,7 +2884,9 @@ mod tests {
             "fixture: the GTD maker is expired per TimeInForce::is_expired"
         );
 
-        price_level.add_order(create_good_till_date_order(1, 10000, 100, past_expiry));
+        price_level
+            .add_order(create_good_till_date_order(1, 10000, 100, past_expiry))
+            .expect("add_order should succeed");
 
         // Despite the expired maker, the match fills it like a standard order.
         let result = price_level.match_order(
@@ -2748,9 +2914,15 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let transaction_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 50));
-        price_level.add_order(create_standard_order(2, 10000, 75));
-        price_level.add_order(create_standard_order(3, 10000, 25));
+        price_level
+            .add_order(create_standard_order(1, 10000, 50))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 75))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(3, 10000, 25))
+            .expect("add_order should succeed");
 
         // Match first two orders completely and third partially
         let taker_id = Id::from_u64(999);
@@ -2803,8 +2975,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
 
         // Add some orders
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 50));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 50))
+            .expect("add_order should succeed");
 
         // Create a snapshot
         let snapshot = price_level.snapshot();
@@ -2833,7 +3009,9 @@ mod tests {
 
         // Add an order
         let order = create_standard_order(1, 10000, 100);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Update the price to a different value
         let update = OrderUpdate::UpdatePrice {
@@ -2855,7 +3033,9 @@ mod tests {
 
         // Test updating price to same value (should return error)
         let order = create_standard_order(2, 10000, 100);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         let same_price_update = OrderUpdate::UpdatePrice {
             order_id: Id::from_u64(2),
@@ -2876,7 +3056,9 @@ mod tests {
 
         // Add an order
         let order = create_standard_order(1, 10000, 100);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Update to increase quantity
         let update = OrderUpdate::UpdateQuantity {
@@ -2931,8 +3113,12 @@ mod tests {
 
         // Add makers A (id 1) then B (id 2) at the same price. A is ahead in
         // price-time priority.
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 100))
+            .expect("add_order should succeed");
 
         // Reduce A's quantity (decrease). A must keep its front position.
         let result = price_level.update_order(OrderUpdate::UpdateQuantity {
@@ -2971,8 +3157,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
 
         // Add makers A (id 1) then B (id 2) at the same price.
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 100))
+            .expect("add_order should succeed");
 
         // Increase A's quantity (Standard orders support resizing). This must
         // demote A to the back of the queue, behind B.
@@ -3011,9 +3201,15 @@ mod tests {
         let price_level = PriceLevel::new(10000);
 
         // Two standard makers plus an iceberg (so hidden_quantity is exercised).
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 100));
-        price_level.add_order(create_iceberg_order(3, 10000, 50, 200));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_iceberg_order(3, 10000, 50, 200))
+            .expect("add_order should succeed");
 
         // Decrease (in place) on a standard order.
         let _ = price_level
@@ -3061,7 +3257,9 @@ mod tests {
 
         // Add an order
         let order = create_standard_order(1, 10000, 100);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Update both price and quantity with different price
         let update = OrderUpdate::UpdatePriceAndQuantity {
@@ -3084,7 +3282,9 @@ mod tests {
 
         // Test with same price but different quantity
         let order = create_standard_order(2, 10000, 100);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         let update = OrderUpdate::UpdatePriceAndQuantity {
             order_id: Id::from_u64(2),
@@ -3111,7 +3311,9 @@ mod tests {
 
         // Add an order
         let order = create_standard_order(1, 10000, 100);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Replace with different price
         let update = OrderUpdate::Replace {
@@ -3135,7 +3337,9 @@ mod tests {
 
         // Test with same price but different quantity
         let order = create_standard_order(2, 10000, 100);
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         let update = OrderUpdate::Replace {
             order_id: Id::from_u64(2),
@@ -3163,8 +3367,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
 
         // Add some orders
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 50));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 50))
+            .expect("add_order should succeed");
 
         // Convert to PriceLevelData
         let data: PriceLevelData = (&price_level).into();
@@ -3222,7 +3430,9 @@ mod tests {
     #[test]
     fn test_price_level_display() {
         let price_level = PriceLevel::new(10000);
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let display_str = format!("{price_level}");
 
@@ -3239,11 +3449,21 @@ mod tests {
     #[test]
     fn test_price_level_from_str() {
         let price_level = PriceLevel::new(10000);
-        price_level.add_order(create_standard_order(1, 10000, 50));
-        price_level.add_order(create_standard_order(2, 10000, 75));
-        price_level.add_order(create_good_till_date_order(3, 10000, 100, 1617000000000));
-        price_level.add_order(create_reserve_order(4, 10000, 100, 100, 20, true, None));
-        price_level.add_order(create_iceberg_order(5, 10000, 50, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 50))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 75))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_good_till_date_order(3, 10000, 100, 1617000000000))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_reserve_order(4, 10000, 100, 100, 20, true, None))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_iceberg_order(5, 10000, 50, 100))
+            .expect("add_order should succeed");
 
         let input = "PriceLevel:price=10000;visible_quantity=375;hidden_quantity=200;order_count=5;orders=[Standard:id=00000000-0000-0001-0000-000000000000;price=10000;quantity=50;side=BUY;timestamp=1616823000000;time_in_force=GTC,Standard:id=00000000-0000-0002-0000-000000000000;price=10000;quantity=75;side=BUY;timestamp=1616823000001;time_in_force=GTC,Standard:id=00000000-0000-0003-0000-000000000000;price=10000;quantity=100;side=BUY;timestamp=1616823000002;time_in_force=GTD-1617000000000,ReserveOrder:id=00000000-0000-0004-0000-000000000000;price=10000;visible_quantity=100;hidden_quantity=100;side=SELL;timestamp=1616823000003;time_in_force=GTC;replenish_threshold=20;replenish_amount=None;auto_replenish=true,IcebergOrder:id=00000000-0000-0005-0000-000000000000;price=10000;visible_quantity=50;hidden_quantity=100;side=SELL;timestamp=1616823000004;time_in_force=GTC]";
         let result = PriceLevel::from_str(input);
@@ -3274,7 +3494,9 @@ mod tests {
     #[test]
     fn test_price_level_serde() {
         let price_level = PriceLevel::new(10000);
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Serialize to JSON
         let serialized = serde_json::to_string(&price_level).unwrap();
@@ -3366,7 +3588,9 @@ mod tests {
         let transaction_id_generator = UuidGenerator::new(namespace);
 
         // Add orders with more quantity than we'll match
-        price_level.add_order(create_standard_order(1, 10000, 200));
+        price_level
+            .add_order(create_standard_order(1, 10000, 200))
+            .expect("add_order should succeed");
 
         // Match only part of what's available
         let match_result = price_level.match_order(
@@ -3389,7 +3613,9 @@ mod tests {
         let price_level = PriceLevel::new(10000);
 
         // Add an order
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Update to a different price (should remove from this level)
         let result = price_level.update_order(OrderUpdate::UpdatePrice {
@@ -3408,7 +3634,9 @@ mod tests {
         let price_level = PriceLevel::new(10000);
 
         // Add an order
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         // Update the quantity but keep the same price
         let result = price_level.update_order(OrderUpdate::UpdatePriceAndQuantity {
@@ -3429,8 +3657,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
 
         // Add some orders
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_iceberg_order(2, 10000, 50, 150));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_iceberg_order(2, 10000, 50, 150))
+            .expect("add_order should succeed");
 
         // Serialize to JSON
         let serialized = serde_json::to_string(&price_level).unwrap();
@@ -3465,7 +3697,9 @@ mod tests {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Try to update price to the same value
         let update = OrderUpdate::UpdatePrice {
@@ -3518,7 +3752,9 @@ mod tests {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Set up a test that simulates order removal by another thread
         // This can be done by modifying the OrderQueue's internal state directly
@@ -3564,7 +3800,9 @@ mod tests {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Update to increase quantity (old visible < new visible)
         let update = OrderUpdate::UpdateQuantity {
@@ -3597,7 +3835,9 @@ mod tests {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Verify initial quantities
         assert_eq!(price_level.visible_quantity(), 50);
@@ -3621,7 +3861,9 @@ mod tests {
             order_id: Id::from_u64(1),
         });
         assert!(result.is_ok());
-        price_level.add_order(new_order);
+        price_level
+            .add_order(new_order)
+            .expect("add_order should succeed");
 
         // Verify both visible and hidden quantities were updated
         assert_eq!(price_level.visible_quantity(), 40);
@@ -3644,7 +3886,9 @@ mod tests {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order);
+        price_level
+            .add_order(order)
+            .expect("add_order should succeed");
 
         // Update both price and quantity with same price
         let update = OrderUpdate::UpdatePriceAndQuantity {
@@ -3680,7 +3924,9 @@ mod tests {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order1);
+        price_level
+            .add_order(order1)
+            .expect("add_order should succeed");
 
         let order2 = OrderType::<()>::IcebergOrder {
             id: Id::from_u64(2),
@@ -3693,7 +3939,9 @@ mod tests {
             time_in_force: TimeInForce::Gtc,
             extra_fields: (),
         };
-        price_level.add_order(order2);
+        price_level
+            .add_order(order2)
+            .expect("add_order should succeed");
 
         // Convert to PriceLevelData
         let data: PriceLevelData = (&price_level).into();
@@ -3751,8 +3999,12 @@ mod tests {
         let trade_ids = UuidGenerator::new(namespace);
 
         // A (id=1) arrives before B (id=2), both 100 @ 10000.
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 100))
+            .expect("add_order should succeed");
 
         // First aggressor partially fills A (60 of 100). A's residual = 40.
         let first = price_level.match_order(
@@ -3811,8 +4063,12 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_ids = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 100))
+            .expect("add_order should succeed");
         let total_before = match price_level.total_quantity() {
             Ok(q) => q,
             Err(e) => panic!("total_quantity failed: {e}"),
@@ -3844,9 +4100,13 @@ mod tests {
         let trade_ids = UuidGenerator::new(namespace);
 
         // Iceberg I (id=1) arrives first: visible 50, hidden 100.
-        price_level.add_order(create_iceberg_order(1, 10000, 50, 100));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 50, 100))
+            .expect("add_order should succeed");
         // O (id=2) arrives later: a plain 50 (iceberg with no hidden).
-        price_level.add_order(create_iceberg_order(2, 10000, 50, 0));
+        price_level
+            .add_order(create_iceberg_order(2, 10000, 50, 0))
+            .expect("add_order should succeed");
 
         // Aggressor consumes I's visible tip (50) → I refreshes from hidden and
         // moves to the tail. remaining hits 0, so this call stops there.
@@ -3886,8 +4146,12 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_ids = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
-        price_level.add_order(create_standard_order(2, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 100))
+            .expect("add_order should succeed");
         let _ = price_level.match_order(
             60,
             Id::from_u64(901),
@@ -3990,14 +4254,18 @@ mod tests {
                     let base = (t * ORDERS_PER_THREAD + i) as u64;
                     let id = base * 2 + 1_000;
                     if i % 2 == 0 {
-                        level.add_order(create_standard_order(id, PRICE, 1 + (base % 7)));
+                        level
+                            .add_order(create_standard_order(id, PRICE, 1 + (base % 7)))
+                            .expect("add_order should succeed");
                     } else {
-                        level.add_order(create_iceberg_order(
-                            id,
-                            PRICE,
-                            1 + (base % 5),
-                            1 + (base % 11),
-                        ));
+                        level
+                            .add_order(create_iceberg_order(
+                                id,
+                                PRICE,
+                                1 + (base % 5),
+                                1 + (base % 11),
+                            ))
+                            .expect("add_order should succeed");
                     }
                 }
             }));
@@ -4182,7 +4450,9 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 100));
+        price_level
+            .add_order(create_standard_order(1, 10000, 100))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             40,
@@ -4211,8 +4481,12 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 60));
-        price_level.add_order(create_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_standard_order(1, 10000, 60))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -4238,8 +4512,12 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 30));
-        price_level.add_order(create_standard_order(2, 10000, 30));
+        price_level
+            .add_order(create_standard_order(1, 10000, 30))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 30))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             100,
@@ -4266,9 +4544,15 @@ mod tests {
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let trade_id_generator = UuidGenerator::new(namespace);
 
-        price_level.add_order(create_standard_order(1, 10000, 40));
-        price_level.add_order(create_standard_order(2, 10000, 30));
-        price_level.add_order(create_standard_order(3, 10000, 50));
+        price_level
+            .add_order(create_standard_order(1, 10000, 40))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(2, 10000, 30))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_standard_order(3, 10000, 50))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             90,
@@ -4320,7 +4604,9 @@ mod tests {
         let trade_id_generator = UuidGenerator::new(namespace);
 
         // visible 50, hidden 200.
-        price_level.add_order(create_iceberg_order(1, 10000, 50, 200));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 50, 200))
+            .expect("add_order should succeed");
 
         // Consume the full visible tranche; the maker replenishes and keeps
         // resting, so it is not in filled_order_ids.
@@ -4350,7 +4636,9 @@ mod tests {
         let trade_id_generator = UuidGenerator::new(namespace);
 
         // visible 50, hidden 200, replenish threshold 10, auto-replenish on.
-        price_level.add_order(create_reserve_order(1, 10000, 50, 200, 10, true, Some(50)));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 50, 200, 10, true, Some(50)))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             50,
@@ -4392,7 +4680,9 @@ mod tests {
 
         let run = || {
             let price_level = PriceLevel::new(10000);
-            price_level.add_order(mk());
+            price_level
+                .add_order(mk())
+                .expect("add_order should succeed");
             let trade_id_generator = UuidGenerator::new(namespace);
             // Cross more than the visible tranche to force replenishment and a
             // multi-trade stream.
@@ -4457,8 +4747,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_iceberg_order(1, 10000, 0, 30));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 0, 30))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         // Counters reflect both orders: visible 0+40, hidden 30+0.
         assert_eq!(price_level.visible_quantity(), 40);
@@ -4498,8 +4792,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_iceberg_order(1, 10000, 0, 30));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 0, 30))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             70,
@@ -4531,8 +4829,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_iceberg_order(1, 10000, 0, 30));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 0, 30))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             71,
@@ -4559,8 +4861,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_iceberg_order(1, 10000, 0, 30));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 0, 30))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             200,
@@ -4593,8 +4899,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_iceberg_order(1, 10000, 0, 30));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 0, 30))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             10,
@@ -4624,7 +4934,9 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_iceberg_order(1, 10000, 0, 25));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 0, 25))
+            .expect("add_order should succeed");
 
         let rejected = price_level.match_order(
             5,
@@ -4667,8 +4979,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_reserve_order(1, 10000, 0, 50, 10, true, Some(20)));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 0, 50, 10, true, Some(20)))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         assert_eq!(price_level.visible_quantity(), 40);
         assert_eq!(price_level.hidden_quantity(), 50);
@@ -4706,8 +5022,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_reserve_order(1, 10000, 0, 50, 10, true, Some(20)));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 0, 50, 10, true, Some(20)))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         let result = price_level.match_order(
             90,
@@ -4734,8 +5054,12 @@ mod tests {
         // And FOK of 91 (one over) must be killed with the queue intact.
         let price_level2 = PriceLevel::new(10000);
         let trade_gen2 = new_trade_id_generator();
-        price_level2.add_order(create_reserve_order(1, 10000, 0, 50, 10, true, Some(20)));
-        price_level2.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level2
+            .add_order(create_reserve_order(1, 10000, 0, 50, 10, true, Some(20)))
+            .expect("add_order should succeed");
+        price_level2
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
         let killed = price_level2.match_order(
             91,
             Id::from_u64(999),
@@ -4759,8 +5083,12 @@ mod tests {
         let price_level = PriceLevel::new(10000);
         let trade_gen = new_trade_id_generator();
 
-        price_level.add_order(create_reserve_order(1, 10000, 0, 50, 10, false, Some(20)));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_reserve_order(1, 10000, 0, 50, 10, false, Some(20)))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         assert_eq!(price_level.visible_quantity(), 40);
         assert_eq!(price_level.hidden_quantity(), 50);
@@ -4804,7 +5132,9 @@ mod tests {
         // FOK pre-check: 0 matchable depth -> killed, queue untouched.
         let fok_level = PriceLevel::new(10000);
         let fok_gen = new_trade_id_generator();
-        fok_level.add_order(create_reserve_order(1, 10000, 0, 50, 10, false, Some(20)));
+        fok_level
+            .add_order(create_reserve_order(1, 10000, 0, 50, 10, false, Some(20)))
+            .expect("add_order should succeed");
 
         let fok = fok_level.match_order(
             5,
@@ -4826,7 +5156,9 @@ mod tests {
         // counters consistent with the queue.
         let po_level = PriceLevel::new(10000);
         let po_gen = new_trade_id_generator();
-        po_level.add_order(create_reserve_order(1, 10000, 0, 50, 10, false, Some(20)));
+        po_level
+            .add_order(create_reserve_order(1, 10000, 0, 50, 10, false, Some(20)))
+            .expect("add_order should succeed");
 
         let post_only = po_level.match_order(
             5,
@@ -4861,8 +5193,12 @@ mod tests {
         let trade_gen = new_trade_id_generator();
 
         // Iceberg with 20 visible / 30 hidden, then a standard maker behind it.
-        price_level.add_order(create_iceberg_order(1, 10000, 20, 30));
-        price_level.add_order(create_sell_standard_order(2, 10000, 40));
+        price_level
+            .add_order(create_iceberg_order(1, 10000, 20, 30))
+            .expect("add_order should succeed");
+        price_level
+            .add_order(create_sell_standard_order(2, 10000, 40))
+            .expect("add_order should succeed");
 
         // Reduce the iceberg's quantity to 0 (degenerate zero-visible state).
         price_level
@@ -4965,16 +5301,18 @@ mod tests {
             let maker_id_u64 = (iter as u64) * 4 + 1;
             let maker_id = Id::from_u64(maker_id_u64);
             // A sell maker so a buy taker crosses it.
-            level.add_order(OrderType::Standard {
-                id: maker_id,
-                price: Price::new(PRICE),
-                quantity: Quantity::new(MAKER_QTY),
-                side: Side::Sell,
-                user_id: Hash32::zero(),
-                timestamp: TimestampMs::new(1_600_000_000_000 + iter as u64),
-                time_in_force: TimeInForce::Gtc,
-                extra_fields: (),
-            });
+            level
+                .add_order(OrderType::Standard {
+                    id: maker_id,
+                    price: Price::new(PRICE),
+                    quantity: Quantity::new(MAKER_QTY),
+                    side: Side::Sell,
+                    user_id: Hash32::zero(),
+                    timestamp: TimestampMs::new(1_600_000_000_000 + iter as u64),
+                    time_in_force: TimeInForce::Gtc,
+                    extra_fields: (),
+                })
+                .expect("add_order should succeed");
 
             let barrier = Arc::new(Barrier::new(2));
             // Deterministic, per-iteration trade-id stream.
@@ -5094,16 +5432,18 @@ mod tests {
             // Add MAKERS sell makers with deterministic ids.
             let base = (iter as u64) * 1_000 + 1;
             for k in 0..MAKERS {
-                level.add_order(OrderType::Standard {
-                    id: Id::from_u64(base + k),
-                    price: Price::new(PRICE),
-                    quantity: Quantity::new(MAKER_QTY),
-                    side: Side::Sell,
-                    user_id: Hash32::zero(),
-                    timestamp: TimestampMs::new(1_600_000_000_000 + iter as u64 * 16 + k),
-                    time_in_force: TimeInForce::Gtc,
-                    extra_fields: (),
-                });
+                level
+                    .add_order(OrderType::Standard {
+                        id: Id::from_u64(base + k),
+                        price: Price::new(PRICE),
+                        quantity: Quantity::new(MAKER_QTY),
+                        side: Side::Sell,
+                        user_id: Hash32::zero(),
+                        timestamp: TimestampMs::new(1_600_000_000_000 + iter as u64 * 16 + k),
+                        time_in_force: TimeInForce::Gtc,
+                        extra_fields: (),
+                    })
+                    .expect("add_order should succeed");
             }
 
             // The matcher will consume the first ~2.5 makers; the canceller
@@ -5207,8 +5547,12 @@ mod tests {
 
         let level = PriceLevel::new(10_000);
         // Insert id 1 FIRST but with a LATER timestamp than id 2 (added second).
-        level.add_order(mk_buy(1, 2_000, 50));
-        level.add_order(mk_buy(2, 1_000, 50));
+        level
+            .add_order(mk_buy(1, 2_000, 50))
+            .expect("add_order should succeed");
+        level
+            .add_order(mk_buy(2, 1_000, 50))
+            .expect("add_order should succeed");
 
         let by_seq: Vec<Id> = level
             .snapshot_by_insertion_seq()
@@ -5259,9 +5603,15 @@ mod tests {
         let level = PriceLevel::new(10_000);
         // Three standard makers with monotonic timestamps (TIMESTAMP_COUNTER),
         // so insertion sequence and timestamp order initially agree.
-        level.add_order(create_standard_order(1, 10_000, 100));
-        level.add_order(create_standard_order(2, 10_000, 100));
-        level.add_order(create_standard_order(3, 10_000, 100));
+        level
+            .add_order(create_standard_order(1, 10_000, 100))
+            .expect("add_order should succeed");
+        level
+            .add_order(create_standard_order(2, 10_000, 100))
+            .expect("add_order should succeed");
+        level
+            .add_order(create_standard_order(3, 10_000, 100))
+            .expect("add_order should succeed");
 
         // Upsize maker 1 (Standard orders resize): total increases 100 -> 150,
         // so update_order takes the quantity-increase branch and demotes it to
@@ -5350,9 +5700,13 @@ mod tests {
         // front priority.
         let level = PriceLevel::new(10_000);
         // Iceberg maker (id 1, Sell) added first: visible 50 over hidden 100.
-        level.add_order(create_iceberg_order(1, 10_000, 50, 100));
+        level
+            .add_order(create_iceberg_order(1, 10_000, 50, 100))
+            .expect("add_order should succeed");
         // A plain Sell maker (id 2) rests behind it.
-        level.add_order(create_sell_standard_order(2, 10_000, 100));
+        level
+            .add_order(create_sell_standard_order(2, 10_000, 100))
+            .expect("add_order should succeed");
 
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let generator = UuidGenerator::new(namespace);
@@ -5453,7 +5807,9 @@ mod tests {
         // N resting standard makers with known ids 1..=N and initial quantity
         // 100 (monotonic timestamps via the shared counter).
         for id in 1..=N as u64 {
-            level.add_order(create_standard_order(id, 10_000, 100));
+            level
+                .add_order(create_standard_order(id, 10_000, 100))
+                .expect("add_order should succeed");
         }
 
         // Barrier aligns the single writer with the readers so the resequencing
@@ -5559,8 +5915,12 @@ mod tests {
     #[test]
     fn test_snapshot_by_insertion_seq_partial_fill_keeps_front() {
         let level = PriceLevel::new(10_000);
-        level.add_order(create_standard_order(1, 10_000, 100));
-        level.add_order(create_standard_order(2, 10_000, 50));
+        level
+            .add_order(create_standard_order(1, 10_000, 100))
+            .expect("add_order should succeed");
+        level
+            .add_order(create_standard_order(2, 10_000, 50))
+            .expect("add_order should succeed");
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let generator = UuidGenerator::new(namespace);
         // Small taker partially fills the front maker (id 1): KeepInPlace, same seq.
@@ -5588,9 +5948,13 @@ mod tests {
     fn test_snapshot_by_insertion_seq_replenished_maker_moves_to_tail() {
         let level = PriceLevel::new(10_000);
         // Iceberg (id 1, Sell) added first: visible 10 over hidden 40.
-        level.add_order(create_iceberg_order(1, 10_000, 10, 40));
+        level
+            .add_order(create_iceberg_order(1, 10_000, 10, 40))
+            .expect("add_order should succeed");
         // A plain Sell maker (id 2) rests behind it.
-        level.add_order(create_sell_standard_order(2, 10_000, 100));
+        level
+            .add_order(create_sell_standard_order(2, 10_000, 100))
+            .expect("add_order should succeed");
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
         let generator = UuidGenerator::new(namespace);
         // Fully consume the iceberg's visible tranche (10): it replenishes from
@@ -5623,9 +5987,15 @@ mod tests {
     #[test]
     fn test_snapshot_by_seq_into_matches_snapshot_by_insertion_seq() {
         let level = PriceLevel::new(10_000);
-        level.add_order(create_standard_order(1, 10_000, 100));
-        level.add_order(create_standard_order(2, 10_000, 50));
-        level.add_order(create_iceberg_order(3, 10_000, 20, 30));
+        level
+            .add_order(create_standard_order(1, 10_000, 100))
+            .expect("add_order should succeed");
+        level
+            .add_order(create_standard_order(2, 10_000, 50))
+            .expect("add_order should succeed");
+        level
+            .add_order(create_iceberg_order(3, 10_000, 20, 30))
+            .expect("add_order should succeed");
 
         let owned: Vec<Id> = level
             .snapshot_by_insertion_seq()
@@ -5655,16 +6025,21 @@ mod tests {
         // starts non-empty (proving `clear()` discards the prior contents
         // rather than appending to them).
         let big = PriceLevel::new(10_000);
-        big.add_order(create_standard_order(1, 10_000, 100));
-        big.add_order(create_standard_order(2, 10_000, 100));
-        big.add_order(create_standard_order(3, 10_000, 100));
+        big.add_order(create_standard_order(1, 10_000, 100))
+            .expect("add_order should succeed");
+        big.add_order(create_standard_order(2, 10_000, 100))
+            .expect("add_order should succeed");
+        big.add_order(create_standard_order(3, 10_000, 100))
+            .expect("add_order should succeed");
         let mut buf = big.snapshot_by_insertion_seq();
         assert_eq!(buf.len(), 3);
 
         // Reuse the same buffer on a SMALLER level: it must shrink to one entry
         // with no stale tail left over from the previous three.
         let small = PriceLevel::new(10_000);
-        small.add_order(create_standard_order(10, 10_000, 100));
+        small
+            .add_order(create_standard_order(10, 10_000, 100))
+            .expect("add_order should succeed");
         small.snapshot_by_seq_into(&mut buf);
         let ids: Vec<Id> = buf.iter().map(|o| o.id()).collect();
         assert_eq!(
@@ -5677,7 +6052,9 @@ mod tests {
         // exactly the new contents in insertion order.
         let bigger = PriceLevel::new(10_000);
         for id in [20_u64, 21, 22, 23] {
-            bigger.add_order(create_standard_order(id, 10_000, 100));
+            bigger
+                .add_order(create_standard_order(id, 10_000, 100))
+                .expect("add_order should succeed");
         }
         bigger.snapshot_by_seq_into(&mut buf);
         let ids: Vec<Id> = buf.iter().map(|o| o.id()).collect();
@@ -5699,8 +6076,12 @@ mod tests {
 
         // Plain makers: 100 + 50 = 150 of depth.
         let level = PriceLevel::new(10_000);
-        level.add_order(create_standard_order(1, 10_000, 100));
-        level.add_order(create_standard_order(2, 10_000, 50));
+        level
+            .add_order(create_standard_order(1, 10_000, 100))
+            .expect("add_order should succeed");
+        level
+            .add_order(create_standard_order(2, 10_000, 50))
+            .expect("add_order should succeed");
 
         assert_eq!(level.matchable_quantity(0), 0, "zero taker fills nothing");
         assert_eq!(level.matchable_quantity(120), 120, "taker below depth");
@@ -5728,7 +6109,8 @@ mod tests {
         // Iceberg replenish: visible 10 over hidden 40 = 50 of total depth, all
         // reachable across replenishment.
         let ice = PriceLevel::new(10_000);
-        ice.add_order(create_iceberg_order(1, 10_000, 10, 40));
+        ice.add_order(create_iceberg_order(1, 10_000, 10, 40))
+            .expect("add_order should succeed");
         let predicted_ice = ice.matchable_quantity(100);
         assert_eq!(
             predicted_ice, 50,
@@ -5760,7 +6142,9 @@ mod tests {
         // A deep level: 200 resting makers.
         let level = PriceLevel::new(10_000);
         for id in 1..=200_u64 {
-            level.add_order(create_standard_order(id, 10_000, 100));
+            level
+                .add_order(create_standard_order(id, 10_000, 100))
+                .expect("add_order should succeed");
         }
         assert_eq!(level.order_count(), 200, "level is deep");
 
@@ -5793,7 +6177,9 @@ mod tests {
         // A shallow level: 3 makers, 300 units of depth.
         let level = PriceLevel::new(10_000);
         for id in 1..=3_u64 {
-            level.add_order(create_standard_order(id, 10_000, 100));
+            level
+                .add_order(create_standard_order(id, 10_000, 100))
+                .expect("add_order should succeed");
         }
         assert_eq!(level.order_count(), 3, "level is shallow");
 
@@ -5816,6 +6202,229 @@ mod tests {
             "trade buffer must be bounded by order count (3), not the incoming \
              quantity (10000); was {}",
             result.trades().as_vec().capacity()
+        );
+    }
+    // ------------------------------------------------------------------
+    // Issue #111 — reject quantity overflow BEFORE mutating level state
+    // ------------------------------------------------------------------
+    //
+    // `order_count` overflow (usize::MAX resting orders) is not directly
+    // testable — it would require ~1.8e19 live orders. It is covered by the
+    // same checked `fetch_update` mechanism as the visible / hidden counters
+    // below; a unit test cannot reach it, so it is exercised structurally
+    // (identical code path) rather than by admitting that many orders.
+
+    #[test]
+    fn test_add_order_visible_quantity_overflow_rejected() {
+        let level = PriceLevel::new(10_000);
+        // Take the visible counter all the way to u64::MAX.
+        level
+            .add_order(create_standard_order(1, 10_000, u64::MAX))
+            .expect("first admission at u64::MAX visible must succeed");
+
+        // Capture the full level state before the failing admission.
+        let before_json = level
+            .snapshot_to_json()
+            .expect("snapshot before must serialize");
+        let before_visible = level.visible_quantity();
+        let before_hidden = level.hidden_quantity();
+        let before_count = level.order_count();
+
+        // Admitting even one more unit would overflow the visible counter.
+        match level.add_order(create_standard_order(2, 10_000, 1)) {
+            Err(PriceLevelError::InvalidOperation { message }) => {
+                assert!(
+                    message.contains("visible quantity overflow"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected visible-overflow InvalidOperation, got {other:?}"),
+        }
+
+        // Nothing mutated: counters, count, and a byte-identical snapshot.
+        assert_eq!(level.visible_quantity(), before_visible);
+        assert_eq!(level.hidden_quantity(), before_hidden);
+        assert_eq!(level.order_count(), before_count);
+        assert_eq!(before_count, 1);
+        let after_json = level
+            .snapshot_to_json()
+            .expect("snapshot after must serialize");
+        assert_eq!(
+            before_json, after_json,
+            "a rejected admission must leave the snapshot byte-identical"
+        );
+
+        // The snapshot still round-trips, and the rejected order is absent.
+        let restored =
+            PriceLevel::from_snapshot_json(&after_json).expect("snapshot must round-trip");
+        assert_eq!(restored.visible_quantity(), u64::MAX);
+        assert_eq!(restored.order_count(), 1);
+        let ids: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+        assert_eq!(ids, vec![Id::from_u64(1)]);
+    }
+
+    #[test]
+    fn test_add_order_hidden_quantity_overflow_rejected() {
+        let level = PriceLevel::new(10_000);
+        // Take the hidden counter to u64::MAX with a hidden-only iceberg.
+        level
+            .add_order(create_iceberg_order(1, 10_000, 0, u64::MAX))
+            .expect("first admission at u64::MAX hidden must succeed");
+
+        let before_visible = level.visible_quantity();
+        let before_hidden = level.hidden_quantity();
+        let before_count = level.order_count();
+
+        match level.add_order(create_iceberg_order(2, 10_000, 0, 1)) {
+            Err(PriceLevelError::InvalidOperation { message }) => {
+                assert!(
+                    message.contains("hidden quantity overflow"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected hidden-overflow InvalidOperation, got {other:?}"),
+        }
+
+        // The visible reservation the failing call briefly took is rolled back,
+        // so no counter drifts.
+        assert_eq!(level.visible_quantity(), before_visible);
+        assert_eq!(level.hidden_quantity(), before_hidden);
+        assert_eq!(level.order_count(), before_count);
+        assert_eq!(before_count, 1);
+        assert_eq!(level.hidden_quantity(), u64::MAX);
+    }
+
+    #[test]
+    fn test_add_order_boundary_sum_reaches_u64_max_succeeds() {
+        let level = PriceLevel::new(10_000);
+        // Two admissions whose visible quantities sum to EXACTLY u64::MAX must
+        // both succeed — the boundary is inclusive.
+        level
+            .add_order(create_standard_order(1, 10_000, u64::MAX - 10))
+            .expect("first admission must succeed");
+        level
+            .add_order(create_standard_order(2, 10_000, 10))
+            .expect("admission reaching exactly u64::MAX must succeed");
+
+        assert_eq!(level.visible_quantity(), u64::MAX);
+        assert_eq!(level.order_count(), 2);
+
+        // Counter == snapshot aggregate == sum over the queue contents.
+        let snapshot = level.snapshot();
+        assert_eq!(snapshot.visible_quantity().as_u64(), u64::MAX);
+        let queue_sum = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .try_fold(0u64, |acc, o| {
+                acc.checked_add(o.visible_quantity().as_u64())
+            })
+            .expect("boundary sum is exactly u64::MAX, no overflow");
+        assert_eq!(queue_sum, u64::MAX);
+    }
+
+    #[test]
+    fn test_reserve_replenish_overflow_no_trade_maker_preserved() {
+        // A reserve whose visible + hidden exceed u64::MAX is admissible (the
+        // two are separate u64 counters). A partial match that would replenish
+        // it computes `new_visible + replenish_qty`, which overflows u64. The
+        // match step must fail atomically: no trade, maker unchanged, no panic
+        // (this test runs under debug assertions, where an unchecked `+` would
+        // panic).
+        let level = PriceLevel::new(10_000);
+        level
+            .add_order(create_reserve_order(
+                1,
+                10_000,
+                u64::MAX,       // visible
+                u64::MAX,       // hidden
+                u64::MAX,       // threshold: any partial fill falls below -> replenish
+                true,           // auto_replenish
+                Some(u64::MAX), // replenish amount: draws the full hidden
+            ))
+            .expect("reserve with separately-valid u64 components must admit");
+
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let generator = UuidGenerator::new(namespace);
+        // A tiny taker triggers a partial fill and the overflowing replenish.
+        let result = level.match_order(
+            1,
+            Id::from_u64(999),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(1_700_000_000_000),
+            &generator,
+        );
+
+        // No trade emitted and the taker is left fully unconsumed.
+        assert_eq!(
+            result.trades().len(),
+            0,
+            "an overflowing replenish must emit no trade"
+        );
+        assert_eq!(
+            result.remaining_quantity().as_u64(),
+            1,
+            "the taker must be left fully unconsumed"
+        );
+
+        // The maker is still resting, unchanged.
+        let resting = level.snapshot_by_insertion_seq();
+        assert_eq!(resting.len(), 1, "the maker must still rest");
+        assert_eq!(resting[0].id(), Id::from_u64(1));
+        assert_eq!(
+            resting[0].visible_quantity().as_u64(),
+            u64::MAX,
+            "maker visible quantity must be unchanged"
+        );
+        assert_eq!(
+            resting[0].hidden_quantity().as_u64(),
+            u64::MAX,
+            "maker hidden quantity must be unchanged"
+        );
+    }
+
+    #[test]
+    fn test_add_order_normal_flow_fifo_unchanged() {
+        // Sanity: the now-fallible add_order preserves normal admission and
+        // strict FIFO consumption for in-range quantities.
+        let level = PriceLevel::new(10_000);
+        level
+            .add_order(create_standard_order(1, 10_000, 30))
+            .expect("admission ok");
+        level
+            .add_order(create_standard_order(2, 10_000, 20))
+            .expect("admission ok");
+        level
+            .add_order(create_standard_order(3, 10_000, 50))
+            .expect("admission ok");
+
+        assert_eq!(level.visible_quantity(), 100);
+        assert_eq!(level.order_count(), 3);
+
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let generator = UuidGenerator::new(namespace);
+        let result = level.match_order(
+            100,
+            Id::from_u64(999),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(1_700_000_000_000),
+            &generator,
+        );
+        let makers: Vec<Id> = result
+            .trades()
+            .as_vec()
+            .iter()
+            .map(|t| t.maker_order_id())
+            .collect();
+        assert_eq!(
+            makers,
+            vec![Id::from_u64(1), Id::from_u64(2), Id::from_u64(3)],
+            "FIFO consumption order must be unchanged"
         );
     }
 }

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -6572,6 +6572,231 @@ mod tests {
             "FIFO consumption order must be unchanged"
         );
     }
+
+    // ------------------------------------------------------------------
+    // Issue #113 — reject duplicate order IDs atomically
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_add_order_duplicate_id_rejected_sequentially() {
+        let level = PriceLevel::new(10_000);
+        let first = level
+            .add_order(create_standard_order(1, 10_000, 100))
+            .expect("first admission must succeed");
+        level
+            .add_order(create_standard_order(2, 10_000, 50))
+            .expect("second (distinct) admission must succeed");
+
+        // Snapshot the full state before the duplicate attempt.
+        let before_json = level.snapshot_to_json().expect("snapshot before");
+        let before_visible = level.visible_quantity();
+        let before_hidden = level.hidden_quantity();
+        let before_count = level.order_count();
+        let before_ids: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+
+        // Re-submit id 1 with a DIFFERENT quantity: must be rejected, never
+        // overwrite the live order.
+        match level.add_order(create_standard_order(1, 10_000, 999)) {
+            Err(PriceLevelError::DuplicateOrderId(id)) => {
+                assert_eq!(id, Id::from_u64(1).to_string())
+            }
+            other => panic!("expected DuplicateOrderId, got {other:?}"),
+        }
+
+        // Nothing changed: counters, order, FIFO order, and a byte-identical
+        // snapshot.
+        assert_eq!(level.visible_quantity(), before_visible);
+        assert_eq!(level.hidden_quantity(), before_hidden);
+        assert_eq!(level.order_count(), before_count);
+        assert_eq!(
+            level.snapshot_to_json().expect("snapshot after"),
+            before_json,
+            "a rejected duplicate must leave the snapshot byte-identical"
+        );
+        let after_ids: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+        assert_eq!(after_ids, before_ids);
+
+        // The original order 1 kept its quantity (100), not the rejected 999.
+        let order1 = level
+            .snapshot_by_insertion_seq()
+            .into_iter()
+            .find(|o| o.id() == Id::from_u64(1))
+            .expect("order 1 must still rest");
+        assert_eq!(order1.visible_quantity().as_u64(), 100);
+        assert_eq!(first.id(), Id::from_u64(1));
+    }
+
+    #[test]
+    fn test_add_order_duplicate_id_across_variants_rejected() {
+        let level = PriceLevel::new(10_000);
+        level
+            .add_order(create_standard_order(1, 10_000, 100))
+            .expect("standard admission must succeed");
+
+        // The same id as a DIFFERENT order variant is still a duplicate.
+        let duplicates = [
+            create_iceberg_order(1, 10_000, 50, 50),
+            create_reserve_order(1, 10_000, 30, 60, 10, true, Some(20)),
+            create_standard_order(1, 10_000, 5),
+        ];
+        for dup in duplicates {
+            match level.add_order(dup) {
+                Err(PriceLevelError::DuplicateOrderId(id)) => {
+                    assert_eq!(id, Id::from_u64(1).to_string())
+                }
+                other => panic!("expected DuplicateOrderId across variants, got {other:?}"),
+            }
+        }
+
+        // The original standard order 1 is intact; the level still holds one.
+        assert_eq!(level.order_count(), 1);
+        let resting = level.snapshot_by_insertion_seq();
+        assert_eq!(resting.len(), 1);
+        assert_eq!(resting[0].id(), Id::from_u64(1));
+        assert_eq!(resting[0].visible_quantity().as_u64(), 100);
+
+        // A genuinely distinct id still admits fine.
+        level
+            .add_order(create_iceberg_order(2, 10_000, 50, 50))
+            .expect("distinct id must admit");
+        assert_eq!(level.order_count(), 2);
+    }
+
+    #[test]
+    fn test_add_order_duplicate_id_concurrent_exactly_one_wins() {
+        use std::sync::{Arc as StdArc, Barrier};
+        use std::thread;
+
+        const THREADS: usize = 8;
+        const ITERATIONS: usize = 50;
+        const DUP_ID: u64 = 1;
+
+        for iter in 0..ITERATIONS {
+            let level = StdArc::new(PriceLevel::new(10_000));
+            let barrier = StdArc::new(Barrier::new(THREADS));
+
+            let handles: Vec<_> = (0..THREADS)
+                .map(|t| {
+                    let level = StdArc::clone(&level);
+                    let barrier = StdArc::clone(&barrier);
+                    thread::spawn(move || {
+                        barrier.wait();
+                        // All threads submit the SAME id with distinct sizes.
+                        level
+                            .add_order(OrderType::Standard {
+                                id: Id::from_u64(DUP_ID),
+                                price: Price::new(10_000),
+                                quantity: Quantity::new(10 + t as u64),
+                                side: Side::Buy,
+                                user_id: Hash32::zero(),
+                                timestamp: TimestampMs::new(1_600_000_000_000 + t as u64),
+                                time_in_force: TimeInForce::Gtc,
+                                extra_fields: (),
+                            })
+                            .is_ok()
+                    })
+                })
+                .collect();
+
+            let successes: usize = handles
+                .into_iter()
+                .map(|h| usize::from(h.join().expect("thread panicked")))
+                .sum();
+            assert_eq!(successes, 1, "iter {iter}: exactly one admission must win");
+
+            // The level is consistent: exactly one order, counters == queue ==
+            // snapshot, and the id-keyed map / ordered index are 1:1.
+            assert_eq!(level.order_count(), 1, "iter {iter}: order_count must be 1");
+            let ids: Vec<Id> = level
+                .snapshot_by_insertion_seq()
+                .iter()
+                .map(|o| o.id())
+                .collect();
+            assert_eq!(
+                ids,
+                vec![Id::from_u64(DUP_ID)],
+                "iter {iter}: exactly one id rests, once"
+            );
+            let snapshot = level.snapshot();
+            assert_eq!(snapshot.order_count(), 1);
+            assert_eq!(snapshot.orders().len(), 1);
+            assert_eq!(
+                level.visible_quantity(),
+                snapshot.visible_quantity().as_u64(),
+                "iter {iter}: counter must equal the snapshot aggregate"
+            );
+            assert_eq!(
+                snapshot.visible_quantity().as_u64(),
+                snapshot.orders()[0].visible_quantity().as_u64(),
+                "iter {iter}: aggregate must equal the single resting order"
+            );
+
+            // Draining consumes the single maker exactly once — proof there is
+            // no phantom second index entry pointing at the same map value.
+            let generator = UuidGenerator::new(Uuid::from_u128(0xD00D_0000 + iter as u128));
+            let result = level.match_order(
+                10_000,
+                Id::from_u64(9_999),
+                TimeInForce::Gtc,
+                TakerKind::Standard,
+                TimestampMs::new(1_700_000_000_000),
+                &generator,
+            );
+            let makers: Vec<Id> = result
+                .trades()
+                .as_vec()
+                .iter()
+                .map(|t| t.maker_order_id())
+                .collect();
+            assert_eq!(
+                makers,
+                vec![Id::from_u64(DUP_ID)],
+                "iter {iter}: the maker must be consumed exactly once"
+            );
+        }
+    }
+
+    #[test]
+    fn test_from_snapshot_rejects_duplicate_ids() {
+        // Build a snapshot whose orders vector repeats id 1.
+        let dup_a = std::sync::Arc::new(create_standard_order(1, 10_000, 100));
+        let dup_b = std::sync::Arc::new(create_standard_order(1, 10_000, 50));
+        let snapshot = crate::price_level::PriceLevelSnapshot::with_orders(
+            Price::new(10_000),
+            vec![dup_a, dup_b],
+        )
+        .expect("snapshot construction must succeed");
+
+        // Direct from_snapshot rejects deterministically — no level built.
+        match PriceLevel::from_snapshot(snapshot.clone()) {
+            Err(PriceLevelError::DuplicateOrderId(id)) => {
+                assert_eq!(id, Id::from_u64(1).to_string())
+            }
+            other => panic!("expected DuplicateOrderId from from_snapshot, got {other:?}"),
+        }
+
+        // The checksum-protected JSON path rejects too — with a DuplicateOrderId
+        // (the checksum is valid), not a ChecksumMismatch.
+        let json = PriceLevelSnapshotPackage::new(snapshot)
+            .expect("package must build")
+            .to_json()
+            .expect("package must serialize");
+        assert!(
+            matches!(
+                PriceLevel::from_snapshot_json(&json),
+                Err(PriceLevelError::DuplicateOrderId(_))
+            ),
+            "from_snapshot_json must reject a duplicate-id snapshot"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -253,7 +253,7 @@ mod tests {
             .expect("add_order should succeed");
 
         let snapshot = price_level.snapshot();
-        let restored = PriceLevel::from(&snapshot);
+        let restored = PriceLevel::try_from(&snapshot).expect("valid snapshot restores");
 
         let original_orders = price_level.snapshot_orders();
         let restored_orders = restored.snapshot_orders();
@@ -6796,6 +6796,79 @@ mod tests {
             ),
             "from_snapshot_json must reject a duplicate-id snapshot"
         );
+    }
+
+    #[test]
+    fn test_add_order_duplicate_id_at_counter_capacity_returns_duplicate() {
+        // Finding 2 (PR #125): admission decides id IDENTITY before reserving
+        // any counter, so a duplicate id submitted when the level's visible
+        // counter is already at u64::MAX reports DuplicateOrderId — NOT a
+        // spurious visible-overflow InvalidOperation — and leaves every counter
+        // byte-identical (no transient inflation an overflow-first order would
+        // cause).
+        let level = PriceLevel::new(10_000);
+        level
+            .add_order(create_standard_order(1, 10_000, u64::MAX))
+            .expect("first admission fills the visible counter to u64::MAX");
+        assert_eq!(level.visible_quantity(), u64::MAX);
+
+        let before_json = level.snapshot_to_json().expect("snapshot before");
+
+        // Re-submit id 1 with a positive quantity: reserving it WOULD overflow
+        // the visible counter, but the duplicate id takes precedence.
+        match level.add_order(create_standard_order(1, 10_000, 100)) {
+            Err(PriceLevelError::DuplicateOrderId(id)) => {
+                assert_eq!(id, Id::from_u64(1).to_string());
+            }
+            other => {
+                panic!("expected DuplicateOrderId (identity before counters), got {other:?}")
+            }
+        }
+
+        // Byte-identical: counters, count, and snapshot unchanged.
+        assert_eq!(level.visible_quantity(), u64::MAX);
+        assert_eq!(level.hidden_quantity(), 0);
+        assert_eq!(level.order_count(), 1);
+        assert_eq!(
+            level.snapshot_to_json().expect("snapshot after"),
+            before_json,
+            "a duplicate at counter capacity must leave the level byte-identical"
+        );
+    }
+
+    #[test]
+    fn test_try_from_snapshot_propagates_duplicate_order_id() {
+        // Finding 3 (PR #125): the infallible `From<&PriceLevelSnapshot>` (which
+        // silently kept-first on a duplicate id while restoring counters over
+        // every copy) is replaced by `TryFrom`, which delegates to
+        // `from_snapshot` and propagates DuplicateOrderId.
+        let dup_a = std::sync::Arc::new(create_standard_order(7, 10_000, 100));
+        let dup_b = std::sync::Arc::new(create_standard_order(7, 10_000, 50));
+        let snapshot = crate::price_level::PriceLevelSnapshot::with_orders(
+            Price::new(10_000),
+            vec![dup_a, dup_b],
+        )
+        .expect("snapshot construction must succeed");
+
+        match PriceLevel::try_from(&snapshot) {
+            Err(PriceLevelError::DuplicateOrderId(id)) => {
+                assert_eq!(id, Id::from_u64(7).to_string());
+            }
+            other => panic!("expected DuplicateOrderId from TryFrom<&Snapshot>, got {other:?}"),
+        }
+
+        // A duplicate-free snapshot restores successfully through TryFrom.
+        let ok_snapshot = crate::price_level::PriceLevelSnapshot::with_orders(
+            Price::new(10_000),
+            vec![
+                std::sync::Arc::new(create_standard_order(1, 10_000, 10)),
+                std::sync::Arc::new(create_standard_order(2, 10_000, 20)),
+            ],
+        )
+        .expect("snapshot construction must succeed");
+        let restored = PriceLevel::try_from(&ok_snapshot).expect("distinct ids restore");
+        assert_eq!(restored.order_count(), 2);
+        assert_eq!(restored.visible_quantity(), 30);
     }
 }
 

--- a/src/price_level/tests/order_queue.rs
+++ b/src/price_level/tests/order_queue.rs
@@ -543,4 +543,71 @@ mod tests {
         }
         assert!(queue.pop().is_none());
     }
+
+    #[test]
+    fn test_concurrent_try_push_cancel_readmit_keeps_map_index_one_to_one() {
+        // Finding 1 (PR #125): `try_push` published the map entry, released the
+        // shard lock, then inserted the index entry. A concurrent cancel +
+        // same-id readmission landing in that window could leave two index
+        // entries for one id (a FIFO jump). `try_push_with` now holds the shard
+        // lock across BOTH publications, so the map and the index stay strictly
+        // 1:1 under an admit / cancel / readmit storm on a tiny, heavily-reused
+        // id set. Assert that invariant at quiescence over many iterations.
+        use std::sync::{Arc as StdArc, Barrier};
+        use std::thread;
+
+        const THREADS: usize = 6;
+        const OPS: usize = 300;
+        const IDS: u64 = 4;
+
+        for iter in 0..40 {
+            let queue = StdArc::new(OrderQueue::new());
+            let barrier = StdArc::new(Barrier::new(THREADS));
+
+            let handles: Vec<_> = (0..THREADS)
+                .map(|t| {
+                    let queue = StdArc::clone(&queue);
+                    let barrier = StdArc::clone(&barrier);
+                    thread::spawn(move || {
+                        barrier.wait();
+                        for op in 0..OPS {
+                            // A tiny id set shared across threads maximizes the
+                            // chance an admission of `id` races a cancel of the
+                            // same `id`.
+                            let id = ((op as u64).wrapping_add(t as u64) % IDS) + 1;
+                            let order = StdArc::new(create_test_order(id, 1_000, 10));
+                            let _ = queue.try_push(order);
+                            let _ = queue.remove(Id::from_u64(id));
+                            let _ = queue.try_push(StdArc::new(create_test_order(id, 1_000, 10)));
+                        }
+                    })
+                })
+                .collect();
+            for h in handles {
+                h.join().expect("thread panicked");
+            }
+
+            // Quiescent: every started operation has completed, so the map and
+            // the ordered index must be exactly 1:1. A split index entry from
+            // the old publication race would make the index longer than the map.
+            assert!(
+                queue.debug_map_index_consistent(),
+                "iter {iter}: id-keyed map and ordered index must be 1:1"
+            );
+
+            // Draining pops each resting id exactly once: a phantom second index
+            // entry would resurface an id or desync the count.
+            let mut popped: Vec<Id> = Vec::new();
+            while let Some(order) = queue.pop() {
+                popped.push(order.id());
+            }
+            let unique: std::collections::HashSet<Id> = popped.iter().copied().collect();
+            assert_eq!(
+                popped.len(),
+                unique.len(),
+                "iter {iter}: every id must be popped at most once"
+            );
+            assert!(queue.is_empty(), "iter {iter}: queue must fully drain");
+        }
+    }
 }

--- a/tests/proptest/properties.rs
+++ b/tests/proptest/properties.rs
@@ -39,7 +39,9 @@ fn build_level(makers: &[Maker]) -> PriceLevel {
     let level = PriceLevel::new(LEVEL_PRICE);
     for maker in makers {
         // `OrderType<()>` is `Copy`, so this rests a copy of the maker order.
-        let _ = level.add_order(maker.order);
+        let _ = level
+            .add_order(maker.order)
+            .expect("add_order should succeed");
     }
     level
 }
@@ -474,7 +476,7 @@ proptest! {
                 extra_fields: (),
             }
         };
-        let _ = level.add_order(order);
+        let _ = level.add_order(order).expect("add_order should succeed");
         let generator = trade_ids();
 
         let total_before = level

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -36,8 +36,12 @@ fn partial_fill_keeps_price_time_priority_across_calls() {
     let trade_ids = UuidGenerator::new(namespace);
 
     // A (id=1) rests before B (id=2); both 100 @ 10_000.
-    level.add_order(standard_buy(1, 10_000, 100, 1_000));
-    level.add_order(standard_buy(2, 10_000, 100, 1_001));
+    level
+        .add_order(standard_buy(1, 10_000, 100, 1_000))
+        .expect("add_order should succeed");
+    level
+        .add_order(standard_buy(2, 10_000, 100, 1_001))
+        .expect("add_order should succeed");
 
     // Partially fill A.
     let first = level.match_order(


### PR DESCRIPTION
## Summary

`OrderQueue::push` inserted unconditionally, so reusing a live order id
overwrote the map value while the old index entry survived — two live
sequences for one id, double-counted counters, and matching able to consume
one order through multiple index entries. Publication is now an atomic
insert-if-absent, admission reports duplicates explicitly, and snapshot
restore rejects repeated ids.

## Stack

- **Stack:** #118 → #114 → #116 → #111 → #113 → #120 → #119 → #115 → #117 → #112 (**this is 5/10**)
- **Base branch:** `stack/4-111-checked-admission`
- **Stacked on:** #124 — **the diff vs `main` is cumulative**; review against the base branch.

## Changes

- `OrderQueue::try_push`: insert-if-absent via the DashMap entry API —
  concurrent same-id submissions serialize on the shard lock, exactly one
  wins; a rejected duplicate touches neither map, index, nor the sequence
  counter (seq minted inside the `Vacant` arm, no gaps).
- `add_order` publishes through `try_push` and rolls back its #111 counter
  reservations on rejection — level byte-identical after a rejected duplicate.
- New hand-written `PriceLevelError::DuplicateOrderId(String)` variant.
- Snapshot restore (`from_snapshot` + package/JSON forms) pre-scans for
  repeated ids and fails with `DuplicateOrderId` (valid checksum ≠ valid
  topology); `OrderQueue` `FromStr`/`Deserialize` reject via `try_push`; the
  infallible `From<Vec>` keeps first occurrence (documented).
- Migration note in `lib.rs`; README regenerated.

## Technical decisions

- `push` survives solely for the quantity-increase re-insert.
  `concurrency-auditor` confirmed this diff's additions are lock-free safe
  (entry-API atomicity, self-healing remove race, rollback underflow
  impossible) and flagged the **inherited** upsize `remove`+`push` window —
  a concurrent duplicate admission can still slip in there. That window is
  explicitly the charter of **#119** (atomic re-sequencing, two PRs up this
  stack); substituting `try_push` there would be an invalid fix. Docs state
  the residual window honestly.
- `PriceLevelError` gains a variant → breaking for exhaustive matchers;
  release-versioning for the stack is handled at merge time (semver CI is
  green for 0.x).

## Public API impact

- New error variant `DuplicateOrderId` (auto-exported via `PriceLevelError`).
- `OrderQueue::try_push` new public method (`#[must_use]`).
- `# Errors` sections updated on the restore constructors; migration guide +
  README regenerated.

## Testing

- [x] Sequential + cross-variant duplicate rejection with byte-identical
  before/after level state (counters, FIFO, snapshot)
- [x] Barrier-controlled concurrency: 8 threads × 50 iterations submitting the
  same id — exactly one success, map/index 1:1, drain consumes the maker once
- [x] Snapshot restore with duplicated ids fails with `DuplicateOrderId` on
  both direct and JSON paths
- [x] Pre-push checks clean locally

476 tests passed; 0 failed (457 lib + 9 + 1 + 9 doctests).

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] New error variant hand-written (`Display`/`Debug`), no `thiserror`
- [x] Non-`SeqCst` orderings justified (advisory counters; atomicity rides on
  the shard lock)
- [x] No new production `unsafe`, no new dependencies
- [x] Migration guide + README updated

Closes #113


- **Blocks:** #126
