### PR TITLE
Enforce level admission and trade topology invariants (#120)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pricelevel"
-version = "0.8.5"
+version = "0.9.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance, lock-free price level implementation for limit order books in Rust. This library provides the building blocks for creating efficient trading systems with support for multiple order types and concurrent access patterns."

--- a/README.md
+++ b/README.md
@@ -513,6 +513,16 @@ binaries may prefer `.expect(...)`); the returned `Arc` is unchanged on
 success. Admissions that stay within `u64` (all normal use) behave exactly
 as before.
 
+`add_order` also now **rejects a duplicate id**: publishing is an
+insert-if-absent, so reusing the id of an order already resting at the level
+returns the new [`PriceLevelError::DuplicateOrderId`] variant (again leaving
+the level unchanged) instead of overwriting the live order and leaving the
+id-keyed map and the ordered index disagreeing. Snapshot restore
+([`PriceLevel::from_snapshot`] and the JSON / package forms) likewise
+rejects an orders vector that repeats an id rather than silently
+overwriting. Submitting genuinely distinct ids (all normal use) is
+unaffected.
+
 
  ## Setup Instructions
 

--- a/README.md
+++ b/README.md
@@ -545,6 +545,41 @@ that could desync a level's counters from its queue:
 - **`OrderQueue::from_vec` is now `pub(crate)`.** It is a keep-first
   constructor that drops duplicates silently; the public restore path is
   [`PriceLevel::from_snapshot`], which rejects them.
+### Migration Guide (level topology invariants — breaking)
+
+A [`PriceLevel`] now enforces that every resting order sits at the level's
+price and shares a single side (the first admitted maker pins the side; a
+fully drained level accepts either side again). [`PriceLevel::add_order`]
+returns [`PriceLevelError::InvalidOperation`] for an order whose price does
+not match the level, or whose side is incompatible with the resting side,
+and [`PriceLevel::from_snapshot`] rejects a snapshot that violates either
+(previously such orders were admitted, trading at the level price rather
+than their own and producing contradictory taker sides in one
+[`MatchResult`]). Callers that composed a level from mixed-price or
+mixed-side orders must route each order to the correct level.
+
+Single-side coherence is a **correctness invariant**, not an
+eventually-consistent one like the advisory counters: it holds only when a
+given level's admissions arrive from a single logical writer (the composing
+order book routes each price to one admission path). The side is derived
+from the live queue, so under genuinely concurrent multi-writer admission a
+narrow race — an opposite side slipping into a momentarily empty level — can
+still admit a mixed side; see the note on the [`PriceLevel`] type.
+
+[`PriceLevel::matchable_quantity`] gains a `taker_id` parameter:
+`matchable_quantity(incoming_quantity)` becomes
+`matchable_quantity(incoming_quantity, taker_id)`. A resting maker sharing
+the taker id is skipped (self-trade prevention), matching the sweep, so a
+fill-or-kill dry run and the real sweep agree. `match_order` applies the
+same **self-trade skip** deterministically in every build profile (it used
+to be a debug-only assertion): a resting maker whose id equals the taker's
+is skipped — no self-trade is emitted and the other makers still match.
+
+This self-trade guard is **order-id identity** — an order can never match
+itself. It is NOT account/owner-level self-trade prevention: two distinct
+order ids owned by the same `user_id` will still trade. Account-level STP is
+the responsibility of the order book composing these levels, which owns the
+account relationships a single price level does not.
 
 
  ## Setup Instructions

--- a/README.md
+++ b/README.md
@@ -523,6 +523,29 @@ rejects an orders vector that repeats an id rather than silently
 overwriting. Submitting genuinely distinct ids (all normal use) is
 unaffected.
 
+### Migration Guide (v0.9 — duplicate-id safety on restore + queue surface)
+
+Three intentional breaking changes remove infallible / overwriting paths
+that could desync a level's counters from its queue:
+
+- **`impl From<&PriceLevelSnapshot> for PriceLevel` is removed; use
+  [`TryFrom`].** The old `From` swallowed aggregate-overflow errors and built
+  the queue keep-first, so a snapshot repeating an id restored counters
+  computed over every copy while the queue kept one. Replace
+  `PriceLevel::from(&snapshot)` / `let lvl: PriceLevel = (&snapshot).into();`
+  with `PriceLevel::try_from(&snapshot)?` (or `.expect(...)` in tests). It
+  delegates to [`PriceLevel::from_snapshot`], returning
+  [`PriceLevelError::DuplicateOrderId`] on a repeated id and the
+  per-order / level aggregate-overflow errors instead of hiding them.
+- **`OrderQueue::push` is now `pub(crate)`.** Unconditional overwriting
+  publication is never safe for an external caller (reusing a live id would
+  silently replace the resting order and strand its old index entry).
+  Admission goes through `add_order` (or, at the queue layer, the
+  insert-if-absent `try_push`); there is no public overwriting insert.
+- **`OrderQueue::from_vec` is now `pub(crate)`.** It is a keep-first
+  constructor that drops duplicates silently; the public restore path is
+  [`PriceLevel::from_snapshot`], which rejects them.
+
 
  ## Setup Instructions
 

--- a/examples/src/bin/contention_test.rs
+++ b/examples/src/bin/contention_test.rs
@@ -100,12 +100,15 @@ fn test_read_write_ratio() {
                         // Write operation
                         match local_counter % 3 {
                             0 => {
-                                // Add a new order
+                                // Add a new order. Ids overlap across threads
+                                // once a counter exceeds 10000 (see the taker
+                                // comment below) and across ratio phases, so
+                                // since issue #113 a rejected duplicate is an
+                                // expected outcome here — deliberately ignored
+                                // to keep the write pressure going.
                                 let order_id = thread_id as u64 * 10000 + local_counter;
                                 let order = create_standard_order(order_id, 10000, 10);
-                                thread_price_level
-                                    .add_order(order)
-                                    .expect("add_order should succeed");
+                                let _ = thread_price_level.add_order(order);
                             }
                             1 => {
                                 // Match order. Takers live in a disjoint high id
@@ -304,11 +307,12 @@ fn test_hot_spot_contention() {
                     // Perform an operation based on iteration
                     match local_counter % 3 {
                         0 => {
-                            // Add a new order with same ID (this will likely fail, but creates contention)
+                            // Add a new order with same ID. Since issue #113 a
+                            // duplicate id is rejected with DuplicateOrderId —
+                            // an expected outcome in this contention pattern,
+                            // so the result is deliberately ignored.
                             let order = create_standard_order(order_idx, 10000, 10);
-                            thread_price_level
-                                .add_order(order)
-                                .expect("add_order should succeed");
+                            let _ = thread_price_level.add_order(order);
                         }
                         1 => {
                             // Cancel an order

--- a/examples/src/bin/hft_simulation.rs
+++ b/examples/src/bin/hft_simulation.rs
@@ -138,8 +138,18 @@ fn main() {
 
             let mut local_counter = 0;
             while thread_running.load(Ordering::Relaxed) {
-                // Generate a unique taker order ID
-                let taker_id = Id::from_u64((thread_id as u64) * 1_000_000 + local_counter);
+                // Generate a unique taker order ID in a DISJOINT high range so a
+                // taker id can never collide with a resting maker id. Makers use
+                // `(thread_id + 1) * 1_000_000 + counter`, so taker thread 10's
+                // base (`10 * 1_000_000`) would otherwise land exactly on maker
+                // thread 9's base (`(9 + 1) * 1_000_000`). A taker sharing a
+                // resting maker's id is a self-fill — impossible for a real
+                // order and caught by match_order's debug-only self-fill
+                // assertion. Offsetting by `1 << 40` (~1.1e12, far above any
+                // reachable maker id) keeps the two id spaces apart, matching
+                // contention_test.
+                let taker_id =
+                    Id::from_u64((1u64 << 40) + (thread_id as u64) * 1_000_000 + local_counter);
 
                 // Match varying quantities
                 let quantity = (local_counter % 5) + 1; // Match 1-5 units

--- a/examples/src/bin/hft_simulation.rs
+++ b/examples/src/bin/hft_simulation.rs
@@ -82,7 +82,10 @@ fn main() {
             let mut local_counter = 0;
             while thread_running.load(Ordering::Relaxed) {
                 // Generate a unique order ID
-                let order_id = (thread_id as u64) * 1_000_000 + local_counter;
+                // +1 offset keeps maker ids clear of the 0..initial_order_count
+                // seed range: admission now rejects a duplicate id (issue
+                // #113) instead of silently overwriting.
+                let order_id = (thread_id as u64 + 1) * 1_000_000 + local_counter;
 
                 // Create and add an order
                 let order_type = match local_counter % 5 {

--- a/examples/src/bin/simple.rs
+++ b/examples/src/bin/simple.rs
@@ -52,7 +52,10 @@ fn main() {
                     thread_barrier.wait(); // Wait for all threads to be ready
 
                     for i in 0..50 {
-                        let order_id = thread_id as u64 * 1000 + i;
+                        // Offset past the ids seeded by setup_initial_orders
+                        // (0..240): admission now rejects a duplicate id
+                        // (issue #113) instead of silently overwriting.
+                        let order_id = 10_000 + thread_id as u64 * 1000 + i;
                         let order = create_order(thread_id, order_id);
                         thread_price_level
                             .add_order(order)

--- a/src/errors/tests/types.rs
+++ b/src/errors/tests/types.rs
@@ -60,6 +60,7 @@ mod tests {
             PriceLevelError::InvalidFormat,
             PriceLevelError::UnknownOrderType("TestOrder".to_string()),
             PriceLevelError::MissingField("id".to_string()),
+            PriceLevelError::DuplicateOrderId("42".to_string()),
             PriceLevelError::InvalidFieldValue {
                 field: "side".to_string(),
                 value: "MIDDLE".to_string(),

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -45,6 +45,14 @@ pub enum PriceLevelError {
     /// The string parameter specifies which field is missing.
     MissingField(String),
 
+    /// Error indicating an order id already rests at the price level.
+    ///
+    /// Admission (or a duplicate-bearing restore) is rejected atomically rather
+    /// than overwriting the live order, which would leave the level's id-keyed
+    /// map and its ordered index disagreeing (two sequences for one id) and its
+    /// counters double-counted. The string parameter is the offending id.
+    DuplicateOrderId(String),
+
     /// Error indicating a field has an invalid value.
     ///
     /// This error occurs when a field's value is present but doesn't meet validation criteria.
@@ -96,6 +104,7 @@ impl Display for PriceLevelError {
                 write!(f, "Unknown order type: {order_type}")
             }
             PriceLevelError::MissingField(field) => write!(f, "Missing field: {field}"),
+            PriceLevelError::DuplicateOrderId(id) => write!(f, "Duplicate order id: {id}"),
             PriceLevelError::InvalidFieldValue { field, value } => {
                 write!(f, "Invalid value for field {field}: {value}")
             }
@@ -128,6 +137,7 @@ impl Debug for PriceLevelError {
                 write!(f, "Unknown order type: {order_type}")
             }
             PriceLevelError::MissingField(field) => write!(f, "Missing field: {field}"),
+            PriceLevelError::DuplicateOrderId(id) => write!(f, "Duplicate order id: {id}"),
             PriceLevelError::InvalidFieldValue { field, value } => {
                 write!(f, "Invalid value for field {field}: {value}")
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,6 +505,16 @@
 //! success. Admissions that stay within `u64` (all normal use) behave exactly
 //! as before.
 //!
+//! `add_order` also now **rejects a duplicate id**: publishing is an
+//! insert-if-absent, so reusing the id of an order already resting at the level
+//! returns the new [`PriceLevelError::DuplicateOrderId`] variant (again leaving
+//! the level unchanged) instead of overwriting the live order and leaving the
+//! id-keyed map and the ordered index disagreeing. Snapshot restore
+//! ([`PriceLevel::from_snapshot`] and the JSON / package forms) likewise
+//! rejects an orders vector that repeats an id rather than silently
+//! overwriting. Submitting genuinely distinct ids (all normal use) is
+//! unaffected.
+//!
 
 mod orders;
 mod price_level;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,6 +515,29 @@
 //! overwriting. Submitting genuinely distinct ids (all normal use) is
 //! unaffected.
 //!
+//! ## Migration Guide (v0.9 — duplicate-id safety on restore + queue surface)
+//!
+//! Three intentional breaking changes remove infallible / overwriting paths
+//! that could desync a level's counters from its queue:
+//!
+//! - **`impl From<&PriceLevelSnapshot> for PriceLevel` is removed; use
+//!   [`TryFrom`].** The old `From` swallowed aggregate-overflow errors and built
+//!   the queue keep-first, so a snapshot repeating an id restored counters
+//!   computed over every copy while the queue kept one. Replace
+//!   `PriceLevel::from(&snapshot)` / `let lvl: PriceLevel = (&snapshot).into();`
+//!   with `PriceLevel::try_from(&snapshot)?` (or `.expect(...)` in tests). It
+//!   delegates to [`PriceLevel::from_snapshot`], returning
+//!   [`PriceLevelError::DuplicateOrderId`] on a repeated id and the
+//!   per-order / level aggregate-overflow errors instead of hiding them.
+//! - **`OrderQueue::push` is now `pub(crate)`.** Unconditional overwriting
+//!   publication is never safe for an external caller (reusing a live id would
+//!   silently replace the resting order and strand its old index entry).
+//!   Admission goes through `add_order` (or, at the queue layer, the
+//!   insert-if-absent `try_push`); there is no public overwriting insert.
+//! - **`OrderQueue::from_vec` is now `pub(crate)`.** It is a keep-first
+//!   constructor that drops duplicates silently; the public restore path is
+//!   [`PriceLevel::from_snapshot`], which rejects them.
+//!
 
 mod orders;
 mod price_level;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,6 +537,41 @@
 //! - **`OrderQueue::from_vec` is now `pub(crate)`.** It is a keep-first
 //!   constructor that drops duplicates silently; the public restore path is
 //!   [`PriceLevel::from_snapshot`], which rejects them.
+//! ## Migration Guide (level topology invariants — breaking)
+//!
+//! A [`PriceLevel`] now enforces that every resting order sits at the level's
+//! price and shares a single side (the first admitted maker pins the side; a
+//! fully drained level accepts either side again). [`PriceLevel::add_order`]
+//! returns [`PriceLevelError::InvalidOperation`] for an order whose price does
+//! not match the level, or whose side is incompatible with the resting side,
+//! and [`PriceLevel::from_snapshot`] rejects a snapshot that violates either
+//! (previously such orders were admitted, trading at the level price rather
+//! than their own and producing contradictory taker sides in one
+//! [`MatchResult`]). Callers that composed a level from mixed-price or
+//! mixed-side orders must route each order to the correct level.
+//!
+//! Single-side coherence is a **correctness invariant**, not an
+//! eventually-consistent one like the advisory counters: it holds only when a
+//! given level's admissions arrive from a single logical writer (the composing
+//! order book routes each price to one admission path). The side is derived
+//! from the live queue, so under genuinely concurrent multi-writer admission a
+//! narrow race — an opposite side slipping into a momentarily empty level — can
+//! still admit a mixed side; see the note on the [`PriceLevel`] type.
+//!
+//! [`PriceLevel::matchable_quantity`] gains a `taker_id` parameter:
+//! `matchable_quantity(incoming_quantity)` becomes
+//! `matchable_quantity(incoming_quantity, taker_id)`. A resting maker sharing
+//! the taker id is skipped (self-trade prevention), matching the sweep, so a
+//! fill-or-kill dry run and the real sweep agree. `match_order` applies the
+//! same **self-trade skip** deterministically in every build profile (it used
+//! to be a debug-only assertion): a resting maker whose id equals the taker's
+//! is skipped — no self-trade is emitted and the other makers still match.
+//!
+//! This self-trade guard is **order-id identity** — an order can never match
+//! itself. It is NOT account/owner-level self-trade prevention: two distinct
+//! order ids owned by the same `user_id` will still trade. Account-level STP is
+//! the responsibility of the order book composing these levels, which owns the
+//! account relationships a single price level does not.
 //!
 
 mod orders;

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -14,7 +14,33 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
-/// A lock-free implementation of a price level in a limit order book
+/// A lock-free implementation of a price level in a limit order book.
+///
+/// # Topology
+///
+/// Every resting order sits at [`Self::price`] and shares a single side. The
+/// side is not stored: it is derived from the resting orders themselves (the
+/// first admitted maker defines it, and a drained level accepts either side
+/// again), so [`Self::add_order`] rejects a mismatching price or side. Deriving
+/// the side is lock-free.
+///
+/// Single-side coherence is a **correctness invariant**, not an
+/// eventually-consistent one — unlike the advisory quantity / count counters
+/// (issue #68), a level that admits two makers of opposite sides does not
+/// converge to a correct state later. Upholding it therefore relies on a
+/// strictly stronger assumption than the counters: that a given level's
+/// admissions arrive from a **single logical writer** (the composing order
+/// book routes each price to one admission path). Absent that, two races can
+/// admit an incompatible side:
+///
+/// - Two **opposite-side admissions into a genuinely empty level**: both may
+///   observe no resting order and both admit.
+/// - An **opposite-side admission racing a same-side upsize** on a
+///   single-order level: a quantity increase via [`Self::update_order`]
+///   re-sequences the sole maker with a remove-then-push, transiently emptying
+///   the queue, and an opposite-side admission observing that gap admits. This
+///   window rides on the same remove+push gap that issue #119's in-place
+///   re-sequencing closes.
 #[derive(Debug)]
 pub struct PriceLevel {
     /// The price of this level
@@ -67,6 +93,38 @@ impl PriceLevel {
             for order in orders {
                 if !seen.insert(order.id()) {
                     return Err(PriceLevelError::DuplicateOrderId(order.id().to_string()));
+                }
+            }
+        }
+
+        // Topology invariants (same rules `add_order` enforces): every order
+        // must sit at the level's price and share a single side. A snapshot that
+        // violates either would reconstruct a level that trades at the wrong
+        // price or emits contradictory taker sides, so reject it here rather
+        // than restore an incoherent level.
+        {
+            let level_price = snapshot.price().as_u128();
+            let mut level_side = None;
+            for order in snapshot.orders() {
+                if order.price().as_u128() != level_price {
+                    return Err(PriceLevelError::InvalidOperation {
+                        message: format!(
+                            "snapshot order price {} does not match level price {level_price}",
+                            order.price().as_u128()
+                        ),
+                    });
+                }
+                match level_side {
+                    None => level_side = Some(order.side()),
+                    Some(side) if side != order.side() => {
+                        return Err(PriceLevelError::InvalidOperation {
+                            message: format!(
+                                "snapshot order side {:?} is incompatible with the level side {side:?}",
+                                order.side()
+                            ),
+                        });
+                    }
+                    Some(_) => {}
                 }
             }
         }
@@ -254,15 +312,58 @@ impl PriceLevel {
     /// undo on these advisory counters), so `try_push_with` publishes nothing
     /// and no counter is left drifted.
     ///
+    /// # Topology invariants
+    ///
+    /// A level holds orders at exactly one price and one side. The order's price
+    /// must equal the level's price, and its side must match the side of the
+    /// orders already resting here (the first admitted maker pins the side; a
+    /// fully drained level accepts either side again). Both are checked before
+    /// any counter is touched, so a rejected order leaves the level unchanged.
+    ///
     /// # Errors
     ///
-    /// Returns [`PriceLevelError::InvalidOperation`] if the order's own
-    /// visible + hidden total overflows `u64`, or if admitting it would
-    /// overflow the level's visible-quantity, hidden-quantity, or order-count
-    /// counter, or [`PriceLevelError::DuplicateOrderId`] if an order with the
-    /// same id already rests at this level. A duplicate id takes precedence over
-    /// a counter overflow. In every case the level is unchanged.
+    /// Returns [`PriceLevelError::InvalidOperation`] if the order's price does
+    /// not match the level's, if its side is incompatible with the resting
+    /// side, if the order's own visible + hidden total overflows `u64`, or if
+    /// admitting it would overflow the level's visible-quantity,
+    /// hidden-quantity, or order-count counter; or
+    /// [`PriceLevelError::DuplicateOrderId`] if an order with the same id
+    /// already rests at this level. A duplicate id takes precedence over a
+    /// counter overflow. In every case the level is unchanged.
     pub fn add_order(&self, order: OrderType<()>) -> Result<Arc<OrderType<()>>, PriceLevelError> {
+        // -------- Admission topology invariants (cheapest checks, no mutation) --------
+        //
+        // A level holds orders at exactly one price and one side. Reject a
+        // mismatch BEFORE reserving any counter capacity, so the level is left
+        // completely unchanged. Price is the cheapest check (two `u128`s), so it
+        // goes first; the side is derived from whatever is already resting.
+        if order.price().as_u128() != self.price {
+            return Err(PriceLevelError::InvalidOperation {
+                message: format!(
+                    "order price {} does not match level price {}",
+                    order.price().as_u128(),
+                    self.price
+                ),
+            });
+        }
+        // The level's side is defined by its resting makers: the first maker
+        // pins it, and a drained (empty) level accepts either side again — the
+        // queue is the source of truth, so no separate side state has to be
+        // stored or reset. Any resting order's side is representative (this very
+        // invariant keeps them all equal). Deriving it is lock-free; see the
+        // type-level note on the one residual window (two opposite-side
+        // admissions racing into a genuinely empty level).
+        if let Some(resting_side) = self.orders.iter_orders().next().map(|o| o.side())
+            && order.side() != resting_side
+        {
+            return Err(PriceLevelError::InvalidOperation {
+                message: format!(
+                    "order side {:?} is incompatible with the level's resting side {resting_side:?}",
+                    order.side()
+                ),
+            });
+        }
+
         // Calculate quantities.
         let visible_qty = order.visible_quantity().as_u64();
         let hidden_qty = order.hidden_quantity().as_u64();
@@ -423,8 +524,13 @@ impl PriceLevel {
     /// level. In particular a zero-visible iceberg (or auto-replenishing
     /// reserve) backed by hidden quantity counts as matchable depth, because the
     /// sweep will draw that hidden into visible and fill it.
-    fn has_matchable_depth(&self) -> bool {
-        self.iter_orders().any(|order| order.is_matchable())
+    ///
+    /// A resting maker sharing `taker_id` is ignored: the sweep skips it for
+    /// self-trade prevention, so it is not liquidity this taker could take, and
+    /// the post-only pre-check must agree.
+    fn has_matchable_depth(&self, taker_id: Id) -> bool {
+        self.iter_orders()
+            .any(|order| order.id() != taker_id && order.is_matchable())
     }
 
     /// Computes how much of `incoming_quantity` this level could actually fill
@@ -439,6 +545,11 @@ impl PriceLevel {
     /// consume — never an over- or under-count — which is what fill-or-kill
     /// (all-or-nothing) correctly depends on.
     ///
+    /// `taker_id` must be the id of the taker this depth is being computed for:
+    /// a resting maker sharing that id is skipped, exactly as the real sweep
+    /// skips it for self-trade prevention, so the prediction and the sweep can
+    /// never diverge.
+    ///
     /// It allocates a working snapshot and is only used on the cold
     /// fill-or-kill path, not on the hot `Gtc` sweep.
     ///
@@ -447,7 +558,7 @@ impl PriceLevel {
     /// feasibility instead of re-deriving the sweep, which would risk drifting
     /// from the real `match_order` behavior.
     #[must_use]
-    pub fn matchable_quantity(&self, incoming_quantity: u64) -> u64 {
+    pub fn matchable_quantity(&self, incoming_quantity: u64, taker_id: Id) -> u64 {
         if incoming_quantity == 0 {
             return 0;
         }
@@ -469,6 +580,12 @@ impl PriceLevel {
             let Some(order) = pending.pop_front() else {
                 break;
             };
+            // Self-trade prevention parity: the real sweep skips a maker sharing
+            // the taker id (`SelfTradeSkipped`), so the dry run must skip it too,
+            // or fill-or-kill would predict depth the sweep will not take.
+            if order.id() == taker_id {
+                continue;
+            }
             let (consumed, updated_order, hidden_reduced, new_remaining) =
                 order.match_against(remaining);
 
@@ -611,7 +728,12 @@ impl PriceLevel {
     /// fill-or-kill pre-checks read the queue before the sweep; under that
     /// single-matcher assumption no concurrent `match_order` can change the
     /// matchable depth between the pre-check and the sweep. Concurrent
-    /// `add_order` from other threads is likewise safe.
+    /// `add_order` from other threads is likewise safe **for counter / queue
+    /// integrity**. The single-side topology invariant carries an additional
+    /// requirement beyond that integrity: it holds only when a given level's
+    /// admissions arrive from one logical path (see the type-level note on
+    /// [`PriceLevel`]), because the side is derived from the live queue rather
+    /// than stored.
     pub fn match_order(
         &self,
         incoming_quantity: u64,
@@ -627,7 +749,10 @@ impl PriceLevel {
         // a positive taker, reject without touching the queue. A zero-quantity
         // taker has nothing to cross, so it is not rejected (it falls through to
         // the vacuous-complete sweep below).
-        if taker_kind.is_post_only() && incoming_quantity > 0 && self.has_matchable_depth() {
+        if taker_kind.is_post_only()
+            && incoming_quantity > 0
+            && self.has_matchable_depth(taker_order_id)
+        {
             tracing::debug!(
                 taker_order_id = %taker_order_id,
                 incoming_quantity,
@@ -642,7 +767,7 @@ impl PriceLevel {
         // Fill-or-kill: all-or-nothing. If the level cannot fill the taker in
         // full, kill it without touching the queue.
         if matches!(taker_tif, TimeInForce::Fok) && incoming_quantity > 0 {
-            let available = self.matchable_quantity(incoming_quantity);
+            let available = self.matchable_quantity(incoming_quantity, taker_order_id);
             if available < incoming_quantity {
                 tracing::debug!(
                     taker_order_id = %taker_order_id,
@@ -715,16 +840,21 @@ impl PriceLevel {
             new_remaining: u64,
         }
 
-        // Either the maker progressed (carrying `StepData`), was parked by the
-        // no-progress guard (`SetAside`), or forced the sweep to abort because
+        // Either the maker progressed (carrying `StepData`), was parked
+        // (`SetAside` for the no-progress guard, `SelfTradeSkipped` for a maker
+        // whose id equals the taker's), or forced the sweep to abort because
         // committing its replenishment would overflow the level's visible
         // counter (`Abort`). The parked / abort variants thread the maker's id
-        // (and, for `SetAside`, its insertion seq) OUT of the locked decision
-        // closure so the `warn!` / `error!` can name the maker without logging
-        // inside the per-entry lock.
+        // (and, where relevant, its insertion seq) OUT of the locked decision
+        // closure so the caller's `warn!` / `debug!` can name the maker without
+        // logging inside the per-entry lock.
         enum StepResult {
             Progressed(StepData),
             SetAside {
+                maker_id: Id,
+                seq: u64,
+            },
+            SelfTradeSkipped {
                 maker_id: Id,
                 seq: u64,
             },
@@ -741,6 +871,29 @@ impl PriceLevel {
 
         while remaining > 0 {
             let outcome = self.orders.match_front(&mut set_aside, |seq, order_arc| {
+                // Self-trade prevention (deterministic in every build profile,
+                // not a debug-only assert): a resting maker must never trade
+                // against a taker carrying the same id. Skip it — park its
+                // sequence like a no-progress maker so the sweep advances to the
+                // makers behind it — rather than emit a self-trade. The maker is
+                // left untouched (no trade, counters and queue unchanged).
+                //
+                // Scope: this is ORDER-ID identity — an order can never match
+                // *itself*. It is NOT account/owner-level self-trade prevention:
+                // two distinct order ids owned by the same `user_id` will still
+                // trade here. Account-level STP is the composing order book's
+                // responsibility (it knows the owner relationships this level
+                // does not).
+                if order_arc.id() == taker_order_id {
+                    return (
+                        FrontAction::SetAside,
+                        StepResult::SelfTradeSkipped {
+                            maker_id: order_arc.id(),
+                            seq,
+                        },
+                    );
+                }
+
                 let (consumed, updated_order, hidden_reduced, new_remaining) =
                     order_arc.match_against(remaining);
 
@@ -881,6 +1034,20 @@ impl PriceLevel {
                             );
                             break;
                         }
+                        StepResult::SelfTradeSkipped { maker_id, seq } => {
+                            // Self-trade prevention: the front maker shares the
+                            // taker's id. Skip it (parked like a set-aside maker)
+                            // and advance to the makers behind it; no trade is
+                            // emitted and the maker is left untouched.
+                            tracing::debug!(
+                                price = self.price,
+                                remaining,
+                                order_id = %maker_id,
+                                seq,
+                                "match sweep: front maker shares the taker id; skipped to prevent self-trade"
+                            );
+                            continue;
+                        }
                         StepResult::Progressed(data) => data,
                     };
                     let new_remaining = data.new_remaining;
@@ -897,9 +1064,10 @@ impl PriceLevel {
 
                         let trade_id = Id::from_uuid(trade_id_generator.next());
 
-                        // A resting maker must never be the taker matching
-                        // against it. Debug-only invariant of the caller.
-                        debug_assert!(data.maker_id != taker_order_id, "self-fill: maker == taker");
+                        // A resting maker can never be the taker here: a maker
+                        // sharing the taker id is skipped (`SelfTradeSkipped`)
+                        // before it reaches this point, so no self-trade is ever
+                        // emitted — deterministically, in every build profile.
 
                         let trade = Trade::with_timestamp(
                             trade_id,

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -218,37 +218,41 @@ impl PriceLevel {
 
     /// Add an order to this price level.
     ///
-    /// Reserves the order's visible / hidden quantity and one count slot on the
-    /// atomic counters **before** publishing it to the queue, so an admission
-    /// that would overflow any counter — or that reuses the id of an order
-    /// already resting here — is rejected with nothing mutated: the queue, the
-    /// counters, the statistics, and therefore any snapshot are left exactly as
-    /// they were. On success the returned `Arc` is the admitted order.
+    /// Decides the order's id IDENTITY first, then reserves its visible /
+    /// hidden quantity and one count slot on the atomic counters **atomically
+    /// with publishing** it to the queue, so an admission that reuses the id of
+    /// an order already resting here — or that would overflow any counter — is
+    /// rejected with nothing mutated: the queue, the counters, the statistics,
+    /// and therefore any snapshot are left exactly as they were. On success the
+    /// returned `Arc` is the admitted order.
     ///
     /// # Duplicate ids
     ///
-    /// The publish step is an insert-if-absent
-    /// ([`OrderQueue::try_push`](crate::price_level::OrderQueue::try_push))
-    /// under the id-keyed map's per-shard lock, so several concurrent
-    /// submissions of the same id resolve to exactly one admission; the rest
-    /// return [`PriceLevelError::DuplicateOrderId`]. A rejected duplicate never
-    /// overwrites the live order (which would leave the map and the ordered
-    /// index disagreeing) and its reserved counter capacity is rolled back
-    /// exactly as an overflow's is.
+    /// Publication goes through
+    /// [`OrderQueue::try_push_with`](crate::price_level::OrderQueue) under the
+    /// id-keyed map's per-shard lock, which decides the id is free **before**
+    /// the counter reservation runs. Several concurrent submissions of the same
+    /// id therefore resolve to exactly one admission; the rest return
+    /// [`PriceLevelError::DuplicateOrderId`] **without touching any counter** —
+    /// a rejected duplicate never overwrites the live order (which would leave
+    /// the map and the ordered index disagreeing) and never transiently inflates
+    /// a level counter.
     ///
-    /// # Overflow safety
+    /// # Error precedence
     ///
-    /// Each counter is bumped with a checked [`AtomicU64::fetch_update`] /
-    /// [`AtomicUsize::fetch_update`] (`checked_add`), which is an atomic
-    /// compare-exchange loop and therefore free of the check-then-`fetch_add`
-    /// TOCTOU race two concurrent admissions near `u64::MAX` would otherwise
-    /// hit. Capacity is reserved in the order visible → hidden → count; if a
-    /// later reservation overflows, the earlier ones are rolled back (by the
-    /// exact delta this call added — a commutative, concurrency-safe undo on
-    /// these advisory counters) before returning, so no counter is ever left
-    /// drifted. Only once all three are reserved is the order published to the
-    /// queue, so the queue can never hold an order whose admission overflowed a
-    /// counter — the invariant this method now upholds.
+    /// The order's own `visible + hidden` overflow is checked first (a pure
+    /// property of the order). Then, under the shard lock, a **duplicate id is
+    /// decided before any counter is touched**: an admission that both reuses a
+    /// live id and would overflow a counter reports
+    /// [`PriceLevelError::DuplicateOrderId`], never the overflow. Only for a
+    /// free id is capacity reserved, visible → hidden → count, each with a
+    /// checked [`AtomicU64::fetch_update`] / [`AtomicUsize::fetch_update`]
+    /// (`checked_add`) — an atomic compare-exchange loop, free of the
+    /// check-then-`fetch_add` TOCTOU race two admissions near `u64::MAX` would
+    /// hit. If a later reservation overflows, the earlier ones are rolled back
+    /// (by the exact delta this call added — a commutative, concurrency-safe
+    /// undo on these advisory counters), so `try_push_with` publishes nothing
+    /// and no counter is left drifted.
     ///
     /// # Errors
     ///
@@ -256,8 +260,8 @@ impl PriceLevel {
     /// visible + hidden total overflows `u64`, or if admitting it would
     /// overflow the level's visible-quantity, hidden-quantity, or order-count
     /// counter, or [`PriceLevelError::DuplicateOrderId`] if an order with the
-    /// same id already rests at this level. In every case the level is
-    /// unchanged.
+    /// same id already rests at this level. A duplicate id takes precedence over
+    /// a counter overflow. In every case the level is unchanged.
     pub fn add_order(&self, order: OrderType<()>) -> Result<Arc<OrderType<()>>, PriceLevelError> {
         // Calculate quantities.
         let visible_qty = order.visible_quantity().as_u64();
@@ -280,71 +284,75 @@ impl PriceLevel {
             });
         }
 
-        // Reserve capacity on each counter BEFORE publishing, using a checked
-        // `fetch_update` (an atomic CAS loop). `Relaxed` on both the success and
-        // failure orderings: these are the advisory counters (issue #68); the
-        // queue publication below carries the real happens-before for a
-        // concurrent reader, so the counters are not a synchronization channel.
-        if self
-            .visible_quantity
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
-                c.checked_add(visible_qty)
-            })
-            .is_err()
-        {
-            return Err(PriceLevelError::InvalidOperation {
-                message: "price level visible quantity overflow on admission".to_string(),
-            });
-        }
-
-        if self
-            .hidden_quantity
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
-                c.checked_add(hidden_qty)
-            })
-            .is_err()
-        {
-            // Roll back the visible reservation this call made.
-            self.visible_quantity
-                .fetch_sub(visible_qty, Ordering::Relaxed);
-            return Err(PriceLevelError::InvalidOperation {
-                message: "price level hidden quantity overflow on admission".to_string(),
-            });
-        }
-
-        if self
-            .order_count
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| c.checked_add(1))
-            .is_err()
-        {
-            // Roll back the visible + hidden reservations this call made.
-            self.visible_quantity
-                .fetch_sub(visible_qty, Ordering::Relaxed);
-            self.hidden_quantity
-                .fetch_sub(hidden_qty, Ordering::Relaxed);
-            return Err(PriceLevelError::InvalidOperation {
-                message: "price level order count overflow on admission".to_string(),
-            });
-        }
-
-        // All capacity reserved; now try to publish the order, rejecting a
-        // duplicate id atomically (insert-if-absent under the DashMap shard
-        // lock — exactly one of several concurrent submissions of the same id
-        // wins). On a duplicate, roll back the exact reservations this call
-        // made (the same undo as an overflow) so the level is left unchanged
-        // and no counter drifts, then surface the rejection. A concurrent
-        // reader can briefly see the reserved count before the order rests (the
-        // advisory-counter window), but never the reverse overflow the
-        // reservation just ruled out.
+        // Publish through `try_push_with`, which decides id IDENTITY FIRST under
+        // the DashMap shard lock and only then runs the counter reservation
+        // below — atomically with the publication. Consequences:
+        //
+        // * A duplicate id is rejected with `DuplicateOrderId` and NOTHING
+        //   touched: the reservation closure never runs, so a rejected duplicate
+        //   cannot transiently inflate a counter, and a duplicate submitted at
+        //   counter capacity reports `DuplicateOrderId` (identity) rather than a
+        //   spurious overflow (the error precedence documented above).
+        // * The reservation runs only once the id is known free; the queue then
+        //   publishes the order into the map + index while holding the shard
+        //   lock, so a concurrent cancel + readmission can never split this id
+        //   across two index entries.
+        //
+        // Inside the closure, capacity is reserved visible → hidden → count with
+        // checked `fetch_update` (an atomic CAS loop, free of the
+        // check-then-`fetch_add` TOCTOU race two admissions near `u64::MAX`
+        // would hit). `Relaxed` throughout: these are the advisory counters
+        // (issue #68); the queue publication carries the real happens-before,
+        // not these RMWs. If a later reservation overflows, the earlier ones are
+        // rolled back by the exact delta this call added — a commutative,
+        // concurrency-safe undo — before returning `Err`, so `try_push_with`
+        // publishes nothing and no counter is left drifted.
         let order_arc = Arc::new(order);
-        if let Err(err) = self.orders.try_push(order_arc.clone()) {
-            self.visible_quantity
-                .fetch_sub(visible_qty, Ordering::Relaxed);
-            self.hidden_quantity
-                .fetch_sub(hidden_qty, Ordering::Relaxed);
-            self.order_count.fetch_sub(1, Ordering::Relaxed);
-            return Err(err);
-        }
+        self.orders.try_push_with(order_arc.clone(), || {
+            if self
+                .visible_quantity
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
+                    c.checked_add(visible_qty)
+                })
+                .is_err()
+            {
+                return Err(PriceLevelError::InvalidOperation {
+                    message: "price level visible quantity overflow on admission".to_string(),
+                });
+            }
+
+            if self
+                .hidden_quantity
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
+                    c.checked_add(hidden_qty)
+                })
+                .is_err()
+            {
+                // Roll back the visible reservation this call made.
+                self.visible_quantity
+                    .fetch_sub(visible_qty, Ordering::Relaxed);
+                return Err(PriceLevelError::InvalidOperation {
+                    message: "price level hidden quantity overflow on admission".to_string(),
+                });
+            }
+
+            if self
+                .order_count
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| c.checked_add(1))
+                .is_err()
+            {
+                // Roll back the visible + hidden reservations this call made.
+                self.visible_quantity
+                    .fetch_sub(visible_qty, Ordering::Relaxed);
+                self.hidden_quantity
+                    .fetch_sub(hidden_qty, Ordering::Relaxed);
+                return Err(PriceLevelError::InvalidOperation {
+                    message: "price level order count overflow on admission".to_string(),
+                });
+            }
+
+            Ok(())
+        })?;
 
         // Update statistics only after a committed admission.
         self.stats.record_order_added();
@@ -1380,27 +1388,28 @@ impl From<&PriceLevel> for PriceLevelData {
     }
 }
 
-impl From<&PriceLevelSnapshot> for PriceLevel {
-    fn from(value: &PriceLevelSnapshot) -> Self {
-        let mut snapshot = value.clone();
-        let _ = snapshot.refresh_aggregates();
+impl TryFrom<&PriceLevelSnapshot> for PriceLevel {
+    type Error = PriceLevelError;
 
-        let order_count = snapshot.orders().len();
-        let visible_quantity = snapshot.visible_quantity().as_u64();
-        let hidden_quantity = snapshot.hidden_quantity().as_u64();
-        let price = snapshot.price().as_u128();
-        // Preserve the persisted statistics instead of resetting them.
-        let stats = (*snapshot.statistics()).clone();
-        let queue = OrderQueue::from(snapshot.into_orders());
-
-        Self {
-            price,
-            visible_quantity: AtomicU64::new(visible_quantity),
-            hidden_quantity: AtomicU64::new(hidden_quantity),
-            order_count: AtomicUsize::new(order_count),
-            orders: queue,
-            stats: Arc::new(stats),
-        }
+    /// Rebuilds a price level from a borrowed snapshot.
+    ///
+    /// Fallible on purpose (this replaced an infallible `From` in v0.9): the old
+    /// `From` swallowed [`PriceLevelSnapshot::refresh_aggregates`] errors and
+    /// built the queue with keep-first duplicate handling, so a snapshot whose
+    /// orders repeated an id would restore counters computed over every copy
+    /// while the queue kept only one — a level whose counters silently disagreed
+    /// with its contents. This clones the snapshot and delegates to
+    /// [`PriceLevel::from_snapshot`], which rejects a repeated id and propagates
+    /// the aggregate-overflow / per-order-total errors instead of hiding them.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::DuplicateOrderId`] if the snapshot's orders
+    /// vector repeats an id, or [`PriceLevelError::InvalidOperation`] if a
+    /// per-order or level aggregate overflows `u64` — see
+    /// [`PriceLevel::from_snapshot`].
+    fn try_from(value: &PriceLevelSnapshot) -> Result<Self, Self::Error> {
+        PriceLevel::from_snapshot(value.clone())
     }
 }
 

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -50,9 +50,26 @@ impl PriceLevel {
     /// Returns [`PriceLevelError::InvalidOperation`] if any restored order's own
     /// visible + hidden total overflows `u64`, or if recomputing the snapshot's
     /// level aggregates overflows `u64` — the same per-order and per-level
-    /// invariants [`Self::add_order`] enforces at admission.
+    /// invariants [`Self::add_order`] enforces at admission — or
+    /// [`PriceLevelError::DuplicateOrderId`] if the snapshot's orders vector
+    /// repeats an order id.
     pub fn from_snapshot(mut snapshot: PriceLevelSnapshot) -> Result<Self, PriceLevelError> {
         snapshot.refresh_aggregates()?;
+
+        // Reject a snapshot whose orders vector repeats an id. Building the
+        // queue would drop the duplicate (keep-first), but the reconstructed
+        // counters are taken from the snapshot's own aggregates / order count,
+        // so a silently-dropped duplicate would leave the restored level's
+        // counters disagreeing with its queue. Fail deterministically instead.
+        {
+            let orders = snapshot.orders();
+            let mut seen = std::collections::HashSet::with_capacity(orders.len());
+            for order in orders {
+                if !seen.insert(order.id()) {
+                    return Err(PriceLevelError::DuplicateOrderId(order.id().to_string()));
+                }
+            }
+        }
 
         let order_count = snapshot.orders().len();
         let visible_quantity = snapshot.visible_quantity().as_u64();
@@ -99,8 +116,10 @@ impl PriceLevel {
     /// valid snapshot-package JSON document, [`PriceLevelError::ChecksumMismatch`]
     /// if the decoded package's SHA-256 checksum does not match its payload,
     /// [`PriceLevelError::SerializationError`] if re-encoding the payload to
-    /// recompute that checksum fails, and [`PriceLevelError::InvalidOperation`]
-    /// on an unsupported snapshot format version.
+    /// recompute that checksum fails, [`PriceLevelError::InvalidOperation`]
+    /// on an unsupported snapshot format version, and
+    /// [`PriceLevelError::DuplicateOrderId`] if the decoded snapshot's orders
+    /// vector repeats an order id.
     pub fn from_snapshot_json(data: &str) -> Result<Self, PriceLevelError> {
         let package = PriceLevelSnapshotPackage::from_json(data)?;
         Self::from_snapshot_package(package)
@@ -201,10 +220,21 @@ impl PriceLevel {
     ///
     /// Reserves the order's visible / hidden quantity and one count slot on the
     /// atomic counters **before** publishing it to the queue, so an admission
-    /// that would overflow any counter is rejected with nothing mutated: the
-    /// queue, the counters, the statistics, and therefore any snapshot are left
-    /// exactly as they were. On success the returned `Arc` is the admitted
-    /// order.
+    /// that would overflow any counter — or that reuses the id of an order
+    /// already resting here — is rejected with nothing mutated: the queue, the
+    /// counters, the statistics, and therefore any snapshot are left exactly as
+    /// they were. On success the returned `Arc` is the admitted order.
+    ///
+    /// # Duplicate ids
+    ///
+    /// The publish step is an insert-if-absent
+    /// ([`OrderQueue::try_push`](crate::price_level::OrderQueue::try_push))
+    /// under the id-keyed map's per-shard lock, so several concurrent
+    /// submissions of the same id resolve to exactly one admission; the rest
+    /// return [`PriceLevelError::DuplicateOrderId`]. A rejected duplicate never
+    /// overwrites the live order (which would leave the map and the ordered
+    /// index disagreeing) and its reserved counter capacity is rolled back
+    /// exactly as an overflow's is.
     ///
     /// # Overflow safety
     ///
@@ -225,7 +255,9 @@ impl PriceLevel {
     /// Returns [`PriceLevelError::InvalidOperation`] if the order's own
     /// visible + hidden total overflows `u64`, or if admitting it would
     /// overflow the level's visible-quantity, hidden-quantity, or order-count
-    /// counter. In every case the level is unchanged.
+    /// counter, or [`PriceLevelError::DuplicateOrderId`] if an order with the
+    /// same id already rests at this level. In every case the level is
+    /// unchanged.
     pub fn add_order(&self, order: OrderType<()>) -> Result<Arc<OrderType<()>>, PriceLevelError> {
         // Calculate quantities.
         let visible_qty = order.visible_quantity().as_u64();
@@ -295,12 +327,24 @@ impl PriceLevel {
             });
         }
 
-        // All capacity reserved; publish the order to the queue. A concurrent
-        // reader can briefly see the reserved count before the order rests
-        // (the advisory-counter window), but never the reverse overflow the
+        // All capacity reserved; now try to publish the order, rejecting a
+        // duplicate id atomically (insert-if-absent under the DashMap shard
+        // lock — exactly one of several concurrent submissions of the same id
+        // wins). On a duplicate, roll back the exact reservations this call
+        // made (the same undo as an overflow) so the level is left unchanged
+        // and no counter drifts, then surface the rejection. A concurrent
+        // reader can briefly see the reserved count before the order rests (the
+        // advisory-counter window), but never the reverse overflow the
         // reservation just ruled out.
         let order_arc = Arc::new(order);
-        self.orders.push(order_arc.clone());
+        if let Err(err) = self.orders.try_push(order_arc.clone()) {
+            self.visible_quantity
+                .fetch_sub(visible_qty, Ordering::Relaxed);
+            self.hidden_quantity
+                .fetch_sub(hidden_qty, Ordering::Relaxed);
+            self.order_count.fetch_sub(1, Ordering::Relaxed);
+            return Err(err);
+        }
 
         // Update statistics only after a committed admission.
         self.stats.record_order_added();

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -3,7 +3,7 @@
 use crate::UuidGenerator;
 use crate::errors::PriceLevelError;
 use crate::execution::{MatchResult, TakerKind, Trade};
-use crate::orders::{Id, OrderType, OrderUpdate, TimeInForce};
+use crate::orders::{Id, OrderType, OrderUpdate, Side, TimeInForce};
 use crate::price_level::order_queue::{FrontAction, FrontOutcome, OrderQueue};
 use crate::price_level::{PriceLevelSnapshot, PriceLevelSnapshotPackage, PriceLevelStatistics};
 use crate::utils::{Price, Quantity, TimestampMs};
@@ -12,35 +12,91 @@ use std::fmt::Display;
 use std::str::FromStr;
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Bit layout of the [`PriceLevel::topology`] word (issue #126): the high two
+/// bits carry the pinned-side tag, the low bits the resting-order count. Packing
+/// both into one atomic makes the side pin and the count move together in a
+/// single compare-exchange, so a drain's un-pin can never race an admission's
+/// pin across two independent atomics.
+mod topology {
+    use crate::orders::Side;
+
+    /// Bits reserved for the resting-order count (the rest hold the side tag).
+    /// `u64::MAX >> 2` orders is astronomically beyond any level's capacity, so
+    /// nothing is lost by borrowing the top two bits for the tag.
+    pub(super) const COUNT_BITS: u32 = 62;
+    pub(super) const COUNT_MASK: u64 = (1 << COUNT_BITS) - 1;
+    pub(super) const TAG_UNPINNED: u64 = 0;
+    pub(super) const TAG_BUY: u64 = 1;
+    pub(super) const TAG_SELL: u64 = 2;
+
+    #[inline]
+    pub(super) fn tag_of(side: Side) -> u64 {
+        match side {
+            Side::Buy => TAG_BUY,
+            Side::Sell => TAG_SELL,
+        }
+    }
+
+    #[inline]
+    pub(super) fn side_of_tag(tag: u64) -> Option<Side> {
+        match tag {
+            TAG_BUY => Some(Side::Buy),
+            TAG_SELL => Some(Side::Sell),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub(super) fn pack(tag: u64, count: u64) -> u64 {
+        (tag << COUNT_BITS) | count
+    }
+
+    #[inline]
+    pub(super) fn tag(word: u64) -> u64 {
+        word >> COUNT_BITS
+    }
+
+    #[inline]
+    pub(super) fn count(word: u64) -> u64 {
+        word & COUNT_MASK
+    }
+}
 
 /// A lock-free implementation of a price level in a limit order book.
 ///
 /// # Topology
 ///
 /// Every resting order sits at [`Self::price`] and shares a single side. The
-/// side is not stored: it is derived from the resting orders themselves (the
-/// first admitted maker defines it, and a drained level accepts either side
-/// again), so [`Self::add_order`] rejects a mismatching price or side. Deriving
-/// the side is lock-free.
+/// side is **pinned atomically** rather than derived from the queue: a single
+/// `topology` word packs `(pinned side, resting order count)` so that an
+/// admission's side decision and the drain that un-pins an emptied level are
+/// one compare-exchange, never two racing atomics (issue #126). The first
+/// admitted maker pins the side; each later same-side admission bumps the
+/// count under the same CAS; the removal that brings the count to zero un-pins
+/// in the same CAS, so a fully drained level accepts either side again. An
+/// opposite-side admission into a non-empty level is rejected.
 ///
 /// Single-side coherence is a **correctness invariant**, not an
 /// eventually-consistent one — unlike the advisory quantity / count counters
-/// (issue #68), a level that admits two makers of opposite sides does not
-/// converge to a correct state later. Upholding it therefore relies on a
-/// strictly stronger assumption than the counters: that a given level's
-/// admissions arrive from a **single logical writer** (the composing order
-/// book routes each price to one admission path). Absent that, two races can
-/// admit an incompatible side:
+/// (issue #68), a level that admitted two makers of opposite sides would not
+/// converge to a correct state later. Pinning side+count in one atomic upholds
+/// it under **arbitrary concurrent admissions and removals**, closing both
+/// races the earlier derive-from-queue scheme left open:
 ///
-/// - Two **opposite-side admissions into a genuinely empty level**: both may
-///   observe no resting order and both admit.
-/// - An **opposite-side admission racing a same-side upsize** on a
-///   single-order level: a quantity increase via [`Self::update_order`]
-///   re-sequences the sole maker with a remove-then-push, transiently emptying
-///   the queue, and an opposite-side admission observing that gap admits. This
-///   window rides on the same remove+push gap that issue #119's in-place
-///   re-sequencing closes.
+/// - Two **opposite-side admissions into a genuinely empty level** now
+///   serialize on the pin CAS: exactly one establishes the side, the other
+///   observes a non-empty opposite-side level and is rejected.
+/// - An **opposite-side admission racing a same-side upsize** cannot slip
+///   through a transient queue gap: the pin persists across a maker's
+///   remove-then-re-add because the count never reaches zero, so the side stays
+///   pinned even while the queue momentarily looks empty.
+///
+/// A concurrent [`Self::snapshot`] cannot capture a torn old-side/new-side view
+/// across a drain-then-re-admit either: a `topology_epoch` is bumped on every
+/// side pin / un-pin, and `snapshot` retries its materialization if the epoch
+/// moves under it (see there).
 #[derive(Debug)]
 pub struct PriceLevel {
     /// The price of this level
@@ -52,8 +108,19 @@ pub struct PriceLevel {
     /// Total hidden quantity at this price level
     hidden_quantity: AtomicU64,
 
-    /// Number of orders at this price level
-    order_count: AtomicUsize,
+    /// Packed `(pinned side, resting order count)` — the atomic topology word
+    /// (issue #126). The side tag lives in the high two bits, the count in the
+    /// low [`topology::COUNT_BITS`]; see the [`topology`] module for the layout
+    /// and [`Self::topology_admit`] / [`Self::topology_release_one`] for the CAS
+    /// protocol. Replaces the former standalone `order_count` counter — the
+    /// count is now read back out of this word.
+    topology: AtomicU64,
+
+    /// Monotonic counter bumped on every side pin / un-pin (issue #126). A
+    /// [`Self::snapshot`] reads it before and after materializing the orders and
+    /// retries if it moved, so a checksummed snapshot can never capture a torn
+    /// old-side/new-side view across a drain-then-re-admit transition.
+    topology_epoch: AtomicU64,
 
     /// Queue of orders at this price level
     orders: OrderQueue,
@@ -102,7 +169,7 @@ impl PriceLevel {
         // violates either would reconstruct a level that trades at the wrong
         // price or emits contradictory taker sides, so reject it here rather
         // than restore an incoherent level.
-        {
+        let level_side: Option<Side> = {
             let level_price = snapshot.price().as_u128();
             let mut level_side = None;
             for order in snapshot.orders() {
@@ -127,7 +194,8 @@ impl PriceLevel {
                     Some(_) => {}
                 }
             }
-        }
+            level_side
+        };
 
         let order_count = snapshot.orders().len();
         let visible_quantity = snapshot.visible_quantity().as_u64();
@@ -137,11 +205,19 @@ impl PriceLevel {
         let stats = (*snapshot.statistics()).clone();
         let queue = OrderQueue::from(snapshot.into_orders());
 
+        // Pin the restored side alongside the restored count in the topology word
+        // (issue #126). An empty snapshot restores Unpinned; a non-empty one pins
+        // the single side the validation above proved coherent. `order_count` is
+        // bounded by the snapshot's own vector length, which fits `COUNT_MASK`.
+        let side_tag = level_side.map_or(topology::TAG_UNPINNED, topology::tag_of);
+        let topology_word = topology::pack(side_tag, order_count as u64);
+
         Ok(Self {
             price,
             visible_quantity: AtomicU64::new(visible_quantity),
             hidden_quantity: AtomicU64::new(hidden_quantity),
-            order_count: AtomicUsize::new(order_count),
+            topology: AtomicU64::new(topology_word),
+            topology_epoch: AtomicU64::new(0),
             orders: queue,
             stats: Arc::new(stats),
         })
@@ -192,7 +268,9 @@ impl PriceLevel {
             price,
             visible_quantity: AtomicU64::new(0),
             hidden_quantity: AtomicU64::new(0),
-            order_count: AtomicUsize::new(0),
+            // Unpinned side, zero resting orders.
+            topology: AtomicU64::new(topology::pack(topology::TAG_UNPINNED, 0)),
+            topology_epoch: AtomicU64::new(0),
             orders: OrderQueue::new(),
             stats: Arc::new(PriceLevelStatistics::new()),
         }
@@ -263,9 +341,139 @@ impl PriceLevel {
     /// [`Self::visible_quantity`]; use [`Self::snapshot`] for a consistent view.
     #[must_use]
     pub fn order_count(&self) -> usize {
-        // `Relaxed`: advisory counter, no happens-before rides on it — see
-        // `visible_quantity` for the full rationale.
-        self.order_count.load(Ordering::Relaxed)
+        // `Relaxed`: advisory read of the count half of the topology word, no
+        // happens-before rides on it — see `visible_quantity` for the rationale.
+        topology::count(self.topology.load(Ordering::Relaxed)) as usize
+    }
+
+    /// The side currently pinned at this level, or `None` if the level is empty
+    /// (Unpinned). Advisory: a concurrent admission / drain can change it right
+    /// after the read.
+    #[must_use]
+    fn pinned_side(&self) -> Option<Side> {
+        topology::side_of_tag(topology::tag(self.topology.load(Ordering::Relaxed)))
+    }
+
+    /// Reserve one admission slot for a `side` order: pin the side (or verify it
+    /// matches the pinned side) and increment the resting-order count, in a
+    /// single compare-exchange (issue #126).
+    ///
+    /// Returns `Ok(true)` iff this call pinned a previously-empty level (the
+    /// caller then bumps [`Self::topology_epoch`]), `Ok(false)` if it joined an
+    /// already-pinned same-side level.
+    ///
+    /// Because the side and the count move together, two opposite-side
+    /// admissions into an empty level serialize here: exactly one wins the CAS
+    /// that pins the side, and the loser then observes a non-empty opposite-side
+    /// level and is rejected. There is no separate "is the level empty" atomic to
+    /// fall out of step with the side.
+    ///
+    /// # Errors
+    ///
+    /// [`PriceLevelError::InvalidOperation`] if `side` is incompatible with the
+    /// pinned side of a non-empty level, or if the count would exceed
+    /// [`topology::COUNT_MASK`].
+    fn topology_admit(&self, side: Side) -> Result<bool, PriceLevelError> {
+        let my_tag = topology::tag_of(side);
+        loop {
+            let cur = self.topology.load(Ordering::Acquire);
+            let tag = topology::tag(cur);
+            let count = topology::count(cur);
+            if count == 0 {
+                // Empty level: establish this side with count 1.
+                let next = topology::pack(my_tag, 1);
+                if self
+                    .topology
+                    .compare_exchange_weak(cur, next, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok()
+                {
+                    return Ok(true);
+                }
+            } else if tag == my_tag {
+                // Same side: bump the count (checked — never wraps).
+                let Some(new_count) = count.checked_add(1).filter(|c| *c <= topology::COUNT_MASK)
+                else {
+                    return Err(PriceLevelError::InvalidOperation {
+                        message: "price level order count overflow on admission".to_string(),
+                    });
+                };
+                let next = topology::pack(my_tag, new_count);
+                if self
+                    .topology
+                    .compare_exchange_weak(cur, next, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok()
+                {
+                    return Ok(false);
+                }
+            } else {
+                // Non-empty level pinned to the opposite side: reject.
+                let resting = topology::side_of_tag(tag);
+                return Err(PriceLevelError::InvalidOperation {
+                    message: format!(
+                        "order side {side:?} is incompatible with the level's resting side {resting:?}"
+                    ),
+                });
+            }
+            // Lost the CAS to a concurrent mutation; reload and retry.
+        }
+    }
+
+    /// Release one admission slot after removing an order: decrement the count
+    /// and un-pin the side when it reaches zero, in a single compare-exchange
+    /// (issue #126).
+    ///
+    /// Returns `true` iff this call brought the count to zero and un-pinned the
+    /// level (the caller then bumps [`Self::topology_epoch`]). Because the un-pin
+    /// rides the same CAS as the decrement, a concurrent admission either sees
+    /// the still-pinned non-empty level (and joins / is rejected) or the drained
+    /// Unpinned level (and establishes) — never an inconsistent in-between.
+    fn topology_release_one(&self) -> bool {
+        loop {
+            let cur = self.topology.load(Ordering::Acquire);
+            let count = topology::count(cur);
+            if count == 0 {
+                // A removal only runs for an order this level held, so the count
+                // is >= 1; never wrap (crate rule). Treat an impossible underflow
+                // as a no-op rather than corrupt the word.
+                debug_assert!(false, "topology count underflow on release");
+                return false;
+            }
+            let new_count = count - 1;
+            let next = if new_count == 0 {
+                topology::pack(topology::TAG_UNPINNED, 0)
+            } else {
+                topology::pack(topology::tag(cur), new_count)
+            };
+            if self
+                .topology
+                .compare_exchange_weak(cur, next, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return new_count == 0;
+            }
+        }
+    }
+
+    /// Bump the topology epoch on a side pin / un-pin so a racing
+    /// [`Self::snapshot`] retries a materialization that spanned the transition.
+    #[inline]
+    fn bump_topology_epoch(&self) {
+        self.topology_epoch.fetch_add(1, Ordering::Release);
+    }
+
+    /// Returns `true` if `orders` is empty or every order shares one side — the
+    /// single-side coherence [`Self::from_snapshot`] requires. Used as the
+    /// termination backstop for `snapshot`'s torn-topology retry (issue #126).
+    fn is_single_side(orders: &[Arc<OrderType<()>>]) -> bool {
+        let mut side = None;
+        for order in orders {
+            match side {
+                None => side = Some(order.side()),
+                Some(s) if s != order.side() => return false,
+                Some(_) => {}
+            }
+        }
+        true
     }
 
     /// Get the statistics for this price level
@@ -303,13 +511,15 @@ impl PriceLevel {
     /// decided before any counter is touched**: an admission that both reuses a
     /// live id and would overflow a counter reports
     /// [`PriceLevelError::DuplicateOrderId`], never the overflow. Only for a
-    /// free id is capacity reserved, visible → hidden → count, each with a
-    /// checked [`AtomicU64::fetch_update`] / [`AtomicUsize::fetch_update`]
-    /// (`checked_add`) — an atomic compare-exchange loop, free of the
-    /// check-then-`fetch_add` TOCTOU race two admissions near `u64::MAX` would
-    /// hit. If a later reservation overflows, the earlier ones are rolled back
-    /// (by the exact delta this call added — a commutative, concurrency-safe
-    /// undo on these advisory counters), so `try_push_with` publishes nothing
+    /// free id is capacity reserved: the visible and hidden quantities with a
+    /// checked [`AtomicU64::fetch_update`] (`checked_add`) — an atomic
+    /// compare-exchange loop, free of the check-then-`fetch_add` TOCTOU race two
+    /// admissions near `u64::MAX` would hit — and THEN the side pin and order
+    /// count together in one compare-exchange (`topology_admit`), which also
+    /// serializes concurrent opposite-side admissions. If the quantity
+    /// reservations or the pin fail, the earlier ones are rolled back (by the
+    /// exact delta this call added — a commutative, concurrency-safe undo on
+    /// these advisory counters), so `try_push_with` publishes nothing
     /// and no counter is left drifted.
     ///
     /// # Topology invariants
@@ -346,20 +556,21 @@ impl PriceLevel {
                 ),
             });
         }
-        // The level's side is defined by its resting makers: the first maker
-        // pins it, and a drained (empty) level accepts either side again — the
-        // queue is the source of truth, so no separate side state has to be
-        // stored or reset. Any resting order's side is representative (this very
-        // invariant keeps them all equal). Deriving it is lock-free; see the
-        // type-level note on the one residual window (two opposite-side
-        // admissions racing into a genuinely empty level).
-        if let Some(resting_side) = self.orders.iter_orders().next().map(|o| o.side())
-            && order.side() != resting_side
+        // The level's side is pinned in the topology word (issue #126): the
+        // first maker pins it, later same-side makers join, and the drain that
+        // empties the level un-pins it so a drained level accepts either side
+        // again. This is a cheap EARLY reject of an opposite-side order against a
+        // non-empty level, so the common mismatch never reserves counter
+        // capacity. It is only an optimization — the AUTHORITATIVE, race-free
+        // side decision is the pin CAS ([`Self::topology_admit`]) run inside the
+        // reservation closure below, which serializes concurrent admissions.
+        let order_side = order.side();
+        if let Some(resting_side) = self.pinned_side()
+            && order_side != resting_side
         {
             return Err(PriceLevelError::InvalidOperation {
                 message: format!(
-                    "order side {:?} is incompatible with the level's resting side {resting_side:?}",
-                    order.side()
+                    "order side {order_side:?} is incompatible with the level's resting side {resting_side:?}"
                 ),
             });
         }
@@ -399,15 +610,17 @@ impl PriceLevel {
         //   lock, so a concurrent cancel + readmission can never split this id
         //   across two index entries.
         //
-        // Inside the closure, capacity is reserved visible → hidden → count with
-        // checked `fetch_update` (an atomic CAS loop, free of the
-        // check-then-`fetch_add` TOCTOU race two admissions near `u64::MAX`
-        // would hit). `Relaxed` throughout: these are the advisory counters
-        // (issue #68); the queue publication carries the real happens-before,
-        // not these RMWs. If a later reservation overflows, the earlier ones are
-        // rolled back by the exact delta this call added — a commutative,
-        // concurrency-safe undo — before returning `Err`, so `try_push_with`
-        // publishes nothing and no counter is left drifted.
+        // Inside the closure, capacity is reserved visible → hidden with checked
+        // `fetch_update` (an atomic CAS loop, free of the check-then-`fetch_add`
+        // TOCTOU race two admissions near `u64::MAX` would hit), and THEN the
+        // side is pinned and the count bumped in one CAS via `topology_admit`.
+        // `Relaxed` on the advisory visible / hidden RMWs (issue #68); the pin
+        // CAS uses `AcqRel` because side coherence is a hard invariant, not an
+        // advisory counter. The pin goes LAST so it is only mutated on the
+        // success path: an incompatible side or a count overflow returns `Err`
+        // after rolling back the visible + hidden reservations this call made
+        // (a commutative, concurrency-safe undo), leaving the topology word
+        // untouched and `try_push_with` publishing nothing.
         let order_arc = Arc::new(order);
         self.orders.try_push_with(order_arc.clone(), || {
             if self
@@ -437,19 +650,28 @@ impl PriceLevel {
                 });
             }
 
-            if self
-                .order_count
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| c.checked_add(1))
-                .is_err()
-            {
-                // Roll back the visible + hidden reservations this call made.
-                self.visible_quantity
-                    .fetch_sub(visible_qty, Ordering::Relaxed);
-                self.hidden_quantity
-                    .fetch_sub(hidden_qty, Ordering::Relaxed);
-                return Err(PriceLevelError::InvalidOperation {
-                    message: "price level order count overflow on admission".to_string(),
-                });
+            // Pin the side and bump the count in one CAS. This is the
+            // authoritative, race-free side decision: two opposite-side
+            // admissions into an empty level serialize here, only one wins.
+            match self.topology_admit(order_side) {
+                Ok(established) => {
+                    if established {
+                        // Pinned a previously-empty level; bump the epoch BEFORE
+                        // the publish that `try_push_with` does next, so a
+                        // snapshot whose walk spans this transition sees the epoch
+                        // move and retries.
+                        self.bump_topology_epoch();
+                    }
+                }
+                Err(err) => {
+                    // Roll back the visible + hidden reservations this call made;
+                    // the topology word was not mutated (pin goes last).
+                    self.visible_quantity
+                        .fetch_sub(visible_qty, Ordering::Relaxed);
+                    self.hidden_quantity
+                        .fetch_sub(hidden_qty, Ordering::Relaxed);
+                    return Err(err);
+                }
             }
 
             Ok(())
@@ -743,6 +965,33 @@ impl PriceLevel {
         timestamp: TimestampMs,
         trade_id_generator: &UuidGenerator,
     ) -> MatchResult {
+        // -------- Self-match is terminal (issue #126, tightening #120) --------
+        //
+        // If the taker's own id already rests at this level, the taker cannot
+        // take liquidity here: matching would either self-trade (forbidden) or,
+        // via the in-sweep skip, walk PAST its own resting order to trade with
+        // OTHER makers — but issue #120's acceptance is that a self-match attempt
+        // emits NO trades and leaves the level byte-identical. So reject
+        // terminally, before any sweep, for EVERY TIF and kind. This check
+        // precedes and therefore dominates the post-only / fill-or-kill
+        // pre-checks below (a self-match `Fok` is Rejected, not Killed); the
+        // post-only behaviour for a taker that does NOT rest here is unchanged.
+        // The lookup is an O(1) id probe. The in-sweep `SelfTradeSkipped` path is
+        // retained as documented defense-in-depth for the narrow race where the
+        // taker's resting order is admitted AFTER this probe but during the
+        // sweep — even then it must never self-trade.
+        if incoming_quantity > 0 && self.orders.find(taker_order_id).is_some() {
+            tracing::debug!(
+                taker_order_id = %taker_order_id,
+                incoming_quantity,
+                price = self.price,
+                "taker rejected: own order id already rests at this level (self-match)"
+            );
+            let mut result = MatchResult::new(taker_order_id, Quantity::new(incoming_quantity));
+            result.mark_rejected(incoming_quantity);
+            return result;
+        }
+
         // -------- Taker TIF / kind pre-checks (before any queue mutation) --------
         //
         // PostOnly: must never take liquidity. If any matchable depth exists for
@@ -871,9 +1120,14 @@ impl PriceLevel {
 
         while remaining > 0 {
             let outcome = self.orders.match_front(&mut set_aside, |seq, order_arc| {
-                // Self-trade prevention (deterministic in every build profile,
-                // not a debug-only assert): a resting maker must never trade
-                // against a taker carrying the same id. Skip it — park its
+                // Self-trade prevention, DEFENSE-IN-DEPTH (issue #126). The
+                // common case is already handled terminally before the sweep: if
+                // the taker id rests here, `match_order` returns `Rejected` with
+                // no trades. This in-sweep skip covers only the narrow race where
+                // the taker's own order is admitted AFTER that pre-check but
+                // before the sweep reaches its slot. Deterministic in every build
+                // profile (not a debug-only assert): a resting maker must never
+                // trade against a taker carrying the same id. Skip it — park its
                 // sequence like a no-progress maker so the sweep advances to the
                 // makers behind it — rather than emit a self-trade. The maker is
                 // left untouched (no trade, counters and queue unchanged).
@@ -1100,7 +1354,11 @@ impl PriceLevel {
 
                     if data.fully_consumed {
                         // Maker fully consumed and removed inside `match_front`.
-                        self.order_count.fetch_sub(1, Ordering::Relaxed);
+                        // Decrement the count and un-pin if this drained the level
+                        // (issue #126); the removal already happened-before here.
+                        if self.topology_release_one() {
+                            self.bump_topology_epoch();
+                        }
                         if data.hidden_stranded > 0 {
                             self.hidden_quantity
                                 .fetch_sub(data.hidden_stranded, Ordering::Relaxed);
@@ -1155,7 +1413,26 @@ impl PriceLevel {
         // sequence) order so a snapshot round-trip re-enqueues them in identical
         // priority order; every aggregate is derived from this same snapshot so
         // they are mutually consistent by construction.
-        let orders = self.snapshot_by_insertion_seq();
+        //
+        // Guard against a TORN topology (issue #126): a walk that spans a
+        // drain-then-re-admit to the opposite side could capture old-side and
+        // new-side orders together, producing a checksummed snapshot that
+        // `from_snapshot` would reject for mixed sides. `topology_epoch` is
+        // bumped on every side pin / un-pin, so if it moves across the walk we
+        // retry. The `is_single_side` fallback GUARANTEES termination: a stable
+        // epoch already implies a coherent walk (a tear requires a transition,
+        // which bumps the epoch), so we only ever loop while a walk actually came
+        // back mixed-side, which needs an in-progress opposite-side flip — once
+        // flipping stops (finite writers) the next walk is coherent and returns.
+        let orders = loop {
+            let epoch_before = self.topology_epoch.load(Ordering::Acquire);
+            let orders = self.snapshot_by_insertion_seq();
+            let epoch_after = self.topology_epoch.load(Ordering::Acquire);
+            if epoch_before == epoch_after || Self::is_single_side(&orders) {
+                break orders;
+            }
+            // A side transition raced the walk AND left a mixed-side view; retry.
+        };
 
         let order_count = orders.len();
 
@@ -1289,7 +1566,11 @@ impl PriceLevel {
                             .fetch_sub(visible_qty, Ordering::Relaxed);
                         self.hidden_quantity
                             .fetch_sub(hidden_qty, Ordering::Relaxed);
-                        self.order_count.fetch_sub(1, Ordering::Relaxed);
+                        // Decrement the count and un-pin if this drained the
+                        // level (issue #126); the `remove` above happened-before.
+                        if self.topology_release_one() {
+                            self.bump_topology_epoch();
+                        }
 
                         // Update statistics
                         self.stats.record_order_removed();
@@ -1443,7 +1724,11 @@ impl PriceLevel {
                             .fetch_sub(visible_qty, Ordering::Relaxed);
                         self.hidden_quantity
                             .fetch_sub(hidden_qty, Ordering::Relaxed);
-                        self.order_count.fetch_sub(1, Ordering::Relaxed);
+                        // Decrement the count and un-pin if this drained the
+                        // level (issue #126); the `remove` above happened-before.
+                        if self.topology_release_one() {
+                            self.bump_topology_epoch();
+                        }
 
                         // Update statistics
                         self.stats.record_order_removed();
@@ -1474,7 +1759,11 @@ impl PriceLevel {
                         .fetch_sub(visible_qty, Ordering::Relaxed);
                     self.hidden_quantity
                         .fetch_sub(hidden_qty, Ordering::Relaxed);
-                    self.order_count.fetch_sub(1, Ordering::Relaxed);
+                    // Decrement the count and un-pin if this drained the level
+                    // (issue #126); the `remove` above happened-before.
+                    if self.topology_release_one() {
+                        self.bump_topology_epoch();
+                    }
 
                     // Update statistics
                     self.stats.record_order_removed();
@@ -1506,7 +1795,11 @@ impl PriceLevel {
                             .fetch_sub(visible_qty, Ordering::Relaxed);
                         self.hidden_quantity
                             .fetch_sub(hidden_qty, Ordering::Relaxed);
-                        self.order_count.fetch_sub(1, Ordering::Relaxed);
+                        // Decrement the count and un-pin if this drained the
+                        // level (issue #126); the `remove` above happened-before.
+                        if self.topology_release_one() {
+                            self.bump_topology_epoch();
+                        }
 
                         // Update statistics
                         self.stats.record_order_removed();

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -97,7 +97,13 @@ impl OrderQueue {
     /// id may collide with a live order, use [`OrderQueue::try_push`], which
     /// rejects the duplicate instead of overwriting it (leaving the id-keyed map
     /// and the ordered index disagreeing).
-    pub fn push(&self, order: Arc<OrderType<()>>) {
+    ///
+    /// `pub(crate)`: overwriting publication is never safe to expose — a caller
+    /// that reused a live id would silently replace the resting order and strand
+    /// its old index entry. Admission goes through [`OrderQueue::try_push`] /
+    /// [`OrderQueue::try_push_with`]; this stays available only to the in-crate
+    /// upsize re-insert, whose id is provably absent at the call site.
+    pub(crate) fn push(&self, order: Arc<OrderType<()>>) {
         // `Relaxed` is sufficient: only the uniqueness and monotonicity of the
         // counter matter. The happens-before ordering between concurrent
         // producers/consumers is provided by the lock-free `index`/`orders`
@@ -111,20 +117,12 @@ impl OrderQueue {
     /// Insert an order only if its id is not already present — the admission
     /// primitive.
     ///
-    /// Uses the `DashMap` entry API so the insert-if-absent decision is atomic
-    /// under the per-shard lock: given several concurrent submissions of the
-    /// same id, exactly one observes `Vacant` and inserts; every other observes
-    /// `Occupied` and is rejected with
-    /// [`PriceLevelError::DuplicateOrderId`], leaving the map value, the index,
-    /// and the sequence counter untouched. A duplicate admitted through this
-    /// method therefore can never produce the two-sequences-for-one-id state
-    /// that a blind [`OrderQueue::push`] would. (The quantity-increase update
-    /// path still vacates the id across its remove-then-push re-insert; that
-    /// residual window is closed by the atomic re-sequencing work in #119.)
-    ///
-    /// The insertion sequence is minted **inside** the `Vacant` arm, so a
-    /// rejected duplicate does not consume a sequence (no gaps) and the index
-    /// entry is added only for the order that actually landed in the map.
+    /// Thin wrapper over the crate-internal `try_push_with` with a no-op
+    /// reservation: the id-uniqueness, held-lock publication, and
+    /// no-sequence-gap guarantees documented there all apply. Use this when
+    /// publication has no side effects to commit atomically with it; the
+    /// reservation-hook form commits a caller-side reservation (e.g. the level's
+    /// atomic counters) under the same shard lock that decides the id is free.
     ///
     /// # Errors
     ///
@@ -132,15 +130,82 @@ impl OrderQueue {
     /// id already rests in the queue.
     #[must_use = "a rejected duplicate must be handled, not ignored"]
     pub fn try_push(&self, order: Arc<OrderType<()>>) -> Result<(), PriceLevelError> {
+        self.try_push_with(order, || Ok(()))
+    }
+
+    /// Insert an order only if its id is absent, committing a caller-supplied
+    /// `reserve` step **atomically with the publication** — the admission
+    /// primitive with a reservation hook.
+    ///
+    /// The `DashMap` entry API makes the whole operation atomic under the
+    /// per-shard lock:
+    ///
+    /// 1. **Identity is decided first.** An `Occupied` entry means the id
+    ///    already rests here: return [`PriceLevelError::DuplicateOrderId`]
+    ///    with **nothing touched** — `reserve` is never run, no sequence is
+    ///    minted, no counter moves. This is why a duplicate can never leave a
+    ///    transient side effect (e.g. an inflated level counter) for another
+    ///    thread to observe, and why a duplicate at counter capacity reports
+    ///    `DuplicateOrderId` rather than a spurious overflow.
+    /// 2. **Then `reserve` runs**, still under the shard lock, now that the id
+    ///    is known free. If it returns `Err`, propagate it with nothing
+    ///    inserted — the caller is responsible for leaving its own state
+    ///    unchanged on `Err` (e.g. rolling back a partial multi-counter
+    ///    reservation before returning).
+    /// 3. **Then publish, holding the shard lock across the index insert.** The
+    ///    map value is inserted (its returned guard keeps the shard write lock),
+    ///    the `seq -> id` index entry is added while that guard is still held,
+    ///    and only then is the guard dropped. Holding the lock across both
+    ///    publications closes the window where the lock released after the map
+    ///    insert but before the index insert: a concurrent cancel + same-id
+    ///    readmission could otherwise land its own entries and let this call's
+    ///    stale index insert produce two index entries for one id. This is the
+    ///    same held-lock shape [`OrderQueue::match_front`]'s `ReplaceAtTail`
+    ///    uses. `self.index` is a separate structure (`SkipMap`), so inserting
+    ///    into it under the `DashMap` shard lock cannot deadlock.
+    ///
+    /// The insertion sequence is minted **inside** the `Vacant` arm, after
+    /// `reserve` succeeds, so neither a rejected duplicate nor a failed
+    /// reservation consumes a sequence (no gaps) and the index entry is added
+    /// only for the order that actually landed in the map.
+    ///
+    /// `reserve` runs while the shard lock is held, so it MUST NOT call back
+    /// into this queue (that would deadlock on the same shard) and MUST NOT
+    /// block; the level's counter reservations (plain atomic RMWs) satisfy both.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::DuplicateOrderId`] if an order with the same
+    /// id already rests in the queue, or whatever error `reserve` returns.
+    #[must_use = "a rejected admission must be handled, not ignored"]
+    pub(crate) fn try_push_with<F>(
+        &self,
+        order: Arc<OrderType<()>>,
+        reserve: F,
+    ) -> Result<(), PriceLevelError>
+    where
+        F: FnOnce() -> Result<(), PriceLevelError>,
+    {
         let order_id = order.id();
         match self.orders.entry(order_id) {
             Entry::Occupied(_) => Err(PriceLevelError::DuplicateOrderId(order_id.to_string())),
             Entry::Vacant(slot) => {
-                // Mint the sequence only now that we know the id is free, so a
-                // rejected duplicate leaves the counter (and the index) alone.
+                // Identity is already decided (this arm means the id is free).
+                // Run the caller's reservation before publishing; on failure
+                // nothing has been inserted and no sequence minted, so the
+                // level stays byte-identical once the caller unwinds its own
+                // partial reservation.
+                reserve()?;
+                // Mint the sequence only now that the id is free and the
+                // reservation committed, so neither a rejected duplicate nor a
+                // failed reservation leaves a gap in the sequence.
                 let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
-                slot.insert((seq, order));
+                // Hold the shard lock across BOTH publications: the map insert
+                // returns a guard that keeps the lock, the index entry is added
+                // while it is held, and only then is the guard dropped.
+                let guard = slot.insert((seq, order));
                 self.index.insert(seq, order_id);
+                drop(guard);
                 Ok(())
             }
         }
@@ -387,6 +452,31 @@ impl OrderQueue {
         Some(order)
     }
 
+    /// Test-only invariant check: the id-keyed map and the ordered index are
+    /// **1:1**. Must be called only at quiescence (no concurrent mutation), when
+    /// every in-flight operation has completed.
+    ///
+    /// Verifies there are exactly as many index entries as map entries and that
+    /// every index entry `seq -> id` points to a map entry whose stored sequence
+    /// is exactly `seq`. A split index entry (two sequences for one id — the
+    /// publication-race bug closed by [`OrderQueue::try_push_with`] holding the
+    /// shard lock across both publications) makes the index longer than the map,
+    /// so this returns `false`.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn debug_map_index_consistent(&self) -> bool {
+        if self.index.len() != self.orders.len() {
+            return false;
+        }
+        self.index.iter().all(|entry| {
+            let seq = *entry.key();
+            let id = *entry.value();
+            self.orders
+                .get(&id)
+                .is_some_and(|slot| slot.value().0 == seq)
+        })
+    }
+
     /// Iterate through current orders without materializing an intermediate vector.
     pub fn iter_orders(&self) -> impl Iterator<Item = Arc<OrderType<()>>> + '_ {
         self.orders.iter().map(|entry| entry.value().1.clone())
@@ -495,9 +585,16 @@ impl OrderQueue {
     /// ordered index always stay 1:1. Callers that must *reject* a
     /// duplicate-bearing vector (e.g. snapshot restore) validate uniqueness
     /// upstream where a `Result` can be returned.
+    ///
+    /// `pub(crate)`: a keep-first constructor that silently drops duplicates is
+    /// not a safe public entry point (a caller could restore counters computed
+    /// over a copy the queue then discards). The public path is
+    /// [`PriceLevel::from_snapshot`](crate::price_level::PriceLevel), which
+    /// rejects duplicates; this stays crate-internal for tests and the
+    /// upstream-validated restore.
     #[allow(dead_code)]
     #[must_use]
-    pub fn from_vec(orders: Vec<Arc<OrderType<()>>>) -> Self {
+    pub(crate) fn from_vec(orders: Vec<Arc<OrderType<()>>>) -> Self {
         let queue = OrderQueue::new();
         for order in orders {
             // Keep-first on a duplicate id: the index must stay 1:1.

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -88,7 +88,15 @@ impl OrderQueue {
         }
     }
 
-    /// Add an order to the tail of the queue (newest time priority).
+    /// Add an order to the tail of the queue (newest time priority),
+    /// **unconditionally overwriting** any existing entry for the same id.
+    ///
+    /// This is the re-insert primitive for a maker that was just removed and is
+    /// being put back under a fresh sequence (the upsize `remove` + `push`
+    /// demotion), where the id is guaranteed absent. For *admission*, where the
+    /// id may collide with a live order, use [`OrderQueue::try_push`], which
+    /// rejects the duplicate instead of overwriting it (leaving the id-keyed map
+    /// and the ordered index disagreeing).
     pub fn push(&self, order: Arc<OrderType<()>>) {
         // `Relaxed` is sufficient: only the uniqueness and monotonicity of the
         // counter matter. The happens-before ordering between concurrent
@@ -98,6 +106,44 @@ impl OrderQueue {
         let order_id = order.id();
         self.orders.insert(order_id, (seq, order));
         self.index.insert(seq, order_id);
+    }
+
+    /// Insert an order only if its id is not already present — the admission
+    /// primitive.
+    ///
+    /// Uses the `DashMap` entry API so the insert-if-absent decision is atomic
+    /// under the per-shard lock: given several concurrent submissions of the
+    /// same id, exactly one observes `Vacant` and inserts; every other observes
+    /// `Occupied` and is rejected with
+    /// [`PriceLevelError::DuplicateOrderId`], leaving the map value, the index,
+    /// and the sequence counter untouched. A duplicate admitted through this
+    /// method therefore can never produce the two-sequences-for-one-id state
+    /// that a blind [`OrderQueue::push`] would. (The quantity-increase update
+    /// path still vacates the id across its remove-then-push re-insert; that
+    /// residual window is closed by the atomic re-sequencing work in #119.)
+    ///
+    /// The insertion sequence is minted **inside** the `Vacant` arm, so a
+    /// rejected duplicate does not consume a sequence (no gaps) and the index
+    /// entry is added only for the order that actually landed in the map.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceLevelError::DuplicateOrderId`] if an order with the same
+    /// id already rests in the queue.
+    #[must_use = "a rejected duplicate must be handled, not ignored"]
+    pub fn try_push(&self, order: Arc<OrderType<()>>) -> Result<(), PriceLevelError> {
+        let order_id = order.id();
+        match self.orders.entry(order_id) {
+            Entry::Occupied(_) => Err(PriceLevelError::DuplicateOrderId(order_id.to_string())),
+            Entry::Vacant(slot) => {
+                // Mint the sequence only now that we know the id is free, so a
+                // rejected duplicate leaves the counter (and the index) alone.
+                let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
+                slot.insert((seq, order));
+                self.index.insert(seq, order_id);
+                Ok(())
+            }
+        }
     }
 
     /// Pop the front (oldest) order together with its insertion sequence,
@@ -444,12 +490,18 @@ impl OrderQueue {
     ///
     /// A new `OrderQueue` instance containing all the orders from the input vector.
     ///
+    /// Note: this infallible constructor drops later orders that repeat an id
+    /// already inserted (keep-first), so the queue's id-keyed map and its
+    /// ordered index always stay 1:1. Callers that must *reject* a
+    /// duplicate-bearing vector (e.g. snapshot restore) validate uniqueness
+    /// upstream where a `Result` can be returned.
     #[allow(dead_code)]
     #[must_use]
     pub fn from_vec(orders: Vec<Arc<OrderType<()>>>) -> Self {
         let queue = OrderQueue::new();
         for order in orders {
-            queue.push(order);
+            // Keep-first on a duplicate id: the index must stay 1:1.
+            let _ = queue.try_push(order);
         }
         queue
     }
@@ -520,7 +572,8 @@ impl FromStr for OrderQueue {
                     OrderType::from_str(order_str).map_err(|e| PriceLevelError::ParseError {
                         message: format!("Order parse error: {e}"),
                     })?;
-                queue.push(Arc::new(order));
+                // Reject a repeated id rather than overwriting it.
+                queue.try_push(Arc::new(order))?;
             }
         }
 
@@ -544,10 +597,13 @@ impl Display for OrderQueue {
 }
 
 impl From<Vec<Arc<OrderType<()>>>> for OrderQueue {
+    /// Infallible conversion: a repeated id is dropped (keep-first) so the map
+    /// and index stay 1:1. Restore paths that must reject duplicates validate
+    /// uniqueness upstream (see [`crate::price_level::PriceLevel::from_snapshot`]).
     fn from(orders: Vec<Arc<OrderType<()>>>) -> Self {
         let queue = OrderQueue::new();
         for order in orders {
-            queue.push(order);
+            let _ = queue.try_push(order);
         }
         queue
     }
@@ -579,9 +635,12 @@ impl<'de> Visitor<'de> for OrderQueueVisitor {
     {
         let queue = OrderQueue::new();
 
-        // Deserialize each order and add it to the queue
+        // Deserialize each order and add it to the queue, rejecting a repeated
+        // id rather than silently overwriting it.
         while let Some(order) = seq.next_element::<OrderType<()>>()? {
-            queue.push(Arc::new(order));
+            queue
+                .try_push(Arc::new(order))
+                .map_err(serde::de::Error::custom)?;
         }
 
         Ok(queue)

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -333,6 +333,18 @@ impl OrderQueue {
                     // escapes into a `FrontAction`).
                     let (action, result) = decide(seq, occupied.get().1.as_ref());
 
+                    // A `SetAside` records a sequence into the caller's scratch
+                    // `HashSet`, whose first insert allocates. Defer that insert
+                    // until AFTER the entry lock is released (issue #126) so no
+                    // allocation ever runs under the shard lock — the set is
+                    // per-sweep scratch owned by the caller, never shared, so it
+                    // needs no lock protection. The other actions commit their
+                    // queue mutations here, under the lock, as before.
+                    let mut park_seq: Option<u64> = None;
+                    // Every arm releases the entry lock by the time it finishes
+                    // (either `occupied.remove()` consumes it, or an explicit
+                    // `drop`), so the deferred `set_aside` insert below never runs
+                    // under the shard lock.
                     match &action {
                         FrontAction::Remove => {
                             // Full consume: remove the entry under the lock, then
@@ -345,8 +357,8 @@ impl OrderQueue {
                             // Partial fill keeping priority: swap the stored value
                             // to the residual in place, keeping the same
                             // sequence/index entry. Still under the entry lock.
-                            let slot = occupied.get_mut();
-                            slot.1 = residual.clone();
+                            occupied.get_mut().1 = residual.clone();
+                            drop(occupied);
                         }
                         FrontAction::ReplaceAtTail(refreshed) => {
                             // Replenished tranche loses time priority, but the
@@ -362,13 +374,12 @@ impl OrderQueue {
                                 slot.0 = new_seq;
                                 slot.1 = refreshed.clone();
                             }
-                            // `occupied` still holds the per-entry lock here (it
-                            // is dropped at the end of this arm), so re-keying the
-                            // index — a different structure (`SkipMap`), no
-                            // deadlock — happens while a concurrent cancel is
-                            // still excluded from the entry. Once the lock is
-                            // released the value already carries `new_seq`, so a
-                            // cancel removes `orders[id]` and `index[new_seq]`
+                            // `occupied` still holds the per-entry lock here, so
+                            // re-keying the index — a different structure
+                            // (`SkipMap`), no deadlock — happens while a concurrent
+                            // cancel is still excluded from the entry. Once the
+                            // lock is released the value already carries `new_seq`,
+                            // so a cancel removes `orders[id]` and `index[new_seq]`
                             // consistently. The only residue a race can leave is a
                             // stale `index[seq|new_seq] -> id` entry pointing at an
                             // already-removed id, which the next `match_front`
@@ -376,12 +387,20 @@ impl OrderQueue {
                             // counter update is ever lost.
                             self.index.remove(&seq);
                             self.index.insert(new_seq, order_id);
+                            drop(occupied);
                         }
                         FrontAction::SetAside => {
-                            // No progress: leave the entry untouched and park its
-                            // sequence so the sweep advances past it.
-                            set_aside.insert(seq);
+                            // No progress: leave the entry untouched. Release the
+                            // lock and park its sequence below.
+                            drop(occupied);
+                            park_seq = Some(seq);
                         }
+                    }
+
+                    // The entry lock is released on every arm above; a
+                    // possibly-allocating scratch-set insert now runs unlocked.
+                    if let Some(seq) = park_seq {
+                        set_aside.insert(seq);
                     }
 
                     return FrontOutcome::Matched { result };

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -40,7 +40,7 @@ mod tests {
             .add_order(create_standard_order(1, 10000, 100))
             .expect("add_order should succeed");
         price_level
-            .add_order(create_iceberg_order(2, 10000, 50, 200))
+            .add_order(create_buy_iceberg_order(2, 10000, 50, 200))
             .expect("add_order should succeed");
 
         let package = price_level
@@ -243,13 +243,21 @@ mod tests {
             .add_order(create_standard_order(1, 15000, 100))
             .expect("add_order should succeed");
         price_level
-            .add_order(create_iceberg_order(2, 15000, 40, 120))
+            .add_order(create_buy_iceberg_order(2, 15000, 40, 120))
             .expect("add_order should succeed");
         price_level
             .add_order(create_post_only_order(3, 15000, 60))
             .expect("add_order should succeed");
         price_level
-            .add_order(create_reserve_order(4, 15000, 30, 90, 15, true, Some(20)))
+            .add_order(create_buy_reserve_order(
+                4,
+                15000,
+                30,
+                90,
+                15,
+                true,
+                Some(20),
+            ))
             .expect("add_order should succeed");
 
         let snapshot = price_level.snapshot();
@@ -284,7 +292,7 @@ mod tests {
             .add_order(create_standard_order(10, 17500, 80))
             .expect("add_order should succeed");
         price_level
-            .add_order(create_trailing_stop_order(11, 17500, 50))
+            .add_order(create_buy_trailing_stop_order(11, 17500, 50))
             .expect("add_order should succeed");
         price_level
             .add_order(create_pegged_order(12, 17500, 40))
@@ -421,6 +429,68 @@ mod tests {
         }
     }
 
+    // Buy-side variants of the Sell-defaulting helpers, for tests that mix
+    // several order types at one level (issue #120: a level holds a single
+    // side, so every maker in these tests must share it).
+    fn create_buy_iceberg_order(id: u64, price: u128, visible: u64, hidden: u64) -> OrderType<()> {
+        let timestamp = TIMESTAMP_COUNTER.fetch_add(1, Ordering::SeqCst);
+        OrderType::IcebergOrder {
+            id: Id::from_u64(id),
+            price: Price::new(price),
+            visible_quantity: Quantity::new(visible),
+            hidden_quantity: Quantity::new(hidden),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(timestamp),
+            time_in_force: TimeInForce::Gtc,
+            extra_fields: (),
+        }
+    }
+
+    fn create_buy_trailing_stop_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
+        let timestamp = TIMESTAMP_COUNTER.fetch_add(1, Ordering::SeqCst);
+        OrderType::TrailingStop {
+            id: Id::from_u64(id),
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(timestamp),
+            time_in_force: TimeInForce::Gtc,
+            trail_amount: Quantity::new(100),
+            last_reference_price: Price::new(price + 100u128),
+            extra_fields: (),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn create_buy_reserve_order(
+        id: u64,
+        price: u128,
+        visible: u64,
+        hidden: u64,
+        threshold: u64,
+        auto_replenish: bool,
+        replenish_amount: Option<u64>,
+    ) -> OrderType<()> {
+        let timestamp = TIMESTAMP_COUNTER.fetch_add(1, Ordering::SeqCst);
+        OrderType::ReserveOrder {
+            id: Id::from_u64(id),
+            price: Price::new(price),
+            visible_quantity: Quantity::new(visible),
+            hidden_quantity: Quantity::new(hidden),
+            side: Side::Buy,
+            user_id: Hash32::zero(),
+            timestamp: TimestampMs::new(timestamp),
+            time_in_force: TimeInForce::Gtc,
+            replenish_threshold: Quantity::new(threshold),
+            replenish_amount: replenish_amount
+                .map(|amount| NonZeroU64::new(amount).expect("test replenish amount must be > 0")),
+            auto_replenish,
+            extra_fields: (),
+        }
+    }
+
     fn create_fill_or_kill_order(id: u64, price: u128, quantity: u64) -> OrderType<()> {
         let timestamp = TIMESTAMP_COUNTER.fetch_add(1, Ordering::SeqCst);
         OrderType::Standard {
@@ -532,13 +602,13 @@ mod tests {
             .add_order(create_standard_order(1, 10000, 100))
             .expect("add_order should succeed");
         price_level
-            .add_order(create_iceberg_order(2, 10000, 50, 200))
+            .add_order(create_buy_iceberg_order(2, 10000, 50, 200))
             .expect("add_order should succeed");
         price_level
             .add_order(create_post_only_order(3, 10000, 75))
             .expect("add_order should succeed");
         price_level
-            .add_order(create_reserve_order(4, 10000, 25, 100, 100, true, None))
+            .add_order(create_buy_reserve_order(4, 10000, 25, 100, 100, true, None))
             .expect("add_order should succeed");
 
         assert_eq!(price_level.visible_quantity(), 250); // 100 + 50 + 75 + 25
@@ -558,7 +628,7 @@ mod tests {
             .add_order(create_standard_order(1, 10000, 100))
             .expect("add_order should succeed");
         price_level
-            .add_order(create_iceberg_order(2, 10000, 50, 200))
+            .add_order(create_buy_iceberg_order(2, 10000, 50, 200))
             .expect("add_order should succeed");
 
         // Cancel the standard order using OrderUpdate
@@ -607,7 +677,7 @@ mod tests {
             .add_order(create_standard_order(1, 10000, 100))
             .expect("add_order should succeed");
         price_level
-            .add_order(create_iceberg_order(2, 10000, 50, 200))
+            .add_order(create_buy_iceberg_order(2, 10000, 50, 200))
             .expect("add_order should succeed");
 
         let orders = price_level.snapshot_orders();
@@ -2268,15 +2338,17 @@ mod tests {
 
     #[test]
     fn test_update_quantity_trailing_stop_decrease_keeps_position() {
+        // Buy side to match the plain maker the helper queues behind it (a level
+        // holds a single side, issue #120).
         assert_update_quantity_decrease_keeps_position(
-            create_trailing_stop_order(1, 10000, 100),
+            create_buy_trailing_stop_order(1, 10000, 100),
             40,
         );
     }
 
     #[test]
     fn test_update_quantity_trailing_stop_increase_demotes() {
-        assert_update_quantity_increase_demotes(create_trailing_stop_order(1, 10000, 100), 150);
+        assert_update_quantity_increase_demotes(create_buy_trailing_stop_order(1, 10000, 100), 150);
     }
 
     #[test]
@@ -3208,7 +3280,7 @@ mod tests {
             .add_order(create_standard_order(2, 10000, 100))
             .expect("add_order should succeed");
         price_level
-            .add_order(create_iceberg_order(3, 10000, 50, 200))
+            .add_order(create_buy_iceberg_order(3, 10000, 50, 200))
             .expect("add_order should succeed");
 
         // Decrease (in place) on a standard order.
@@ -3459,13 +3531,13 @@ mod tests {
             .add_order(create_good_till_date_order(3, 10000, 100, 1617000000000))
             .expect("add_order should succeed");
         price_level
-            .add_order(create_reserve_order(4, 10000, 100, 100, 20, true, None))
+            .add_order(create_buy_reserve_order(4, 10000, 100, 100, 20, true, None))
             .expect("add_order should succeed");
         price_level
-            .add_order(create_iceberg_order(5, 10000, 50, 100))
+            .add_order(create_buy_iceberg_order(5, 10000, 50, 100))
             .expect("add_order should succeed");
 
-        let input = "PriceLevel:price=10000;visible_quantity=375;hidden_quantity=200;order_count=5;orders=[Standard:id=00000000-0000-0001-0000-000000000000;price=10000;quantity=50;side=BUY;timestamp=1616823000000;time_in_force=GTC,Standard:id=00000000-0000-0002-0000-000000000000;price=10000;quantity=75;side=BUY;timestamp=1616823000001;time_in_force=GTC,Standard:id=00000000-0000-0003-0000-000000000000;price=10000;quantity=100;side=BUY;timestamp=1616823000002;time_in_force=GTD-1617000000000,ReserveOrder:id=00000000-0000-0004-0000-000000000000;price=10000;visible_quantity=100;hidden_quantity=100;side=SELL;timestamp=1616823000003;time_in_force=GTC;replenish_threshold=20;replenish_amount=None;auto_replenish=true,IcebergOrder:id=00000000-0000-0005-0000-000000000000;price=10000;visible_quantity=50;hidden_quantity=100;side=SELL;timestamp=1616823000004;time_in_force=GTC]";
+        let input = "PriceLevel:price=10000;visible_quantity=375;hidden_quantity=200;order_count=5;orders=[Standard:id=00000000-0000-0001-0000-000000000000;price=10000;quantity=50;side=BUY;timestamp=1616823000000;time_in_force=GTC,Standard:id=00000000-0000-0002-0000-000000000000;price=10000;quantity=75;side=BUY;timestamp=1616823000001;time_in_force=GTC,Standard:id=00000000-0000-0003-0000-000000000000;price=10000;quantity=100;side=BUY;timestamp=1616823000002;time_in_force=GTD-1617000000000,ReserveOrder:id=00000000-0000-0004-0000-000000000000;price=10000;visible_quantity=100;hidden_quantity=100;side=BUY;timestamp=1616823000003;time_in_force=GTC;replenish_threshold=20;replenish_amount=None;auto_replenish=true,IcebergOrder:id=00000000-0000-0005-0000-000000000000;price=10000;visible_quantity=50;hidden_quantity=100;side=BUY;timestamp=1616823000004;time_in_force=GTC]";
         let result = PriceLevel::from_str(input);
 
         if let Err(ref err) = result {
@@ -3661,7 +3733,7 @@ mod tests {
             .add_order(create_standard_order(1, 10000, 100))
             .expect("add_order should succeed");
         price_level
-            .add_order(create_iceberg_order(2, 10000, 50, 150))
+            .add_order(create_buy_iceberg_order(2, 10000, 50, 150))
             .expect("add_order should succeed");
 
         // Serialize to JSON
@@ -4259,7 +4331,7 @@ mod tests {
                             .expect("add_order should succeed");
                     } else {
                         level
-                            .add_order(create_iceberg_order(
+                            .add_order(create_buy_iceberg_order(
                                 id,
                                 PRICE,
                                 1 + (base % 5),
@@ -5994,7 +6066,7 @@ mod tests {
             .add_order(create_standard_order(2, 10_000, 50))
             .expect("add_order should succeed");
         level
-            .add_order(create_iceberg_order(3, 10_000, 20, 30))
+            .add_order(create_buy_iceberg_order(3, 10_000, 20, 30))
             .expect("add_order should succeed");
 
         let owned: Vec<Id> = level
@@ -6083,10 +6155,19 @@ mod tests {
             .add_order(create_standard_order(2, 10_000, 50))
             .expect("add_order should succeed");
 
-        assert_eq!(level.matchable_quantity(0), 0, "zero taker fills nothing");
-        assert_eq!(level.matchable_quantity(120), 120, "taker below depth");
+        let taker = Id::from_u64(999);
+        assert_eq!(
+            level.matchable_quantity(0, taker),
+            0,
+            "zero taker fills nothing"
+        );
+        assert_eq!(
+            level.matchable_quantity(120, taker),
+            120,
+            "taker below depth"
+        );
         // A taker above the available depth is capped at the depth.
-        let predicted = level.matchable_quantity(200);
+        let predicted = level.matchable_quantity(200, taker);
         assert_eq!(predicted, 150, "taker above depth is capped at depth");
 
         // The dry run does not mutate, so the real sweep on the same level must
@@ -6111,7 +6192,7 @@ mod tests {
         let ice = PriceLevel::new(10_000);
         ice.add_order(create_iceberg_order(1, 10_000, 10, 40))
             .expect("add_order should succeed");
-        let predicted_ice = ice.matchable_quantity(100);
+        let predicted_ice = ice.matchable_quantity(100, Id::from_u64(998));
         assert_eq!(
             predicted_ice, 50,
             "matchable_quantity reaches hidden depth via replenishment"
@@ -6433,7 +6514,9 @@ mod tests {
             ))
             .expect("reserve own total fits u64");
         level
-            .add_order(create_standard_order(2, 10_000, u64::MAX - 1))
+            // Sell to stay side-coherent with the reserve above (issue #120
+            // pins the level side to its first resting maker).
+            .add_order(create_sell_standard_order(2, 10_000, u64::MAX - 1))
             .expect("standard own total fits u64");
         assert_eq!(level.visible_quantity(), u64::MAX);
 
@@ -6643,8 +6726,8 @@ mod tests {
 
         // The same id as a DIFFERENT order variant is still a duplicate.
         let duplicates = [
-            create_iceberg_order(1, 10_000, 50, 50),
-            create_reserve_order(1, 10_000, 30, 60, 10, true, Some(20)),
+            create_buy_iceberg_order(1, 10_000, 50, 50),
+            create_buy_reserve_order(1, 10_000, 30, 60, 10, true, Some(20)),
             create_standard_order(1, 10_000, 5),
         ];
         for dup in duplicates {
@@ -6665,7 +6748,7 @@ mod tests {
 
         // A genuinely distinct id still admits fine.
         level
-            .add_order(create_iceberg_order(2, 10_000, 50, 50))
+            .add_order(create_buy_iceberg_order(2, 10_000, 50, 50))
             .expect("distinct id must admit");
         assert_eq!(level.order_count(), 2);
     }
@@ -6836,6 +6919,33 @@ mod tests {
         );
     }
 
+    // ------------------------------------------------------------------
+    // Issue #120 — admission and trade topology invariants
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_add_order_wrong_price_rejected() {
+        let level = PriceLevel::new(10_000);
+        level
+            .add_order(create_standard_order(1, 10_000, 100))
+            .expect("in-price admission must succeed");
+
+        let before = level.snapshot_to_json().expect("snapshot before");
+        // An order at a different price must be rejected, level unchanged.
+        match level.add_order(create_standard_order(2, 10_001, 50)) {
+            Err(PriceLevelError::InvalidOperation { message }) => {
+                assert!(message.contains("price"), "unexpected message: {message}");
+            }
+            other => panic!("expected wrong-price InvalidOperation, got {other:?}"),
+        }
+        assert_eq!(level.order_count(), 1);
+        assert_eq!(
+            level.snapshot_to_json().expect("snapshot after"),
+            before,
+            "a rejected wrong-price admission must leave the level unchanged"
+        );
+    }
+
     #[test]
     fn test_try_from_snapshot_propagates_duplicate_order_id() {
         // Finding 3 (PR #125): the infallible `From<&PriceLevelSnapshot>` (which
@@ -6869,6 +6979,195 @@ mod tests {
         let restored = PriceLevel::try_from(&ok_snapshot).expect("distinct ids restore");
         assert_eq!(restored.order_count(), 2);
         assert_eq!(restored.visible_quantity(), 30);
+    }
+
+    #[test]
+    fn test_add_order_mixed_side_rejected_then_readmissible_after_drain() {
+        let level = PriceLevel::new(10_000);
+        // First maker pins the level side to Buy.
+        level
+            .add_order(create_standard_order(1, 10_000, 100))
+            .expect("first (Buy) admission must succeed");
+
+        let before = level.snapshot_to_json().expect("snapshot before");
+        // A Sell maker is incompatible with the Buy level.
+        match level.add_order(create_sell_standard_order(2, 10_000, 50)) {
+            Err(PriceLevelError::InvalidOperation { message }) => {
+                assert!(message.contains("side"), "unexpected message: {message}");
+            }
+            other => panic!("expected mixed-side InvalidOperation, got {other:?}"),
+        }
+        assert_eq!(level.order_count(), 1);
+        assert_eq!(
+            level.snapshot_to_json().expect("snapshot after"),
+            before,
+            "a rejected mixed-side admission must leave the level unchanged"
+        );
+
+        // Drain the level to empty via a full match.
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let generator = UuidGenerator::new(namespace);
+        let _ = level.match_order(
+            100,
+            Id::from_u64(900),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(1_700_000_000_000),
+            &generator,
+        );
+        assert_eq!(level.order_count(), 0, "the level must be drained empty");
+
+        // A drained level accepts either side again: the opposite side now admits.
+        level
+            .add_order(create_sell_standard_order(3, 10_000, 70))
+            .expect("a drained level must re-accept the opposite side");
+        assert_eq!(level.order_count(), 1);
+    }
+
+    #[test]
+    fn test_match_order_self_trade_skipped() {
+        // Makers 1, 2, 3 rest in FIFO order; the taker shares maker 1's id.
+        let level = PriceLevel::new(10_000);
+        level
+            .add_order(create_standard_order(1, 10_000, 40))
+            .expect("maker 1 admits");
+        level
+            .add_order(create_standard_order(2, 10_000, 30))
+            .expect("maker 2 admits");
+        level
+            .add_order(create_standard_order(3, 10_000, 50))
+            .expect("maker 3 admits");
+
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let generator = UuidGenerator::new(namespace);
+        // Taker id == maker 1's id: maker 1 must be skipped, 2 and 3 consumed.
+        let result = level.match_order(
+            1_000,
+            Id::from_u64(1),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(1_700_000_000_000),
+            &generator,
+        );
+
+        // No trade names the taker as its own maker (no self-trade emitted).
+        let makers: Vec<Id> = result
+            .trades()
+            .as_vec()
+            .iter()
+            .map(|t| t.maker_order_id())
+            .collect();
+        assert!(
+            makers.iter().all(|m| *m != Id::from_u64(1)),
+            "no trade may have maker == taker; got {makers:?}"
+        );
+        // The other makers are still consumed, in FIFO order.
+        assert_eq!(makers, vec![Id::from_u64(2), Id::from_u64(3)]);
+        // MatchResult stays consistent: executed == 30 + 50 = 80.
+        assert_eq!(
+            result.executed_quantity().expect("no overflow").as_u64(),
+            80
+        );
+        // The skipped maker 1 is left resting, untouched.
+        let resting: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+        assert_eq!(resting, vec![Id::from_u64(1)]);
+    }
+
+    #[test]
+    fn test_matchable_quantity_self_trade_parity_with_fok() {
+        // Maker 1 (shares the taker id) has 40; maker 2 has 60. A taker id 1
+        // can only take maker 2's 60 (maker 1 is self-trade-skipped).
+        let level = PriceLevel::new(10_000);
+        level
+            .add_order(create_standard_order(1, 10_000, 40))
+            .expect("maker 1 admits");
+        level
+            .add_order(create_standard_order(2, 10_000, 60))
+            .expect("maker 2 admits");
+
+        // The dry run agrees: skipping the self-trade maker leaves 60.
+        assert_eq!(level.matchable_quantity(100, Id::from_u64(1)), 60);
+        assert_eq!(level.matchable_quantity(60, Id::from_u64(1)), 60);
+
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        // A FOK taker (id 1) of 100 must be KILLED: only 60 is takeable.
+        let killed = level.match_order(
+            100,
+            Id::from_u64(1),
+            TimeInForce::Fok,
+            TakerKind::Standard,
+            TimestampMs::new(1_700_000_000_000),
+            &UuidGenerator::new(namespace),
+        );
+        assert!(
+            killed.was_killed(),
+            "FOK 100 must be killed (only 60 takeable)"
+        );
+        assert_eq!(killed.trades().len(), 0);
+        assert_eq!(
+            level.order_count(),
+            2,
+            "a killed FOK leaves the queue untouched"
+        );
+
+        // A FOK taker (id 1) of 60 must FILL: exactly maker 2's 60.
+        let filled = level.match_order(
+            60,
+            Id::from_u64(1),
+            TimeInForce::Fok,
+            TakerKind::Standard,
+            TimestampMs::new(1_700_000_000_001),
+            &UuidGenerator::new(namespace),
+        );
+        assert!(filled.is_complete(), "FOK 60 must fill");
+        let makers: Vec<Id> = filled
+            .trades()
+            .as_vec()
+            .iter()
+            .map(|t| t.maker_order_id())
+            .collect();
+        assert_eq!(makers, vec![Id::from_u64(2)], "only maker 2 fills the FOK");
+    }
+
+    #[test]
+    fn test_from_snapshot_rejects_wrong_price_and_mixed_side() {
+        // Wrong price: an order whose price differs from the level's.
+        let wrong_price = crate::price_level::PriceLevelSnapshot::with_orders(
+            Price::new(10_000),
+            vec![
+                std::sync::Arc::new(create_standard_order(1, 10_000, 100)),
+                std::sync::Arc::new(create_standard_order(2, 10_001, 50)),
+            ],
+        )
+        .expect("snapshot construction succeeds");
+        assert!(
+            matches!(
+                PriceLevel::from_snapshot(wrong_price),
+                Err(PriceLevelError::InvalidOperation { .. })
+            ),
+            "from_snapshot must reject a wrong-price order"
+        );
+
+        // Mixed side: Buy and Sell orders in one snapshot.
+        let mixed_side = crate::price_level::PriceLevelSnapshot::with_orders(
+            Price::new(10_000),
+            vec![
+                std::sync::Arc::new(create_standard_order(1, 10_000, 100)),
+                std::sync::Arc::new(create_sell_standard_order(2, 10_000, 50)),
+            ],
+        )
+        .expect("snapshot construction succeeds");
+        assert!(
+            matches!(
+                PriceLevel::from_snapshot(mixed_side),
+                Err(PriceLevelError::InvalidOperation { .. })
+            ),
+            "from_snapshot must reject a mixed-side snapshot"
+        );
     }
 }
 

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -6572,6 +6572,231 @@ mod tests {
             "FIFO consumption order must be unchanged"
         );
     }
+
+    // ------------------------------------------------------------------
+    // Issue #113 — reject duplicate order IDs atomically
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_add_order_duplicate_id_rejected_sequentially() {
+        let level = PriceLevel::new(10_000);
+        let first = level
+            .add_order(create_standard_order(1, 10_000, 100))
+            .expect("first admission must succeed");
+        level
+            .add_order(create_standard_order(2, 10_000, 50))
+            .expect("second (distinct) admission must succeed");
+
+        // Snapshot the full state before the duplicate attempt.
+        let before_json = level.snapshot_to_json().expect("snapshot before");
+        let before_visible = level.visible_quantity();
+        let before_hidden = level.hidden_quantity();
+        let before_count = level.order_count();
+        let before_ids: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+
+        // Re-submit id 1 with a DIFFERENT quantity: must be rejected, never
+        // overwrite the live order.
+        match level.add_order(create_standard_order(1, 10_000, 999)) {
+            Err(PriceLevelError::DuplicateOrderId(id)) => {
+                assert_eq!(id, Id::from_u64(1).to_string())
+            }
+            other => panic!("expected DuplicateOrderId, got {other:?}"),
+        }
+
+        // Nothing changed: counters, order, FIFO order, and a byte-identical
+        // snapshot.
+        assert_eq!(level.visible_quantity(), before_visible);
+        assert_eq!(level.hidden_quantity(), before_hidden);
+        assert_eq!(level.order_count(), before_count);
+        assert_eq!(
+            level.snapshot_to_json().expect("snapshot after"),
+            before_json,
+            "a rejected duplicate must leave the snapshot byte-identical"
+        );
+        let after_ids: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+        assert_eq!(after_ids, before_ids);
+
+        // The original order 1 kept its quantity (100), not the rejected 999.
+        let order1 = level
+            .snapshot_by_insertion_seq()
+            .into_iter()
+            .find(|o| o.id() == Id::from_u64(1))
+            .expect("order 1 must still rest");
+        assert_eq!(order1.visible_quantity().as_u64(), 100);
+        assert_eq!(first.id(), Id::from_u64(1));
+    }
+
+    #[test]
+    fn test_add_order_duplicate_id_across_variants_rejected() {
+        let level = PriceLevel::new(10_000);
+        level
+            .add_order(create_standard_order(1, 10_000, 100))
+            .expect("standard admission must succeed");
+
+        // The same id as a DIFFERENT order variant is still a duplicate.
+        let duplicates = [
+            create_iceberg_order(1, 10_000, 50, 50),
+            create_reserve_order(1, 10_000, 30, 60, 10, true, Some(20)),
+            create_standard_order(1, 10_000, 5),
+        ];
+        for dup in duplicates {
+            match level.add_order(dup) {
+                Err(PriceLevelError::DuplicateOrderId(id)) => {
+                    assert_eq!(id, Id::from_u64(1).to_string())
+                }
+                other => panic!("expected DuplicateOrderId across variants, got {other:?}"),
+            }
+        }
+
+        // The original standard order 1 is intact; the level still holds one.
+        assert_eq!(level.order_count(), 1);
+        let resting = level.snapshot_by_insertion_seq();
+        assert_eq!(resting.len(), 1);
+        assert_eq!(resting[0].id(), Id::from_u64(1));
+        assert_eq!(resting[0].visible_quantity().as_u64(), 100);
+
+        // A genuinely distinct id still admits fine.
+        level
+            .add_order(create_iceberg_order(2, 10_000, 50, 50))
+            .expect("distinct id must admit");
+        assert_eq!(level.order_count(), 2);
+    }
+
+    #[test]
+    fn test_add_order_duplicate_id_concurrent_exactly_one_wins() {
+        use std::sync::{Arc as StdArc, Barrier};
+        use std::thread;
+
+        const THREADS: usize = 8;
+        const ITERATIONS: usize = 50;
+        const DUP_ID: u64 = 1;
+
+        for iter in 0..ITERATIONS {
+            let level = StdArc::new(PriceLevel::new(10_000));
+            let barrier = StdArc::new(Barrier::new(THREADS));
+
+            let handles: Vec<_> = (0..THREADS)
+                .map(|t| {
+                    let level = StdArc::clone(&level);
+                    let barrier = StdArc::clone(&barrier);
+                    thread::spawn(move || {
+                        barrier.wait();
+                        // All threads submit the SAME id with distinct sizes.
+                        level
+                            .add_order(OrderType::Standard {
+                                id: Id::from_u64(DUP_ID),
+                                price: Price::new(10_000),
+                                quantity: Quantity::new(10 + t as u64),
+                                side: Side::Buy,
+                                user_id: Hash32::zero(),
+                                timestamp: TimestampMs::new(1_600_000_000_000 + t as u64),
+                                time_in_force: TimeInForce::Gtc,
+                                extra_fields: (),
+                            })
+                            .is_ok()
+                    })
+                })
+                .collect();
+
+            let successes: usize = handles
+                .into_iter()
+                .map(|h| usize::from(h.join().expect("thread panicked")))
+                .sum();
+            assert_eq!(successes, 1, "iter {iter}: exactly one admission must win");
+
+            // The level is consistent: exactly one order, counters == queue ==
+            // snapshot, and the id-keyed map / ordered index are 1:1.
+            assert_eq!(level.order_count(), 1, "iter {iter}: order_count must be 1");
+            let ids: Vec<Id> = level
+                .snapshot_by_insertion_seq()
+                .iter()
+                .map(|o| o.id())
+                .collect();
+            assert_eq!(
+                ids,
+                vec![Id::from_u64(DUP_ID)],
+                "iter {iter}: exactly one id rests, once"
+            );
+            let snapshot = level.snapshot();
+            assert_eq!(snapshot.order_count(), 1);
+            assert_eq!(snapshot.orders().len(), 1);
+            assert_eq!(
+                level.visible_quantity(),
+                snapshot.visible_quantity().as_u64(),
+                "iter {iter}: counter must equal the snapshot aggregate"
+            );
+            assert_eq!(
+                snapshot.visible_quantity().as_u64(),
+                snapshot.orders()[0].visible_quantity().as_u64(),
+                "iter {iter}: aggregate must equal the single resting order"
+            );
+
+            // Draining consumes the single maker exactly once — proof there is
+            // no phantom second index entry pointing at the same map value.
+            let generator = UuidGenerator::new(Uuid::from_u128(0xD00D_0000 + iter as u128));
+            let result = level.match_order(
+                10_000,
+                Id::from_u64(9_999),
+                TimeInForce::Gtc,
+                TakerKind::Standard,
+                TimestampMs::new(1_700_000_000_000),
+                &generator,
+            );
+            let makers: Vec<Id> = result
+                .trades()
+                .as_vec()
+                .iter()
+                .map(|t| t.maker_order_id())
+                .collect();
+            assert_eq!(
+                makers,
+                vec![Id::from_u64(DUP_ID)],
+                "iter {iter}: the maker must be consumed exactly once"
+            );
+        }
+    }
+
+    #[test]
+    fn test_from_snapshot_rejects_duplicate_ids() {
+        // Build a snapshot whose orders vector repeats id 1.
+        let dup_a = std::sync::Arc::new(create_standard_order(1, 10_000, 100));
+        let dup_b = std::sync::Arc::new(create_standard_order(1, 10_000, 50));
+        let snapshot = crate::price_level::PriceLevelSnapshot::with_orders(
+            Price::new(10_000),
+            vec![dup_a, dup_b],
+        )
+        .expect("snapshot construction must succeed");
+
+        // Direct from_snapshot rejects deterministically — no level built.
+        match PriceLevel::from_snapshot(snapshot.clone()) {
+            Err(PriceLevelError::DuplicateOrderId(id)) => {
+                assert_eq!(id, Id::from_u64(1).to_string())
+            }
+            other => panic!("expected DuplicateOrderId from from_snapshot, got {other:?}"),
+        }
+
+        // The checksum-protected JSON path rejects too — with a DuplicateOrderId
+        // (the checksum is valid), not a ChecksumMismatch.
+        let json = PriceLevelSnapshotPackage::new(snapshot)
+            .expect("package must build")
+            .to_json()
+            .expect("package must serialize");
+        assert!(
+            matches!(
+                PriceLevel::from_snapshot_json(&json),
+                Err(PriceLevelError::DuplicateOrderId(_))
+            ),
+            "from_snapshot_json must reject a duplicate-id snapshot"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -7025,62 +7025,81 @@ mod tests {
     }
 
     #[test]
-    fn test_match_order_self_trade_skipped() {
-        // Makers 1, 2, 3 rest in FIFO order; the taker shares maker 1's id.
-        let level = PriceLevel::new(10_000);
-        level
-            .add_order(create_standard_order(1, 10_000, 40))
-            .expect("maker 1 admits");
-        level
-            .add_order(create_standard_order(2, 10_000, 30))
-            .expect("maker 2 admits");
-        level
-            .add_order(create_standard_order(3, 10_000, 50))
-            .expect("maker 3 admits");
-
+    fn test_match_order_self_match_terminal_rejected_all_tifs() {
+        // Issue #126: a self-match is TERMINAL. If the taker's own id rests at
+        // the level, the match emits NO trades and leaves the level
+        // byte-identical for EVERY TIF and kind — it does NOT walk past its own
+        // resting order to trade with the other makers (the old skip behaviour).
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
-        let generator = UuidGenerator::new(namespace);
-        // Taker id == maker 1's id: maker 1 must be skipped, 2 and 3 consumed.
-        let result = level.match_order(
-            1_000,
-            Id::from_u64(1),
-            TimeInForce::Gtc,
-            TakerKind::Standard,
-            TimestampMs::new(1_700_000_000_000),
-            &generator,
-        );
 
-        // No trade names the taker as its own maker (no self-trade emitted).
-        let makers: Vec<Id> = result
-            .trades()
-            .as_vec()
-            .iter()
-            .map(|t| t.maker_order_id())
-            .collect();
-        assert!(
-            makers.iter().all(|m| *m != Id::from_u64(1)),
-            "no trade may have maker == taker; got {makers:?}"
-        );
-        // The other makers are still consumed, in FIFO order.
-        assert_eq!(makers, vec![Id::from_u64(2), Id::from_u64(3)]);
-        // MatchResult stays consistent: executed == 30 + 50 = 80.
-        assert_eq!(
-            result.executed_quantity().expect("no overflow").as_u64(),
-            80
-        );
-        // The skipped maker 1 is left resting, untouched.
-        let resting: Vec<Id> = level
-            .snapshot_by_insertion_seq()
-            .iter()
-            .map(|o| o.id())
-            .collect();
-        assert_eq!(resting, vec![Id::from_u64(1)]);
+        // Every TIF, plus the post-only kind, must reject identically.
+        let cases: [(TimeInForce, TakerKind); 6] = [
+            (TimeInForce::Gtc, TakerKind::Standard),
+            (TimeInForce::Ioc, TakerKind::Standard),
+            (TimeInForce::Fok, TakerKind::Standard),
+            (TimeInForce::Day, TakerKind::Standard),
+            (TimeInForce::Gtc, TakerKind::PostOnly),
+            (TimeInForce::Fok, TakerKind::PostOnly),
+        ];
+
+        for (tif, kind) in cases {
+            // Makers 1, 2, 3 rest in FIFO order; the taker shares maker 1's id.
+            let level = PriceLevel::new(10_000);
+            level
+                .add_order(create_standard_order(1, 10_000, 40))
+                .expect("maker 1 admits");
+            level
+                .add_order(create_standard_order(2, 10_000, 30))
+                .expect("maker 2 admits");
+            level
+                .add_order(create_standard_order(3, 10_000, 50))
+                .expect("maker 3 admits");
+            let before = level.snapshot_by_insertion_seq();
+
+            let result = level.match_order(
+                1_000,
+                Id::from_u64(1),
+                tif,
+                kind,
+                TimestampMs::new(1_700_000_000_000),
+                &UuidGenerator::new(namespace),
+            );
+
+            // Terminal Rejected: zero trades, full remaining, nothing executed.
+            assert!(
+                result.was_rejected(),
+                "self-match must be Rejected for {tif:?}/{kind:?}"
+            );
+            assert_eq!(result.trades().len(), 0, "{tif:?}/{kind:?}: no trades");
+            assert_eq!(
+                result.remaining_quantity().as_u64(),
+                1_000,
+                "{tif:?}/{kind:?}: full remaining"
+            );
+            assert_eq!(
+                result.executed_quantity().expect("no overflow").as_u64(),
+                0,
+                "{tif:?}/{kind:?}: nothing executed"
+            );
+
+            // The level is byte-identical: all three makers still rest in order.
+            let after = level.snapshot_by_insertion_seq();
+            assert_eq!(
+                before.iter().map(|o| o.id()).collect::<Vec<_>>(),
+                after.iter().map(|o| o.id()).collect::<Vec<_>>(),
+                "{tif:?}/{kind:?}: queue unchanged"
+            );
+            assert_eq!(level.order_count(), 3, "{tif:?}/{kind:?}: count unchanged");
+            assert_counters_match_queue(&level);
+        }
     }
 
     #[test]
-    fn test_matchable_quantity_self_trade_parity_with_fok() {
-        // Maker 1 (shares the taker id) has 40; maker 2 has 60. A taker id 1
-        // can only take maker 2's 60 (maker 1 is self-trade-skipped).
+    fn test_matchable_quantity_self_skip_but_match_order_rejects_self() {
+        // Maker 1 (shares the taker id) has 40; maker 2 has 60. The dry-run
+        // helper `matchable_quantity` still skips the self-trade maker (it backs
+        // the in-sweep defense-in-depth path, where the taker's order is admitted
+        // mid-sweep), so it reports 60 takeable.
         let level = PriceLevel::new(10_000);
         level
             .add_order(create_standard_order(1, 10_000, 40))
@@ -7089,48 +7108,203 @@ mod tests {
             .add_order(create_standard_order(2, 10_000, 60))
             .expect("maker 2 admits");
 
-        // The dry run agrees: skipping the self-trade maker leaves 60.
         assert_eq!(level.matchable_quantity(100, Id::from_u64(1)), 60);
         assert_eq!(level.matchable_quantity(60, Id::from_u64(1)), 60);
 
+        // But `match_order` is TERMINAL when the taker id already rests (issue
+        // #126): it rejects up front for every TIF, dominating the FOK dry run —
+        // a self-match FOK is Rejected, NOT killed and NOT filled from maker 2.
         let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
-        // A FOK taker (id 1) of 100 must be KILLED: only 60 is takeable.
-        let killed = level.match_order(
-            100,
-            Id::from_u64(1),
-            TimeInForce::Fok,
-            TakerKind::Standard,
-            TimestampMs::new(1_700_000_000_000),
-            &UuidGenerator::new(namespace),
-        );
-        assert!(
-            killed.was_killed(),
-            "FOK 100 must be killed (only 60 takeable)"
-        );
-        assert_eq!(killed.trades().len(), 0);
-        assert_eq!(
-            level.order_count(),
-            2,
-            "a killed FOK leaves the queue untouched"
-        );
+        for qty in [100u64, 60] {
+            let result = level.match_order(
+                qty,
+                Id::from_u64(1),
+                TimeInForce::Fok,
+                TakerKind::Standard,
+                TimestampMs::new(1_700_000_000_000),
+                &UuidGenerator::new(namespace),
+            );
+            assert!(
+                result.was_rejected(),
+                "self-match FOK({qty}) is Rejected, not killed/filled"
+            );
+            assert!(!result.was_killed(), "self-match is Rejected, not Killed");
+            assert_eq!(result.trades().len(), 0, "no trades on self-match");
+            assert_eq!(result.remaining_quantity().as_u64(), qty);
+            assert_eq!(
+                level.order_count(),
+                2,
+                "a rejected self-match leaves the queue untouched"
+            );
+        }
 
-        // A FOK taker (id 1) of 60 must FILL: exactly maker 2's 60.
+        // A taker with a DISTINCT id (id 3) does take maker 1 + maker 2 normally.
         let filled = level.match_order(
-            60,
-            Id::from_u64(1),
+            100,
+            Id::from_u64(3),
             TimeInForce::Fok,
             TakerKind::Standard,
             TimestampMs::new(1_700_000_000_001),
             &UuidGenerator::new(namespace),
         );
-        assert!(filled.is_complete(), "FOK 60 must fill");
+        assert!(filled.is_complete(), "non-self FOK 100 fills 40 + 60");
         let makers: Vec<Id> = filled
             .trades()
             .as_vec()
             .iter()
             .map(|t| t.maker_order_id())
             .collect();
-        assert_eq!(makers, vec![Id::from_u64(2)], "only maker 2 fills the FOK");
+        assert_eq!(makers, vec![Id::from_u64(1), Id::from_u64(2)]);
+    }
+
+    #[test]
+    fn test_opposite_side_admissions_race_exactly_one_wins() {
+        // Issue #126 🔴: two opposite-side admissions racing into a genuinely
+        // empty level must NEVER both admit — the atomic side pin serializes
+        // them so exactly one wins and the other is rejected. Under the old
+        // derive-from-queue scheme both could observe an empty queue and admit.
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        const ITERATIONS: usize = 3_000;
+        const PRICE: u128 = 10_000;
+
+        for iter in 0..ITERATIONS {
+            let level = Arc::new(PriceLevel::new(PRICE));
+            let barrier = Arc::new(Barrier::new(2));
+            let buy_id = iter as u64 * 2 + 1;
+            let sell_id = buy_id + 1;
+
+            let buyer = {
+                let level = Arc::clone(&level);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    level.add_order(create_standard_order(buy_id, PRICE, 10))
+                })
+            };
+            let seller = {
+                let level = Arc::clone(&level);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    level.add_order(create_sell_standard_order(sell_id, PRICE, 10))
+                })
+            };
+
+            let buy_res = buyer.join().expect("buyer thread panicked");
+            let sell_res = seller.join().expect("seller thread panicked");
+
+            // Exactly one admission wins.
+            let admitted = usize::from(buy_res.is_ok()) + usize::from(sell_res.is_ok());
+            assert_eq!(
+                admitted,
+                1,
+                "iter {iter}: exactly one opposite-side admission may win (buy_ok={}, sell_ok={})",
+                buy_res.is_ok(),
+                sell_res.is_ok()
+            );
+            // The loser is rejected with an incompatible-side error.
+            if let Err(err) = &buy_res {
+                assert!(matches!(err, PriceLevelError::InvalidOperation { .. }));
+            }
+            if let Err(err) = &sell_res {
+                assert!(matches!(err, PriceLevelError::InvalidOperation { .. }));
+            }
+
+            // The level holds exactly one order; snapshot is single-side; the
+            // advisory counters agree with the queue.
+            assert_eq!(level.order_count(), 1, "iter {iter}");
+            let snap = level.snapshot();
+            assert_eq!(snap.orders().len(), 1, "iter {iter}");
+            assert_counters_match_queue(&level);
+
+            // A drained level re-accepts EITHER side (the pin un-pinned on drain).
+            let winner_id = if buy_res.is_ok() { buy_id } else { sell_id };
+            level
+                .update_order(OrderUpdate::Cancel {
+                    order_id: Id::from_u64(winner_id),
+                })
+                .expect("cancel winner")
+                .expect("winner was resting");
+            assert_eq!(level.order_count(), 0, "iter {iter}: drained");
+            // Whichever side lost the race can now be admitted into the empty level.
+            let readmit = if buy_res.is_ok() {
+                level.add_order(create_sell_standard_order(sell_id, PRICE, 7))
+            } else {
+                level.add_order(create_standard_order(buy_id, PRICE, 7))
+            };
+            assert!(
+                readmit.is_ok(),
+                "iter {iter}: a drained level must re-accept the opposite side"
+            );
+        }
+    }
+
+    #[test]
+    fn test_snapshot_never_captures_torn_side_under_flips() {
+        // Issue #126 🔴: a snapshot walk that spans a drain-then-re-admit to the
+        // opposite side must never capture a torn old-side/new-side view (which
+        // `from_snapshot` would reject for mixed sides). The topology epoch makes
+        // `snapshot` retry across such a transition; here a flipper thread churns
+        // the level Buy-batch -> drained -> Sell-batch -> drained while the main
+        // thread takes many snapshots and asserts each is single-side.
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::thread;
+
+        const PRICE: u128 = 10_000;
+        const BATCH: u64 = 8;
+
+        let level = Arc::new(PriceLevel::new(PRICE));
+        let done = Arc::new(AtomicBool::new(false));
+
+        let flipper = {
+            let level = Arc::clone(&level);
+            let done = Arc::clone(&done);
+            thread::spawn(move || {
+                let mut round = 0u64;
+                while !done.load(Ordering::Relaxed) {
+                    let buy = round.is_multiple_of(2);
+                    let base = 1_000 + round * BATCH;
+                    for i in 0..BATCH {
+                        let id = base + i;
+                        let order = if buy {
+                            create_standard_order(id, PRICE, 5)
+                        } else {
+                            create_sell_standard_order(id, PRICE, 5)
+                        };
+                        // May transiently fail if the opposite side is still
+                        // draining; that is fine, we just churn the topology.
+                        let _ = level.add_order(order);
+                    }
+                    for i in 0..BATCH {
+                        let _ = level.update_order(OrderUpdate::Cancel {
+                            order_id: Id::from_u64(base + i),
+                        });
+                    }
+                    round += 1;
+                }
+            })
+        };
+
+        for _ in 0..50_000 {
+            let snap = level.snapshot();
+            let mut side = None;
+            for order in snap.orders() {
+                match side {
+                    None => side = Some(order.side()),
+                    Some(s) => assert_eq!(
+                        s,
+                        order.side(),
+                        "snapshot captured a torn mixed-side view (issue #126)"
+                    ),
+                }
+            }
+        }
+
+        done.store(true, Ordering::Relaxed);
+        flipper.join().expect("flipper thread panicked");
     }
 
     #[test]

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -253,7 +253,7 @@ mod tests {
             .expect("add_order should succeed");
 
         let snapshot = price_level.snapshot();
-        let restored = PriceLevel::from(&snapshot);
+        let restored = PriceLevel::try_from(&snapshot).expect("valid snapshot restores");
 
         let original_orders = price_level.snapshot_orders();
         let restored_orders = restored.snapshot_orders();
@@ -6796,6 +6796,79 @@ mod tests {
             ),
             "from_snapshot_json must reject a duplicate-id snapshot"
         );
+    }
+
+    #[test]
+    fn test_add_order_duplicate_id_at_counter_capacity_returns_duplicate() {
+        // Finding 2 (PR #125): admission decides id IDENTITY before reserving
+        // any counter, so a duplicate id submitted when the level's visible
+        // counter is already at u64::MAX reports DuplicateOrderId — NOT a
+        // spurious visible-overflow InvalidOperation — and leaves every counter
+        // byte-identical (no transient inflation an overflow-first order would
+        // cause).
+        let level = PriceLevel::new(10_000);
+        level
+            .add_order(create_standard_order(1, 10_000, u64::MAX))
+            .expect("first admission fills the visible counter to u64::MAX");
+        assert_eq!(level.visible_quantity(), u64::MAX);
+
+        let before_json = level.snapshot_to_json().expect("snapshot before");
+
+        // Re-submit id 1 with a positive quantity: reserving it WOULD overflow
+        // the visible counter, but the duplicate id takes precedence.
+        match level.add_order(create_standard_order(1, 10_000, 100)) {
+            Err(PriceLevelError::DuplicateOrderId(id)) => {
+                assert_eq!(id, Id::from_u64(1).to_string());
+            }
+            other => {
+                panic!("expected DuplicateOrderId (identity before counters), got {other:?}")
+            }
+        }
+
+        // Byte-identical: counters, count, and snapshot unchanged.
+        assert_eq!(level.visible_quantity(), u64::MAX);
+        assert_eq!(level.hidden_quantity(), 0);
+        assert_eq!(level.order_count(), 1);
+        assert_eq!(
+            level.snapshot_to_json().expect("snapshot after"),
+            before_json,
+            "a duplicate at counter capacity must leave the level byte-identical"
+        );
+    }
+
+    #[test]
+    fn test_try_from_snapshot_propagates_duplicate_order_id() {
+        // Finding 3 (PR #125): the infallible `From<&PriceLevelSnapshot>` (which
+        // silently kept-first on a duplicate id while restoring counters over
+        // every copy) is replaced by `TryFrom`, which delegates to
+        // `from_snapshot` and propagates DuplicateOrderId.
+        let dup_a = std::sync::Arc::new(create_standard_order(7, 10_000, 100));
+        let dup_b = std::sync::Arc::new(create_standard_order(7, 10_000, 50));
+        let snapshot = crate::price_level::PriceLevelSnapshot::with_orders(
+            Price::new(10_000),
+            vec![dup_a, dup_b],
+        )
+        .expect("snapshot construction must succeed");
+
+        match PriceLevel::try_from(&snapshot) {
+            Err(PriceLevelError::DuplicateOrderId(id)) => {
+                assert_eq!(id, Id::from_u64(7).to_string());
+            }
+            other => panic!("expected DuplicateOrderId from TryFrom<&Snapshot>, got {other:?}"),
+        }
+
+        // A duplicate-free snapshot restores successfully through TryFrom.
+        let ok_snapshot = crate::price_level::PriceLevelSnapshot::with_orders(
+            Price::new(10_000),
+            vec![
+                std::sync::Arc::new(create_standard_order(1, 10_000, 10)),
+                std::sync::Arc::new(create_standard_order(2, 10_000, 20)),
+            ],
+        )
+        .expect("snapshot construction must succeed");
+        let restored = PriceLevel::try_from(&ok_snapshot).expect("distinct ids restore");
+        assert_eq!(restored.order_count(), 2);
+        assert_eq!(restored.visible_quantity(), 30);
     }
 }
 

--- a/src/price_level/tests/order_queue.rs
+++ b/src/price_level/tests/order_queue.rs
@@ -543,4 +543,71 @@ mod tests {
         }
         assert!(queue.pop().is_none());
     }
+
+    #[test]
+    fn test_concurrent_try_push_cancel_readmit_keeps_map_index_one_to_one() {
+        // Finding 1 (PR #125): `try_push` published the map entry, released the
+        // shard lock, then inserted the index entry. A concurrent cancel +
+        // same-id readmission landing in that window could leave two index
+        // entries for one id (a FIFO jump). `try_push_with` now holds the shard
+        // lock across BOTH publications, so the map and the index stay strictly
+        // 1:1 under an admit / cancel / readmit storm on a tiny, heavily-reused
+        // id set. Assert that invariant at quiescence over many iterations.
+        use std::sync::{Arc as StdArc, Barrier};
+        use std::thread;
+
+        const THREADS: usize = 6;
+        const OPS: usize = 300;
+        const IDS: u64 = 4;
+
+        for iter in 0..40 {
+            let queue = StdArc::new(OrderQueue::new());
+            let barrier = StdArc::new(Barrier::new(THREADS));
+
+            let handles: Vec<_> = (0..THREADS)
+                .map(|t| {
+                    let queue = StdArc::clone(&queue);
+                    let barrier = StdArc::clone(&barrier);
+                    thread::spawn(move || {
+                        barrier.wait();
+                        for op in 0..OPS {
+                            // A tiny id set shared across threads maximizes the
+                            // chance an admission of `id` races a cancel of the
+                            // same `id`.
+                            let id = ((op as u64).wrapping_add(t as u64) % IDS) + 1;
+                            let order = StdArc::new(create_test_order(id, 1_000, 10));
+                            let _ = queue.try_push(order);
+                            let _ = queue.remove(Id::from_u64(id));
+                            let _ = queue.try_push(StdArc::new(create_test_order(id, 1_000, 10)));
+                        }
+                    })
+                })
+                .collect();
+            for h in handles {
+                h.join().expect("thread panicked");
+            }
+
+            // Quiescent: every started operation has completed, so the map and
+            // the ordered index must be exactly 1:1. A split index entry from
+            // the old publication race would make the index longer than the map.
+            assert!(
+                queue.debug_map_index_consistent(),
+                "iter {iter}: id-keyed map and ordered index must be 1:1"
+            );
+
+            // Draining pops each resting id exactly once: a phantom second index
+            // entry would resurface an id or desync the count.
+            let mut popped: Vec<Id> = Vec::new();
+            while let Some(order) = queue.pop() {
+                popped.push(order.id());
+            }
+            let unique: std::collections::HashSet<Id> = popped.iter().copied().collect();
+            assert_eq!(
+                popped.len(),
+                unique.len(),
+                "iter {iter}: every id must be popped at most once"
+            );
+            assert!(queue.is_empty(), "iter {iter}: queue must fully drain");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`add_order` accepted any order regardless of price or side: a wrong-price
maker traded at the level price instead of its own, mixed maker sides produced
contradictory taker sides inside one `MatchResult`, and the maker ≠ taker
guard was debug-only — release builds could emit self-trades. Admission now
enforces topology before touching state, and self-trades are structurally
impossible in every build profile.

## Stack

- **Stack:** #118 → #114 → #116 → #111 → #113 → #120 → #119 → #115 → #117 → #112 (**this is 6/10**)
- **Base branch:** `stack/5-113-duplicate-ids`
- **Stacked on:** #125 — **the diff vs `main` is cumulative**; review against the base branch.

## Changes

- Admission validates `order.price == level.price` and side coherence before
  any counter reservation; rejections leave the level byte-identical.
- Level side is **derived from the resting orders** (first maker pins it; a
  drained level accepts either side again). Documented honestly as a
  correctness invariant on single-logical-writer admission, including both
  residual race windows (empty-level admission race; upsize remove+push
  transient — the latter closed by #119 next in this stack).
- Self-trade policy: a front maker whose id equals the taker id is parked like
  a set-aside maker — no trade, no counter movement, FIFO preserved for the
  rest. Scoped explicitly as order-id identity (an order never matches
  itself); account-level STP via `user_id` stays the composing book's job.
- **BREAKING:** `matchable_quantity(quantity, taker_id)` — the FOK dry run
  applies the identical skip, so dry run and sweep cannot diverge (migration
  guide + README updated).
- `from_snapshot` validates the same topology; `From<&PriceLevelSnapshot>`
  documented as the trusted-input path that skips validation.

## Technical decisions

- Reviewed by `architect` (PASS), `microstructure-critic` (SKIP policy and
  derive-from-queue contract judged defensible — skip is the only
  policy-neutral action a building block can take; cancel-newest/oldest are
  book-level responsibilities), and `concurrency-auditor` (commit safe; skip
  is allocation-free, terminates, and cannot loop).
- The critic's suggested `AtomicSide` CAS pin (closes the empty-level race) is
  deliberately deferred to a follow-up issue rather than widening this PR.
- `InvalidOperation` reused for price/side rejections (consistent with the
  admission-overflow errors); dedicated variants can follow if downstream
  needs to branch on the reason.

## Public API impact

- `matchable_quantity` signature change (breaking) — migration guide +
  README regenerated. No new pub items.

## Testing

- [x] Wrong-price and mixed-side admissions rejected with byte-identical
  level state; opposite side admissible again after a full drain
- [x] Self-trade skip: maker left resting, others consumed in FIFO,
  `MatchResult` consistent; FOK dry-run parity case (kill vs fill)
- [x] Snapshot restore rejects wrong-price / mixed-side orders
- [x] 14 existing tests made side-coherent (they mixed sides only via helper
  defaults — the exact bug this issue forbids); no assertion weakened
  (architect spot-checked)
- [x] Pre-push checks + full examples suite clean locally

481 tests passed; 0 failed (462 lib + 9 + 1 + 9 doctests).

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] No new production `unsafe`, no new dependencies
- [x] Self-trade skip allocation-free on the match path (auditor-verified)
- [x] Migration guide + README updated

Closes #120


- **Blocks:** #127
