### PR TITLE
Make execution-statistics failures non-partial and observable (#117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,23 @@ checksum error). Re-take any persisted snapshots with this release. No code
 changes are required at the call sites: `snapshot_to_json()` /
 `from_snapshot_json()` keep the same signatures.
 
+### Migration Guide (snapshot format v2 → v3)
+
+`SNAPSHOT_FORMAT_VERSION` is bumped from `2` to `3` (issue #129). Version 3
+owns the optional 9th statistics field, `stats_degraded` (issue #117): a
+**degraded** level — one where an execution's statistics contribution was
+dropped all-or-nothing — serializes that field, and such a payload is now a
+v3 package rather than a v2 package mislabelled with an extra field an old
+8-field-only reader would reject.
+
+Restore is **backward compatible**: [`PriceLevelSnapshotPackage::validate`]
+accepts **both** v2 (legacy, 8-field statistics, `stats_degraded` defaults
+`false`) and v3, so snapshots written by the previous release keep restoring
+unchanged; only v1 is still rejected. Checksum recomputation is
+version-agnostic — a non-degraded level serializes the same 8 fields under
+either version, so a legacy v2 package's SHA-256 still matches. New snapshots
+are written at v3. No code changes are required at the call sites.
+
 ### Migration Guide (`Trade::total_value` is now checked)
 
 [`Trade::total_value`](crate::execution::Trade::total_value) now returns

--- a/examples/src/bin/integration_snapshot_recovery.rs
+++ b/examples/src/bin/integration_snapshot_recovery.rs
@@ -86,8 +86,9 @@ fn main() {
         .snapshot_package()
         .unwrap_or_else(|e| exit_err(&format!("snapshot_package: {e}")));
 
-    // Snapshot format v2 (statistics persisted, issue #63).
-    assert_eq_or_exit(package.version(), 2, "snapshot version");
+    // Snapshot format v3 (statistics persisted since v2/#63; v3 owns the
+    // optional `stats_degraded` field, issue #129).
+    assert_eq_or_exit(package.version(), 3, "snapshot version");
     assert_or_exit(
         !package.checksum().is_empty(),
         "checksum should not be empty",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,6 +444,23 @@
 //! changes are required at the call sites: `snapshot_to_json()` /
 //! `from_snapshot_json()` keep the same signatures.
 //!
+//! ## Migration Guide (snapshot format v2 → v3)
+//!
+//! `SNAPSHOT_FORMAT_VERSION` is bumped from `2` to `3` (issue #129). Version 3
+//! owns the optional 9th statistics field, `stats_degraded` (issue #117): a
+//! **degraded** level — one where an execution's statistics contribution was
+//! dropped all-or-nothing — serializes that field, and such a payload is now a
+//! v3 package rather than a v2 package mislabelled with an extra field an old
+//! 8-field-only reader would reject.
+//!
+//! Restore is **backward compatible**: [`PriceLevelSnapshotPackage::validate`]
+//! accepts **both** v2 (legacy, 8-field statistics, `stats_degraded` defaults
+//! `false`) and v3, so snapshots written by the previous release keep restoring
+//! unchanged; only v1 is still rejected. Checksum recomputation is
+//! version-agnostic — a non-degraded level serializes the same 8 fields under
+//! either version, so a legacy v2 package's SHA-256 still matches. New snapshots
+//! are written at v3. No code changes are required at the call sites.
+//!
 //! ## Migration Guide (`Trade::total_value` is now checked)
 //!
 //! [`Trade::total_value`](crate::execution::Trade::total_value) now returns

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -1088,6 +1088,11 @@ impl PriceLevel {
             hidden_stranded: u64,
             /// The taker's remaining quantity after this maker is matched.
             new_remaining: u64,
+            /// `true` when this step's level-counter deltas were already applied
+            /// INSIDE the locked decision closure (the replenish path, issue
+            /// #128). The post-lock body then skips re-applying them so the
+            /// counters move exactly once.
+            counters_committed: bool,
         }
 
         // Either the maker progressed (carrying `StepData`), was parked
@@ -1195,58 +1200,70 @@ impl PriceLevel {
                     0
                 };
 
-                let data = StepData {
-                    consumed,
-                    hidden_reduced,
-                    fully_consumed: updated_order.is_none(),
-                    maker_id,
-                    maker_side,
-                    maker_price,
-                    maker_timestamp,
-                    hidden_stranded,
-                    new_remaining,
-                };
+                let fully_consumed = updated_order.is_none();
 
+                // Compute the action. For a replenishment, PUBLISH this step's
+                // level-counter transition HERE — under the maker's entry lock,
+                // before returning the action (issue #128) — so a concurrent
+                // `UpdateQuantity` that next locks this same entry observes the
+                // level counters already consistent with the replenished queue.
+                // Applying it only after the entry released would leave the
+                // counter transiently BELOW the queue's visible sum, and the
+                // update's `old -> new` decrease could then underflow (`0 - 100`
+                // wrap). `counters_committed` tells the post-lock body to skip
+                // re-applying this step's deltas so the counters move exactly once.
+                let mut counters_committed = false;
                 let action = match updated_order {
                     None => FrontAction::Remove,
                     Some(updated) => {
                         if hidden_reduced > 0 {
-                            // Replenishment: a fresh tranche moves from hidden
-                            // into visible, so the level's visible counter takes
-                            // the net delta `hidden_reduced - consumed` (the
-                            // `fetch_sub(consumed)` + `fetch_add(hidden_reduced)`
-                            // applied after this closure returns). Even when every
-                            // resting order's own total fits `u64`, the level's
-                            // visible SUM can exceed `u64::MAX` once hidden depth
-                            // is converted to visible — a state the counter (and
-                            // the true queue visible sum) cannot represent.
-                            //
-                            // Pre-validate that net delta against the LIVE visible
-                            // counter with checked arithmetic BEFORE committing:
-                            // read the counter (the same reserve-before-commit
-                            // pattern used under the entry lock), and if
-                            // `current - consumed + hidden_reduced` would not fit
-                            // `u64`, ABORT. The abort leaves the maker
-                            // byte-identical (`SetAside` mutates nothing), emits
-                            // no trade, and terminates the sweep, so no younger
-                            // maker trades past this FIFO front and the counter
-                            // never wraps. The stuck depth is unreachable until a
-                            // cancel / downsize frees headroom.
-                            let current_visible = self.visible_quantity.load(Ordering::Relaxed);
-                            let fits = current_visible
-                                .checked_sub(consumed)
-                                .and_then(|v| v.checked_add(hidden_reduced))
-                                .is_some();
-                            if !fits {
+                            // Replenishment: a fresh tranche moves hidden ->
+                            // visible. Apply the visible NET delta
+                            // (`- consumed + hidden_reduced`) as ONE checked RMW
+                            // plus the hidden decrement, atomically visible before
+                            // the entry lock releases. The checked `fetch_update`
+                            // supersedes the old load-only `fits` pre-check: even
+                            // when every resting order's own total fits `u64`, the
+                            // level's visible SUM can exceed `u64::MAX` once hidden
+                            // depth converts to visible, so a net delta that would
+                            // overflow ABORTS the step (`SetAside` mutates nothing,
+                            // emits no trade, ends the sweep) — no younger maker
+                            // trades past this FIFO front and the counter never
+                            // wraps. The stuck depth is unreachable until a cancel
+                            // / downsize frees headroom.
+                            let net_ok = self
+                                .visible_quantity
+                                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
+                                    c.checked_sub(consumed)
+                                        .and_then(|v| v.checked_add(hidden_reduced))
+                                })
+                                .is_ok();
+                            if !net_ok {
                                 return (FrontAction::SetAside, StepResult::Abort { maker_id });
                             }
-                            // Replenishment: refreshed tranche loses priority.
+                            self.hidden_quantity
+                                .fetch_sub(hidden_reduced, Ordering::Relaxed);
+                            counters_committed = true;
+                            // Refreshed tranche loses priority.
                             FrontAction::ReplaceAtTail(Arc::new(updated))
                         } else {
                             // Pure partial fill: keep priority in place.
                             FrontAction::KeepInPlace(Arc::new(updated))
                         }
                     }
+                };
+
+                let data = StepData {
+                    consumed,
+                    hidden_reduced,
+                    fully_consumed,
+                    maker_id,
+                    maker_side,
+                    maker_price,
+                    maker_timestamp,
+                    hidden_stranded,
+                    new_remaining,
+                    counters_committed,
                 };
 
                 (action, StepResult::Progressed(data))
@@ -1314,8 +1331,13 @@ impl PriceLevel {
                         // not this RMW. The delta is keyed off the committed
                         // action so it never double-counts with a concurrent
                         // cancel (which decrements only the residual it removes).
-                        self.visible_quantity
-                            .fetch_sub(data.consumed, Ordering::Relaxed);
+                        // Skipped for a replenish step: its visible net delta
+                        // (already including `- consumed`) was applied under the
+                        // entry lock in the decision closure (issue #128).
+                        if !data.counters_committed {
+                            self.visible_quantity
+                                .fetch_sub(data.consumed, Ordering::Relaxed);
+                        }
 
                         let trade_id = Id::from_uuid(trade_id_generator.next());
 
@@ -1364,10 +1386,14 @@ impl PriceLevel {
                             self.hidden_quantity
                                 .fetch_sub(data.hidden_stranded, Ordering::Relaxed);
                         }
-                    } else if data.hidden_reduced > 0 {
+                    } else if data.hidden_reduced > 0 && !data.counters_committed {
                         // Replenishment: a fresh tranche moved from hidden into
                         // visible. The maker stayed resident (re-sequenced in
                         // place by `match_front`), so only the counters move.
+                        // As of issue #128 the replenish path commits this
+                        // transition under the entry lock (`counters_committed`),
+                        // so this post-lock branch is now unreachable for it and
+                        // kept only as a defensive no-op.
                         self.hidden_quantity
                             .fetch_sub(data.hidden_reduced, Ordering::Relaxed);
                         self.visible_quantity
@@ -1605,28 +1631,42 @@ impl PriceLevel {
                 new_quantity,
             } => {
                 // Overflow-checked forward reservation of a level counter for a
-                // component moving `old -> new`. Increase is validated with
-                // `checked_add` (rejecting before any queue mutation); decrease
-                // simply subtracts. `Relaxed`: advisory counters (issue #68).
+                // component moving `old -> new`. BOTH directions use a checked
+                // `fetch_update` and reject before any queue mutation: an
+                // increase must not overflow `u64`, and a decrease must not
+                // underflow it (issue #128 defense). `Relaxed`: advisory counters
+                // (issue #68).
+                //
+                // The underflow guard is a belt-and-suspenders backstop. It is
+                // unreachable in practice because issue #128's structural fix
+                // publishes the match sweep's replenish counter transition UNDER
+                // the maker's entry lock: by the time this `UpdateQuantity` holds
+                // that same entry lock and reads `old` from the live maker, the
+                // level counter already includes this maker's full `old`
+                // contribution, so `counter >= old >= old - new` and the subtract
+                // cannot go negative. The check simply refuses to wrap if that
+                // invariant were ever violated, leaving the level untouched.
                 fn reserve(
                     counter: &std::sync::atomic::AtomicU64,
                     old: u64,
                     new: u64,
                 ) -> Result<(), PriceLevelError> {
-                    if new >= old {
-                        counter
-                            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
-                                c.checked_add(new - old)
-                            })
-                            .map(|_| ())
-                            .map_err(|_| PriceLevelError::InvalidOperation {
-                                message: "price level quantity counter overflow on update"
-                                    .to_string(),
-                            })
+                    let result = if new >= old {
+                        let delta = new - old;
+                        counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
+                            c.checked_add(delta)
+                        })
                     } else {
-                        counter.fetch_sub(old - new, Ordering::Relaxed);
-                        Ok(())
-                    }
+                        let delta = old - new;
+                        counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
+                            c.checked_sub(delta)
+                        })
+                    };
+                    result
+                        .map(|_| ())
+                        .map_err(|_| PriceLevelError::InvalidOperation {
+                            message: "price level quantity counter overflow on update".to_string(),
+                        })
                 }
                 // Undo this call's own `old -> new` reservation (commutative with
                 // concurrent deltas — it reverses exactly what it added).

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -957,6 +957,18 @@ impl PriceLevel {
     /// admissions arrive from one logical path (see the type-level note on
     /// [`PriceLevel`]), because the side is derived from the live queue rather
     /// than stored.
+    ///
+    /// # Statistics
+    ///
+    /// Per-level execution statistics are recorded **all-or-nothing** and can
+    /// never fail the match: the trade is already committed when
+    /// `PriceLevelStatistics::record_execution` runs. If recording overflows a
+    /// statistics counter, that execution's contribution is dropped atomically
+    /// (it advances every aggregate or none), the drop is logged at `WARN` (a
+    /// recoverable anomaly, not an aborted match), and the level's
+    /// `PriceLevelStatistics::stats_degraded` flag is set (sticky,
+    /// snapshot-persisted) so the under-count is observable. The emitted trades
+    /// and the `MatchResult` are unaffected (issue #117).
     pub fn match_order(
         &self,
         incoming_quantity: u64,
@@ -1365,12 +1377,33 @@ impl PriceLevel {
                             result.add_filled_order_id(data.maker_id);
                         }
 
-                        let _ = self.stats.record_execution(
+                        // The trade is already committed (added to `result` and
+                        // the queue mutated) — statistics recording cannot fail
+                        // it retroactively. Recording is all-or-nothing (issue
+                        // #117): on overflow the execution's contribution is
+                        // dropped atomically and a sticky `stats_degraded` flag
+                        // is set on the level's statistics (observable via
+                        // `PriceLevelStatistics::stats_degraded`), leaving the
+                        // trade stream unaffected. Log the drop rather than
+                        // discard it silently.
+                        if let Err(err) = self.stats.record_execution(
                             data.consumed,
                             data.maker_price,
                             data.maker_timestamp,
                             timestamp.as_u64(),
-                        );
+                        ) {
+                            // WARN, not ERROR: the match is not aborted — this is
+                            // a recoverable observability anomaly flagged by the
+                            // sticky degraded flag (the trade is committed).
+                            tracing::warn!(
+                                price = self.price,
+                                taker_order_id = %taker_order_id,
+                                maker_order_id = %data.maker_id,
+                                consumed = data.consumed,
+                                error = %err,
+                                "execution statistics dropped (all-or-nothing); level stats marked degraded — trade unaffected"
+                            );
+                        }
                     }
 
                     remaining = new_remaining;

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -4,7 +4,7 @@ use crate::UuidGenerator;
 use crate::errors::PriceLevelError;
 use crate::execution::{MatchResult, TakerKind, Trade};
 use crate::orders::{Id, OrderType, OrderUpdate, Side, TimeInForce};
-use crate::price_level::order_queue::{FrontAction, FrontOutcome, OrderQueue};
+use crate::price_level::order_queue::{FrontAction, FrontOutcome, OrderQueue, UpdateDecision};
 use crate::price_level::{PriceLevelSnapshot, PriceLevelSnapshotPackage, PriceLevelStatistics};
 use crate::utils::{Price, Quantity, TimestampMs};
 use serde::{Deserialize, Serialize};
@@ -1532,14 +1532,27 @@ impl PriceLevel {
     /// visible tranche and keep hidden), so the branch reflects the real size
     /// change rather than a silent no-op.
     ///
+    /// # Applied to the live maker (issue #115)
+    ///
+    /// The resize, the priority decision, and the level-counter update are all
+    /// derived from the order **currently resident in the queue**, computed and
+    /// committed together under a single per-entry lock — never from a pre-read.
+    /// A concurrent match or replenishment that commits first is therefore fully
+    /// reflected: an update applies `new_quantity` to the *live* visible tranche
+    /// and preserves the *live* hidden depth, so it can never resurrect executed
+    /// or cancelled quantity, and the increase-vs-decrease policy is chosen from
+    /// the live total (never stale). The level counters are validated with
+    /// checked math before the queue mutates, so an update that would overflow a
+    /// level counter is rejected with the level left unchanged.
+    ///
     /// # Errors
     ///
     /// Returns [`PriceLevelError::InvalidOperation`] if an
     /// [`OrderUpdate::UpdatePrice`] / [`OrderUpdate::Replace`] would not move
     /// the order to a different price level, if computing an order's total
-    /// quantity overflows `u64`, or if applying a quantity update's counter
-    /// delta would take the level's visible- or hidden-quantity counter past
-    /// `u64::MAX` (rejected with the queue and counters untouched).
+    /// quantity overflows `u64`, or if an [`OrderUpdate::UpdateQuantity`] would
+    /// overflow the level's visible- or hidden-quantity counter (the maker and
+    /// its queue position are left unchanged in that case).
     #[must_use = "the updated order (or None when the order is absent) must be handled"]
     pub fn update_order(
         &self,
@@ -1591,126 +1604,96 @@ impl PriceLevel {
                 order_id,
                 new_quantity,
             } => {
-                // Read the current order to build the resized order and pick the
-                // priority policy. The counter deltas below are taken from the
-                // order actually removed/replaced under the queue's per-entry
-                // lock — not from this pre-read — so a concurrent update cannot
-                // drift `visible_quantity` / `hidden_quantity` from the queue.
-                let Some(order) = self.orders.find(order_id) else {
-                    return Ok(None); // Order not found
-                };
-
-                let prev_total = order
-                    .visible_quantity()
-                    .as_u64()
-                    .checked_add(order.hidden_quantity().as_u64())
-                    .ok_or_else(|| PriceLevelError::InvalidOperation {
-                        message: "order total quantity overflow".to_string(),
-                    })?;
-
-                // Build the updated order. `with_reduced_quantity` sets the
-                // (visible/main) quantity to exactly `new_quantity` for every
-                // order variant, so `new_total` reflects the real post-update
-                // size and the increase/decrease branch below is chosen
-                // correctly for all types.
-                let new_order = order.with_reduced_quantity(new_quantity.as_u64());
-                let new_visible = new_order.visible_quantity().as_u64();
-                let new_hidden = new_order.hidden_quantity().as_u64();
-                let new_total = new_visible.checked_add(new_hidden).ok_or_else(|| {
-                    PriceLevelError::InvalidOperation {
-                        message: "order total quantity overflow".to_string(),
-                    }
-                })?;
-
-                // Pre-validate the LEVEL counter deltas before mutating the
-                // queue: an upsize (or a visible/hidden reshuffle) whose delta
-                // would take a level counter past `u64::MAX` must be rejected
-                // with the queue and counters untouched, never committed and then
-                // wrapped by the raw `fetch_add` below. Project each counter from
-                // its live value using the pre-read order's components as `old`;
-                // if either projection does not fit `u64`, reject.
-                //
-                // This uses the pre-read `order` (not the value the queue mutation
-                // will actually replace), so a concurrent update of the same id
-                // could make the projection stale (TOCTOU) — strictly better than
-                // the unchecked wrap it replaces, and #115 closes the window
-                // exactly by reserving under the entry lock.
-                let old_visible_pre = order.visible_quantity().as_u64();
-                let old_hidden_pre = order.hidden_quantity().as_u64();
-                let projects = |counter: &AtomicU64, old: u64, new: u64| -> bool {
-                    let cur = counter.load(Ordering::Relaxed);
+                // Overflow-checked forward reservation of a level counter for a
+                // component moving `old -> new`. Increase is validated with
+                // `checked_add` (rejecting before any queue mutation); decrease
+                // simply subtracts. `Relaxed`: advisory counters (issue #68).
+                fn reserve(
+                    counter: &std::sync::atomic::AtomicU64,
+                    old: u64,
+                    new: u64,
+                ) -> Result<(), PriceLevelError> {
                     if new >= old {
-                        cur.checked_add(new - old).is_some()
-                    } else {
-                        cur.checked_sub(old - new).is_some()
-                    }
-                };
-                if !projects(&self.visible_quantity, old_visible_pre, new_visible)
-                    || !projects(&self.hidden_quantity, old_hidden_pre, new_hidden)
-                {
-                    return Err(PriceLevelError::InvalidOperation {
-                        message: "price level quantity counter overflow on update".to_string(),
-                    });
-                }
-
-                let new_order_arc = Arc::new(new_order);
-
-                // Perform the queue mutation and capture the order it actually
-                // removed/replaced, so the counter deltas reflect the real
-                // transition rather than the possibly-stale pre-read above.
-                let old = if new_total > prev_total {
-                    // Quantity INCREASE: demote to the back of the queue (a fresh
-                    // tail sequence), losing time priority. Uses the atomic
-                    // `resequence_to_tail` primitive (issue #119): the id stays
-                    // resident in the MAP throughout — no absent window — so a
-                    // concurrent cancel cannot be lost, a same-id admission is
-                    // always rejected, and match-front can no longer act on a
-                    // stale front position. (The INDEX is still re-keyed in two
-                    // steps, so one match scan may transiently miss the maker —
-                    // a missed fill at worst, strictly narrower than the old
-                    // remove+push absence.) Returns the replaced order (for the
-                    // counter deltas below) or `None` if concurrently removed.
-                    let Some(replaced) = self
-                        .orders
-                        .resequence_to_tail(order_id, new_order_arc.clone())
-                    else {
-                        return Ok(None); // Removed by another thread.
-                    };
-                    replaced
-                } else {
-                    // Quantity DECREASE or unchanged total: keep the maker's
-                    // queue position by swapping the stored order in place at its
-                    // existing insertion sequence, under the DashMap per-entry
-                    // lock.
-                    let Some(replaced) =
-                        self.orders.update_in_place(order_id, new_order_arc.clone())
-                    else {
-                        return Ok(None); // Removed by another thread.
-                    };
-                    replaced
-                };
-
-                // Apply the counter deltas from the actual replaced order. A
-                // single component (visible or hidden) can move in EITHER
-                // direction even when the total shrinks or is unchanged, because
-                // quantity can shift between the visible and hidden portions, so
-                // handle both signs.
-                let old_visible = old.visible_quantity().as_u64();
-                let old_hidden = old.hidden_quantity().as_u64();
-                // `Relaxed` on both branches: advisory counters (issue #68); the
-                // queue mutation above (`update_in_place` / `resequence_to_tail`)
-                // carries the happens-before, not these counter RMWs.
-                let apply = |counter: &std::sync::atomic::AtomicU64, old: u64, new: u64| {
-                    if new >= old {
-                        counter.fetch_add(new - old, Ordering::Relaxed);
+                        counter
+                            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
+                                c.checked_add(new - old)
+                            })
+                            .map(|_| ())
+                            .map_err(|_| PriceLevelError::InvalidOperation {
+                                message: "price level quantity counter overflow on update"
+                                    .to_string(),
+                            })
                     } else {
                         counter.fetch_sub(old - new, Ordering::Relaxed);
+                        Ok(())
                     }
-                };
-                apply(&self.visible_quantity, old_visible, new_visible);
-                apply(&self.hidden_quantity, old_hidden, new_hidden);
+                }
+                // Undo this call's own `old -> new` reservation (commutative with
+                // concurrent deltas — it reverses exactly what it added).
+                fn unreserve(counter: &std::sync::atomic::AtomicU64, old: u64, new: u64) {
+                    if new >= old {
+                        counter.fetch_sub(new - old, Ordering::Relaxed);
+                    } else {
+                        counter.fetch_add(old - new, Ordering::Relaxed);
+                    }
+                }
 
-                Ok(Some(new_order_arc))
+                let visible_counter = &self.visible_quantity;
+                let hidden_counter = &self.hidden_quantity;
+
+                // Derive the resized order, choose the priority policy, and
+                // reserve the level counters ALL against the LIVE stored order,
+                // under the entry lock (issue #115). Nothing is read before the
+                // lock, so a concurrent match / replenish that committed first is
+                // fully reflected: the update can never resurrect executed or
+                // cancelled visible / hidden quantity, and the policy is chosen
+                // from the live total, not a stale pre-read. The counters are
+                // reserved with checked math BEFORE the queue commits, so an
+                // update that would overflow a level counter is rejected with the
+                // level (and queue) untouched.
+                let outcome = self.orders.update_entry(order_id, |live| {
+                    let old_visible = live.visible_quantity().as_u64();
+                    let old_hidden = live.hidden_quantity().as_u64();
+                    let live_total = old_visible.checked_add(old_hidden).ok_or_else(|| {
+                        PriceLevelError::InvalidOperation {
+                            message: "order total quantity overflow".to_string(),
+                        }
+                    })?;
+
+                    // `with_reduced_quantity` sets the visible/main tranche to
+                    // exactly `new_quantity` for every variant and preserves the
+                    // LIVE hidden depth (never restored from a pre-read).
+                    let new_order = live.with_reduced_quantity(new_quantity.as_u64());
+                    let new_visible = new_order.visible_quantity().as_u64();
+                    let new_hidden = new_order.hidden_quantity().as_u64();
+                    let new_total = new_visible.checked_add(new_hidden).ok_or_else(|| {
+                        PriceLevelError::InvalidOperation {
+                            message: "order total quantity overflow".to_string(),
+                        }
+                    })?;
+
+                    // Validate + reserve the level counters before mutating the
+                    // queue. On a hidden overflow, roll the visible reservation
+                    // back so a rejected update leaves the counters unchanged.
+                    reserve(visible_counter, old_visible, new_visible)?;
+                    if let Err(err) = reserve(hidden_counter, old_hidden, new_hidden) {
+                        unreserve(visible_counter, old_visible, new_visible);
+                        return Err(err);
+                    }
+
+                    // Priority policy from the LIVE total (cannot be stale).
+                    let arc = Arc::new(new_order);
+                    if new_total > live_total {
+                        Ok(UpdateDecision::ReplaceAtTail(arc))
+                    } else {
+                        Ok(UpdateDecision::KeepInPlace(arc))
+                    }
+                });
+
+                match outcome {
+                    None => Ok(None), // Order not found / concurrently removed.
+                    Some(result) => result.map(Some),
+                }
             }
 
             OrderUpdate::UpdatePriceAndQuantity {

--- a/src/price_level/level.rs
+++ b/src/price_level/level.rs
@@ -1386,12 +1386,22 @@ impl PriceLevel {
                         // `PriceLevelStatistics::stats_degraded`), leaving the
                         // trade stream unaffected. Log the drop rather than
                         // discard it silently.
+                        // Read the degraded flag BEFORE recording: under the
+                        // single-matcher-per-level model this is the faithful
+                        // witness of the `false -> true` transition (issue #129).
+                        // `record_execution` sets the flag atomically via
+                        // `compare_exchange`; we log the WARN only on the FIRST
+                        // drop that transitions it, so a burst of dropped
+                        // executions logs once, not once per drop — the sticky
+                        // flag remains the durable signal for the rest.
+                        let was_degraded = self.stats.stats_degraded();
                         if let Err(err) = self.stats.record_execution(
                             data.consumed,
                             data.maker_price,
                             data.maker_timestamp,
                             timestamp.as_u64(),
-                        ) {
+                        ) && !was_degraded
+                        {
                             // WARN, not ERROR: the match is not aborted — this is
                             // a recoverable observability anomaly flagged by the
                             // sticky degraded flag (the trade is committed).

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -394,15 +394,22 @@ impl OrderQueue {
                     // needs no lock protection. The other actions commit their
                     // queue mutations here, under the lock, as before.
                     let mut park_seq: Option<u64> = None;
+                    // The order swapped OUT of the slot by a partial fill /
+                    // replenish, captured with `mem::replace` and dropped only
+                    // AFTER the entry lock is released (issue #128), so a
+                    // last-reference deallocation never runs under the shard lock.
+                    let mut evicted: Option<Arc<OrderType<()>>> = None;
                     // Every arm releases the entry lock by the time it finishes
                     // (either `occupied.remove()` consumes it, or an explicit
-                    // `drop`), so the deferred `set_aside` insert below never runs
-                    // under the shard lock.
+                    // `drop`), so the deferred `set_aside` insert and the evicted
+                    // order's drop below never run under the shard lock.
                     match &action {
                         FrontAction::Remove => {
                             // Full consume: remove the entry under the lock, then
                             // drop its index entry. A cancel cannot also remove it
                             // (the entry is gone), so no double counter decrement.
+                            // `remove` consumes the guard, releasing the lock
+                            // before the removed value is dropped.
                             let _ = occupied.remove();
                             self.index.remove(&seq);
                         }
@@ -410,7 +417,10 @@ impl OrderQueue {
                             // Partial fill keeping priority: swap the stored value
                             // to the residual in place, keeping the same
                             // sequence/index entry. Still under the entry lock.
-                            occupied.get_mut().1 = residual.clone();
+                            evicted = Some(std::mem::replace(
+                                &mut occupied.get_mut().1,
+                                residual.clone(),
+                            ));
                             drop(occupied);
                         }
                         FrontAction::ReplaceAtTail(refreshed) => {
@@ -425,7 +435,7 @@ impl OrderQueue {
                             {
                                 let slot = occupied.get_mut();
                                 slot.0 = new_seq;
-                                slot.1 = refreshed.clone();
+                                evicted = Some(std::mem::replace(&mut slot.1, refreshed.clone()));
                             }
                             // `occupied` still holds the per-entry lock here, so
                             // re-keying the index — a different structure
@@ -454,10 +464,12 @@ impl OrderQueue {
                     }
 
                     // The entry lock is released on every arm above; a
-                    // possibly-allocating scratch-set insert now runs unlocked.
+                    // possibly-allocating scratch-set insert and the evicted
+                    // order's drop now run unlocked.
                     if let Some(seq) = park_seq {
                         set_aside.insert(seq);
                     }
+                    drop(evicted);
 
                     return FrontOutcome::Matched { result };
                 }
@@ -515,19 +527,25 @@ impl OrderQueue {
                     order_id,
                     "update_entry: the decided order must keep the id it is stored under"
                 );
-                let committed = match decision {
+                // Each arm swaps the new order into the slot with `mem::replace`,
+                // capturing the OLD `Arc` in `evicted` (issue #128). The old Arc
+                // is dropped only AFTER the entry lock is released below, so if
+                // the queue held the last reference, its deallocation never runs
+                // inside the shard's critical section.
+                let (committed, evicted) = match decision {
                     UpdateDecision::KeepInPlace(new_order) => {
-                        occupied.get_mut().1 = new_order.clone();
-                        new_order
+                        let evicted =
+                            std::mem::replace(&mut occupied.get_mut().1, new_order.clone());
+                        (new_order, evicted)
                     }
                     UpdateDecision::ReplaceAtTail(new_order) => {
                         let new_seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
-                        let old_seq = {
+                        let (old_seq, evicted) = {
                             let slot = occupied.get_mut();
                             let old_seq = slot.0;
                             slot.0 = new_seq;
-                            slot.1 = new_order.clone();
-                            old_seq
+                            let evicted = std::mem::replace(&mut slot.1, new_order.clone());
+                            (old_seq, evicted)
                         };
                         // Re-key NEW-KEY-FIRST (issue #127): insert the new
                         // sequence before removing the old one, so the id is
@@ -538,9 +556,12 @@ impl OrderQueue {
                         // (the stored sequence is already `new_seq`).
                         self.index.insert(new_seq, order_id);
                         self.index.remove(&old_seq);
-                        new_order
+                        (new_order, evicted)
                     }
                 };
+                // Release the shard lock, THEN drop the evicted order.
+                drop(occupied);
+                drop(evicted);
                 Some(Ok(committed))
             }
         }

--- a/src/price_level/order_queue.rs
+++ b/src/price_level/order_queue.rs
@@ -62,6 +62,22 @@ pub(crate) enum FrontAction {
     SetAside,
 }
 
+/// The mutation an [`OrderQueue::update_entry`] decision closure asks the queue
+/// to commit, after deriving it from the **live** stored order under the entry
+/// lock. Mirrors the [`FrontAction`] precedent for the match sweep.
+#[derive(Debug)]
+pub(crate) enum UpdateDecision {
+    /// Decrease / unchanged total: swap the stored value to the resized order at
+    /// its existing insertion sequence, keeping its price-time position.
+    KeepInPlace(Arc<OrderType<()>>),
+    /// Increase in total: demote the resized order to a fresh tail sequence
+    /// (losing time priority) by minting a new sequence, swapping the stored
+    /// `(seq, order)` pair in place, and re-keying the index — all under the
+    /// entry lock the update already holds. Same shape as the
+    /// [`FrontAction::ReplaceAtTail`] the match sweep commits.
+    ReplaceAtTail(Arc<OrderType<()>>),
+}
+
 /// The outcome of a single [`OrderQueue::match_front`] step, reported back to
 /// the sweep so it can drive the loop and apply counter deltas.
 #[derive(Debug)]
@@ -93,11 +109,12 @@ impl OrderQueue {
     ///
     /// Test-only queue-building fixture. It has no production caller: admission
     /// uses [`OrderQueue::try_push`] / [`OrderQueue::try_push_with`]
-    /// (insert-if-absent, issue #113) and the quantity-increase demotion uses
-    /// [`OrderQueue::resequence_to_tail`] (in-place, issue #119). Its blind
-    /// overwrite would leave the id-keyed map and the ordered index
-    /// disagreeing, so it is deliberately not part of the public API — like
-    /// [`OrderQueue::reinsert`], it is `#[cfg(test)]`.
+    /// (insert-if-absent, issue #113) and every quantity update re-derives and
+    /// re-sequences in place under the entry lock via
+    /// [`OrderQueue::update_entry`] (issue #115). Its blind overwrite would
+    /// leave the id-keyed map and the ordered index disagreeing, so it is
+    /// deliberately not part of the public API — like [`OrderQueue::reinsert`],
+    /// it is `#[cfg(test)]`.
     #[cfg(test)]
     pub(crate) fn push(&self, order: Arc<OrderType<()>>) {
         // `Relaxed` is sufficient: only the uniqueness and monotonicity of the
@@ -119,9 +136,10 @@ impl OrderQueue {
     /// publication has no side effects to commit atomically with it; the
     /// reservation-hook form commits a caller-side reservation (e.g. the level's
     /// atomic counters) under the same shard lock that decides the id is free.
-    /// The quantity-increase update path no longer vacates the id either: as of
-    /// issue #119 it demotes in place via `resequence_to_tail`, so there is no
-    /// remove-then-push window for a same-id admission to slip into.
+    /// The quantity-update path no longer vacates the id either: as of issues
+    /// #119 / #115 it re-derives and re-sequences in place under the entry lock
+    /// (`update_entry`), so there is no remove-then-push window for a same-id
+    /// admission to slip into.
     ///
     /// # Errors
     ///
@@ -340,9 +358,10 @@ impl OrderQueue {
                 Entry::Occupied(mut occupied) => {
                     // Stale front-selection guard (issue #119). The `(seq, id)`
                     // pair was read from the index BEFORE this entry lock was
-                    // taken. A concurrent `resequence_to_tail` (quantity-increase
-                    // demotion) may have moved this maker to a fresh tail
-                    // sequence in that gap, so the entry now stores a DIFFERENT
+                    // taken. A concurrent quantity-increase demotion (the
+                    // `ReplaceAtTail` path of `update_entry`) may have moved this
+                    // maker to a fresh tail sequence in that gap, so the entry
+                    // now stores a DIFFERENT
                     // sequence and the maker is no longer the front. Acting on it
                     // via the stale front position would break FIFO. Drop the
                     // stale index key (the demoted maker already lives under its
@@ -446,66 +465,83 @@ impl OrderQueue {
         }
     }
 
-    /// Atomically re-sequence `order_id` to the tail (a fresh insertion
-    /// sequence), swapping in `new_order`, **without ever removing the id from
-    /// the map**. Returns the replaced order, or `None` if the id was
-    /// concurrently removed (nothing is inserted in that case).
+    /// Atomically derive, decide, and commit an update against the **live**
+    /// stored order for `order_id`, all inside the per-entry lock (issue #115).
     ///
-    /// This is the quantity-increase demotion primitive (issue #119). It is the
-    /// standalone form of the [`FrontAction::ReplaceAtTail`] path the match
-    /// sweep already uses: it holds the `DashMap` per-entry (shard) lock across
-    /// the whole operation — mint a tail sequence, swap the stored
-    /// `(sequence, order)` pair in place, then re-key the index
-    /// (`old_seq -> new_seq`) — so the id stays continuously resident in
-    /// `orders`. The prior `remove` + `push` demotion opened an absent window in
-    /// which the id was gone from the map; a concurrent cancel could report no
-    /// removal while the update re-inserted (lost cancel / resurrection), a
-    /// concurrent same-id admission could slip into the gap, and
-    /// [`OrderQueue::match_front`] could act on a stale front. Because the id
-    /// never leaves the map here, a concurrent [`OrderQueue::remove`] either
-    /// fully precedes this call (this returns `None`) or fully follows it (it
-    /// removes the re-sequenced order): all three hazards are closed. The index
-    /// re-key inserts the NEW key before removing the old (issue #127), so the id
-    /// is never absent from the INDEX either: a concurrent front scan always
-    /// finds this maker at one key or the other and can never return `Empty`
-    /// with liquidity resting. The transient two-key window is discarded by the
-    /// stale-front guard in [`OrderQueue::match_front`] / [`OrderQueue::pop_entry`].
+    /// `decide` runs against the order currently resident in the map — not a
+    /// stale pre-read — and returns the [`UpdateDecision`] to commit, or a
+    /// [`PriceLevelError`] to reject the update without touching the queue. The
+    /// decision (the resized order and the in-place-vs-demote priority policy)
+    /// therefore reflects any concurrent match / replenish that committed before
+    /// the lock was taken, so an update can never resurrect executed or
+    /// cancelled quantity, and the priority policy can never be chosen from a
+    /// stale total. This mirrors the [`OrderQueue::match_front`] decision-closure
+    /// pattern; the closure must not let a reference into the live order escape
+    /// its return value.
     ///
-    /// Allocation-free beyond the `Arc` the caller hands in and the index node
-    /// [`crossbeam_skiplist::SkipMap::insert`] allocates for the new key.
-    pub(crate) fn resequence_to_tail(
+    /// Returns:
+    /// - `None` if the id is not present (concurrently removed / never existed);
+    /// - `Some(Err(_))` if `decide` rejected the update (queue untouched);
+    /// - `Some(Ok(new_order))` with the committed order on success.
+    ///
+    /// Both commits happen under the single entry lock this method already
+    /// holds: `KeepInPlace` swaps the stored value; `ReplaceAtTail` mints a fresh
+    /// tail sequence, swaps the `(seq, order)` pair, and re-keys the index in
+    /// place (delegating to a separate re-sequence method here would deadlock on
+    /// the same shard lock).
+    #[must_use = "the caller must handle committed / rejected / absent outcomes"]
+    pub(crate) fn update_entry<F>(
         &self,
         order_id: Id,
-        new_order: Arc<OrderType<()>>,
-    ) -> Option<Arc<OrderType<()>>> {
+        decide: F,
+    ) -> Option<Result<Arc<OrderType<()>>, PriceLevelError>>
+    where
+        F: FnOnce(&OrderType<()>) -> Result<UpdateDecision, PriceLevelError>,
+    {
         match self.orders.entry(order_id) {
-            // Concurrently removed: do not resurrect it.
             Entry::Vacant(_) => None,
             Entry::Occupied(mut occupied) => {
-                // Mint the tail sequence and swap the stored (seq, order) pair in
-                // place under the entry lock, then re-key the index while the
-                // lock is still held (a different structure — no deadlock),
-                // exactly as `ReplaceAtTail` does.
-                let new_seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
-                let (old_seq, replaced) = {
-                    let slot = occupied.get_mut();
-                    let old_seq = slot.0;
-                    let replaced = std::mem::replace(&mut slot.1, new_order);
-                    slot.0 = new_seq;
-                    (old_seq, replaced)
+                // Derive + decide against the LIVE stored order under the lock.
+                // The borrow ends with the `decide` call (it returns owned data),
+                // so `get_mut()` below is free to commit.
+                let decision = match decide(occupied.get().1.as_ref()) {
+                    Ok(decision) => decision,
+                    Err(err) => return Some(Err(err)),
                 };
-                // Re-key the index NEW-KEY-FIRST (issue #127): insert the new
-                // sequence BEFORE removing the old one, so the id is never
-                // transiently absent from the index. A concurrent `match_front`
-                // front scan therefore always finds this maker (at the old key or
-                // the new one) — it can never see a gap and return `Empty` with
-                // liquidity resting. The transient window where BOTH keys point
-                // at the id is harmless: the stale-front guard (`stored != seq`)
-                // in `match_front` / `pop_entry` discards the old key on
-                // selection, since the stored sequence is already `new_seq`.
-                self.index.insert(new_seq, order_id);
-                self.index.remove(&old_seq);
-                Some(replaced)
+                debug_assert_eq!(
+                    match &decision {
+                        UpdateDecision::KeepInPlace(o) | UpdateDecision::ReplaceAtTail(o) => o.id(),
+                    },
+                    order_id,
+                    "update_entry: the decided order must keep the id it is stored under"
+                );
+                let committed = match decision {
+                    UpdateDecision::KeepInPlace(new_order) => {
+                        occupied.get_mut().1 = new_order.clone();
+                        new_order
+                    }
+                    UpdateDecision::ReplaceAtTail(new_order) => {
+                        let new_seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
+                        let old_seq = {
+                            let slot = occupied.get_mut();
+                            let old_seq = slot.0;
+                            slot.0 = new_seq;
+                            slot.1 = new_order.clone();
+                            old_seq
+                        };
+                        // Re-key NEW-KEY-FIRST (issue #127): insert the new
+                        // sequence before removing the old one, so the id is
+                        // never transiently absent from the index and a
+                        // concurrent front scan can never return `Empty` with
+                        // liquidity resting. The transient two-key window is
+                        // discarded on selection by the stale-front guard
+                        // (the stored sequence is already `new_seq`).
+                        self.index.insert(new_seq, order_id);
+                        self.index.remove(&old_seq);
+                        new_order
+                    }
+                };
+                Some(Ok(committed))
             }
         }
     }
@@ -532,35 +568,6 @@ impl OrderQueue {
     #[inline]
     pub fn find(&self, order_id: Id) -> Option<Arc<OrderType<()>>> {
         self.orders.get(&order_id).map(|o| o.value().1.clone())
-    }
-
-    /// Replace the stored order for `order_id` in place, keeping its existing
-    /// insertion sequence (and therefore its price-time / FIFO position).
-    ///
-    /// Returns the previous order if `order_id` was present, or `None` if it
-    /// was not (e.g. concurrently removed). The `index` entry `seq -> id`
-    /// stays valid because the sequence is unchanged, so only the `DashMap`
-    /// value is swapped.
-    ///
-    /// The whole swap happens under the `DashMap` per-entry lock, so a
-    /// concurrent [`OrderQueue::remove`] of the same id either observes the
-    /// old value and removes it, or observes the new value and removes that —
-    /// it never sees the entry mid-update. This closes the
-    /// absent-from-`orders` window that a remove-then-push sequence would open.
-    #[must_use]
-    pub(crate) fn update_in_place(
-        &self,
-        order_id: Id,
-        new_order: Arc<OrderType<()>>,
-    ) -> Option<Arc<OrderType<()>>> {
-        debug_assert_eq!(
-            new_order.id(),
-            order_id,
-            "update_in_place: new_order id must match the key it is stored under"
-        );
-        let mut entry = self.orders.get_mut(&order_id)?;
-        let (_seq, slot) = entry.value_mut();
-        Some(std::mem::replace(slot, new_order))
     }
 
     /// Remove an order with the given ID.
@@ -633,8 +640,8 @@ impl OrderQueue {
     /// stored sequence. Because the map holds exactly one entry per order, a
     /// duplicate id is impossible by construction, and because each
     /// `(seq, order)` pair is swapped atomically under the `DashMap` per-entry
-    /// lock (both [`FrontAction::ReplaceAtTail`] and
-    /// [`OrderQueue::update_in_place`] mutate value and sequence together under
+    /// lock (both the [`FrontAction::ReplaceAtTail`] sweep step and
+    /// [`OrderQueue::update_entry`] mutate value and sequence together under
     /// it), every emitted pair is a real committed state — an order caught
     /// mid-re-sequencing appears at either its old or its new sequence, never
     /// both and never as a mixed `(old_seq, new_order)` pair. Walking the
@@ -678,8 +685,8 @@ impl OrderQueue {
             .map(|entry| entry.value().clone())
             .collect();
         // Unstable sort is deterministic here because sequences are unique
-        // across live orders (`push` / `ReplaceAtTail` mint distinct seqs via
-        // `fetch_add`; `update_in_place` keeps the order's own seq).
+        // across live orders (the tail-appending paths mint distinct seqs via
+        // `fetch_add`; an in-place update keeps the order's own seq).
         pairs.sort_unstable_by_key(|(seq, _)| *seq);
         out.clear();
         out.extend(pairs.into_iter().map(|(_, order)| order));

--- a/src/price_level/snapshot.rs
+++ b/src/price_level/snapshot.rs
@@ -261,12 +261,29 @@ impl PriceLevelSnapshot {
     }
 }
 
-/// Format version for checksum-enabled price level snapshots.
+/// Format version for checksum-enabled price level snapshots. New packages are
+/// written at this version.
 ///
-/// Version 2 (issue #63) persists per-level [`PriceLevelStatistics`] inside the
-/// snapshot. Version 1 packages carried no statistics and are rejected by
-/// [`PriceLevelSnapshotPackage::validate`] with a version mismatch.
-pub const SNAPSHOT_FORMAT_VERSION: u32 = 2;
+/// - **Version 1** carried no statistics — rejected by
+///   [`PriceLevelSnapshotPackage::validate`] with a version mismatch.
+/// - **Version 2** (issue #63) persists per-level [`PriceLevelStatistics`] as an
+///   8-field statistics payload (no `stats_degraded`).
+/// - **Version 3** (issue #129) is the current shape: it owns the optional 9th
+///   `stats_degraded` statistics field. A degraded level (which serializes that
+///   field) is a v3 payload, so it is no longer mislabelled v2 where an old
+///   8-field-only reader would choke on the unknown field.
+///
+/// [`PriceLevelSnapshotPackage::validate`] accepts BOTH v2 (legacy, 8-field,
+/// `stats_degraded` defaults `false`) and v3, so old snapshots keep restoring;
+/// v1 is still rejected. Checksum recomputation is version-agnostic — a
+/// non-degraded level serializes 8 fields under either version, so a legacy v2
+/// package's SHA-256 still matches.
+pub const SNAPSHOT_FORMAT_VERSION: u32 = 3;
+
+/// The set of snapshot format versions [`PriceLevelSnapshotPackage::validate`]
+/// accepts on restore: the current [`SNAPSHOT_FORMAT_VERSION`] (v3) and the
+/// legacy v2 (issue #129). v1 (statistics-less) is not accepted.
+const SUPPORTED_SNAPSHOT_VERSIONS: &[u32] = &[2, 3];
 
 /// Serialized representation of a price level snapshot including checksum validation metadata.
 ///
@@ -361,11 +378,11 @@ impl PriceLevelSnapshotPackage {
     // Snapshot restoration / validation is a cold path: keep it out of line.
     #[inline(never)]
     pub fn validate(&self) -> Result<(), PriceLevelError> {
-        if self.version != SNAPSHOT_FORMAT_VERSION {
+        if !SUPPORTED_SNAPSHOT_VERSIONS.contains(&self.version) {
             return Err(PriceLevelError::InvalidOperation {
                 message: format!(
-                    "Unsupported snapshot version: {} (expected {})",
-                    self.version, SNAPSHOT_FORMAT_VERSION
+                    "Unsupported snapshot version: {} (expected one of {:?})",
+                    self.version, SUPPORTED_SNAPSHOT_VERSIONS
                 ),
             });
         }

--- a/src/price_level/statistics.rs
+++ b/src/price_level/statistics.rs
@@ -18,22 +18,26 @@ use std::time::{SystemTime, UNIX_EPOCH};
 ///
 /// # Atomic ordering
 ///
-/// **Every atomic access in this type uses [`Ordering::Relaxed`], deliberately.**
-/// These are pure observability counters: nothing in the engine reads a
-/// statistic to gate a queue mutation, and no other field's visibility is
-/// published through them. They carry no happens-before relationship — each
-/// counter is independent and may be read mid-update, so a multi-field read
-/// (serde, [`Display`](std::fmt::Display), [`Clone`]) is an explicitly
-/// best-effort, non-transactional point-in-time view that can be torn across
-/// fields. This is unlike `PriceLevel::snapshot`, which is internally
-/// consistent (it derives its aggregates from one materialized order vector);
-/// these statistics counters are not part of that consistency guarantee.
-/// `Relaxed` is therefore both correct and the
-/// cheapest valid choice; a stronger ordering would only add cost without
-/// buying any guarantee a consumer relies on. The lone read-modify-write loop
-/// in [`checked_fetch_add_u64`](Self::checked_fetch_add_u64) is a standard
-/// `compare_exchange_weak` CAS retry — see the note there for why both its
-/// success and failure orderings are `Relaxed`.
+/// The individual counters are `Relaxed` observability atomics: nothing in the
+/// engine reads a statistic to gate a queue mutation, and no other field's
+/// visibility is published through them. Point accessors ([`orders_executed`](Self::orders_executed),
+/// the average ratios, …) load them `Relaxed` and remain best-effort — a ratio
+/// across two counters can still be transiently torn and self-corrects once
+/// recording quiesces.
+///
+/// A **multi-field** read — [`Clone`] (which backs the checksummed
+/// `PriceLevel::snapshot`) and the serde / [`Display`](std::fmt::Display)
+/// serialization paths — instead goes through a **seqlock** (issue #129) so it
+/// copies a consistent set that never mixes a pre- and post-`record_execution`
+/// prefix (which would otherwise checksum a state the level never held). The
+/// `stats_seq` sequence counter is bumped to odd on a writer's entry
+/// ([`record_execution`](Self::record_execution) / [`reset`](Self::reset)) and
+/// back to even on its exit, both `Release`; a reader loads it `Acquire`, copies
+/// the fields, `Acquire`-fences, re-loads it, and retries if it changed or was
+/// odd. Writers are serialized by the engine model (one matcher per level +
+/// `reset`'s quiescence contract), which the seqlock assumes. The lone
+/// read-modify-write loop in [`checked_fetch_add_u64`](Self::checked_fetch_add_u64)
+/// is a standard `compare_exchange_weak` CAS retry.
 #[derive(Debug)]
 pub struct PriceLevelStatistics {
     /// Number of orders added
@@ -69,6 +73,58 @@ pub struct PriceLevelStatistics {
     /// is the observable signal that the recorded aggregates under-count the
     /// true executions. Serialized so it round-trips through a snapshot.
     stats_degraded: AtomicBool,
+
+    /// Seqlock sequence for consistent multi-field reads (issue #129). Even when
+    /// no writer is in a section, odd while a writer ([`record_execution`](Self::record_execution)
+    /// / [`reset`](Self::reset)) is mutating. Purely internal — never serialized
+    /// — so a restored / cloned value starts even (0).
+    stats_seq: AtomicU64,
+}
+
+/// RAII guard bracketing a statistics WRITE section for the seqlock (issue
+/// #129). Constructing it bumps `stats_seq` to odd; dropping it bumps back to
+/// even, so a concurrent multi-field reader retries if it overlapped either
+/// increment. Using a guard keeps the section correct across the early returns
+/// in [`PriceLevelStatistics::record_execution`].
+struct WriteSeqGuard<'a> {
+    seq: &'a AtomicU64,
+}
+
+impl<'a> WriteSeqGuard<'a> {
+    #[inline]
+    fn new(seq: &'a AtomicU64) -> Self {
+        // Enter: even -> odd. `Relaxed` RMW plus a `Release` fence so the field
+        // writes that follow cannot be reordered before the odd marker a reader
+        // watches for.
+        seq.fetch_add(1, Ordering::Relaxed);
+        std::sync::atomic::fence(Ordering::Release);
+        Self { seq }
+    }
+}
+
+impl Drop for WriteSeqGuard<'_> {
+    #[inline]
+    fn drop(&mut self) {
+        // Exit: odd -> even, `Release` so every field write in the section
+        // happens-before a reader's `Acquire` load of the (now even) sequence.
+        self.seq.fetch_add(1, Ordering::Release);
+    }
+}
+
+/// A consistent point-in-time copy of every statistics field, read under the
+/// seqlock (issue #129). Plain values, no atomics — so `Clone` / serialize
+/// materialize a coherent set rather than a torn mix of counters.
+#[derive(Clone, Copy)]
+struct StatsData {
+    orders_added: usize,
+    orders_removed: usize,
+    orders_executed: usize,
+    quantity_executed: u64,
+    value_executed: u64,
+    last_execution_time: u64,
+    first_arrival_time: u64,
+    sum_waiting_time: u64,
+    stats_degraded: bool,
 }
 
 impl PriceLevelStatistics {
@@ -104,6 +160,108 @@ impl PriceLevelStatistics {
         }
     }
 
+    /// Checked `+= value` on a `usize` counter, mirroring
+    /// [`checked_fetch_add_u64`](Self::checked_fetch_add_u64). `orders_executed`
+    /// can be seeded to `usize::MAX` through `FromStr` / serde, so a plain
+    /// `fetch_add(1)` could wrap while the other aggregates advance (issue #129);
+    /// this rejects the overflow so the all-or-nothing rollback can undo the
+    /// prefix instead.
+    fn checked_fetch_add_usize(
+        target: &AtomicUsize,
+        value: usize,
+        field: &str,
+    ) -> Result<(), PriceLevelError> {
+        let mut current = target.load(Ordering::Relaxed);
+        loop {
+            let next =
+                current
+                    .checked_add(value)
+                    .ok_or_else(|| PriceLevelError::InvalidOperation {
+                        message: format!("{field} overflow"),
+                    })?;
+            match target.compare_exchange_weak(current, next, Ordering::Relaxed, Ordering::Relaxed)
+            {
+                Ok(_) => return Ok(()),
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    /// Set the sticky degraded flag; returns `true` iff THIS call transitioned it
+    /// `false -> true` (issue #129). The caller (`PriceLevel::match_order`) logs
+    /// the WARN only on that transition, so a burst of dropped executions marks
+    /// the level degraded once and logs once, not once per drop.
+    pub(crate) fn mark_degraded(&self) -> bool {
+        self.stats_degraded
+            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+    }
+
+    /// Read a consistent snapshot of every field under the seqlock (issue #129).
+    ///
+    /// Retries until a full copy brackets an even, unchanged sequence — i.e. no
+    /// writer transaction ([`record_execution`](Self::record_execution) /
+    /// [`reset`](Self::reset)) overlapped it, so the copy is NEVER a torn mix of
+    /// a pre- and post-write prefix (a bounded fallback that returned a torn copy
+    /// would defeat the checksummed snapshot this backs).
+    ///
+    /// # Liveness
+    ///
+    /// The loop's work PER attempt is bounded (one sequence load + a nine-field
+    /// copy), and it converges under the advisory writer-serialization contract
+    /// (one matcher per level + `reset`'s quiescence): a writer holds the section
+    /// for only a short, allocation-free burst before dropping the guard back to
+    /// even, and `record_execution` is finite, so a reader exits on the first
+    /// iteration when uncontended and otherwise as soon as recording quiesces
+    /// (which it always does — the matcher cannot record forever). A panicking
+    /// writer still restores the even sequence via the guard's `Drop`, so the
+    /// reader is never stranded on a permanently-odd sequence.
+    fn read_consistent(&self) -> StatsData {
+        loop {
+            let s1 = self.stats_seq.load(Ordering::Acquire);
+            if s1 & 1 != 0 {
+                // A writer is mid-section; spin until it exits.
+                std::hint::spin_loop();
+                continue;
+            }
+            let data = StatsData {
+                orders_added: self.orders_added.load(Ordering::Relaxed),
+                orders_removed: self.orders_removed.load(Ordering::Relaxed),
+                orders_executed: self.orders_executed.load(Ordering::Relaxed),
+                quantity_executed: self.quantity_executed.load(Ordering::Relaxed),
+                value_executed: self.value_executed.load(Ordering::Relaxed),
+                last_execution_time: self.last_execution_time.load(Ordering::Relaxed),
+                first_arrival_time: self.first_arrival_time.load(Ordering::Relaxed),
+                sum_waiting_time: self.sum_waiting_time.load(Ordering::Relaxed),
+                stats_degraded: self.stats_degraded.load(Ordering::Relaxed),
+            };
+            // Ensure the field loads complete before re-reading the sequence.
+            std::sync::atomic::fence(Ordering::Acquire);
+            let s2 = self.stats_seq.load(Ordering::Relaxed);
+            if s1 == s2 {
+                return data;
+            }
+            std::hint::spin_loop();
+        }
+    }
+
+    /// Reconstruct from a plain [`StatsData`] copy (seqlock reader output), with
+    /// a fresh even sequence.
+    fn from_data(data: StatsData) -> Self {
+        Self {
+            orders_added: AtomicUsize::new(data.orders_added),
+            orders_removed: AtomicUsize::new(data.orders_removed),
+            orders_executed: AtomicUsize::new(data.orders_executed),
+            quantity_executed: AtomicU64::new(data.quantity_executed),
+            value_executed: AtomicU64::new(data.value_executed),
+            last_execution_time: AtomicU64::new(data.last_execution_time),
+            first_arrival_time: AtomicU64::new(data.first_arrival_time),
+            sum_waiting_time: AtomicU64::new(data.sum_waiting_time),
+            stats_degraded: AtomicBool::new(data.stats_degraded),
+            stats_seq: AtomicU64::new(0),
+        }
+    }
+
     #[inline]
     fn current_timestamp_milliseconds() -> Result<u64, PriceLevelError> {
         SystemTime::now()
@@ -134,6 +292,7 @@ impl PriceLevelStatistics {
             first_arrival_time: AtomicU64::new(current_time),
             sum_waiting_time: AtomicU64::new(0),
             stats_degraded: AtomicBool::new(false),
+            stats_seq: AtomicU64::new(0),
         }
     }
 
@@ -192,6 +351,13 @@ impl PriceLevelStatistics {
     ) -> Result<(), PriceLevelError> {
         let current_time = execution_timestamp;
 
+        // Bracket the whole record as a seqlock WRITE (issue #129): a concurrent
+        // multi-field reader (`Clone` / serialize) retries rather than capture an
+        // in-flight prefix, and `reset` — also a writer — cannot interleave this
+        // transaction's rollback. The guard's `Drop` closes the section (back to
+        // even) on EVERY return path below, including the early validation errors.
+        let _write = WriteSeqGuard::new(&self.stats_seq);
+
         // Validate everything that can fail BEFORE mutating any counter, so a
         // rejected record leaves the statistics untouched. Any failure marks the
         // stats degraded: this execution's contribution is being dropped.
@@ -199,7 +365,7 @@ impl PriceLevelStatistics {
             match current_time.checked_sub(order_timestamp) {
                 Some(value) => Some(value),
                 None => {
-                    self.stats_degraded.store(true, Ordering::Relaxed);
+                    self.mark_degraded();
                     return Err(PriceLevelError::InvalidOperation {
                         message: format!(
                             "order timestamp {order_timestamp} is in the future of current time {current_time}"
@@ -217,7 +383,7 @@ impl PriceLevelStatistics {
         {
             Some(value) => value,
             None => {
-                self.stats_degraded.store(true, Ordering::Relaxed);
+                self.mark_degraded();
                 return Err(PriceLevelError::InvalidOperation {
                     message: "value_executed overflow (quantity * price exceeds u64 storage)"
                         .to_string(),
@@ -227,17 +393,22 @@ impl PriceLevelStatistics {
 
         // Commit the additive aggregates with a rollback of the already-committed
         // prefix on a later overflow (all-or-nothing). `orders_executed` is a
-        // `usize` counter that cannot overflow in practice, but it is part of the
-        // transaction so it is rolled back too. `last_execution_time` is a
-        // non-additive "latest" store, applied only after every additive commit
-        // succeeds so a rejected record never advances it.
-        self.orders_executed.fetch_add(1, Ordering::Relaxed);
+        // `usize` counter that could be seeded to `usize::MAX` via FromStr / serde
+        // (issue #129), so it is a CHECKED add and part of the transaction —
+        // rolled back like the others. `last_execution_time` is a non-additive
+        // "latest" store, applied only after every additive commit succeeds so a
+        // rejected record never advances it.
+        if let Err(err) = Self::checked_fetch_add_usize(&self.orders_executed, 1, "orders_executed")
+        {
+            self.mark_degraded();
+            return Err(err);
+        }
 
         if let Err(err) =
             Self::checked_fetch_add_u64(&self.quantity_executed, quantity, "quantity_executed")
         {
             self.orders_executed.fetch_sub(1, Ordering::Relaxed);
-            self.stats_degraded.store(true, Ordering::Relaxed);
+            self.mark_degraded();
             return Err(err);
         }
 
@@ -247,7 +418,7 @@ impl PriceLevelStatistics {
             self.quantity_executed
                 .fetch_sub(quantity, Ordering::Relaxed);
             self.orders_executed.fetch_sub(1, Ordering::Relaxed);
-            self.stats_degraded.store(true, Ordering::Relaxed);
+            self.mark_degraded();
             return Err(err);
         }
 
@@ -262,12 +433,15 @@ impl PriceLevelStatistics {
             self.quantity_executed
                 .fetch_sub(quantity, Ordering::Relaxed);
             self.orders_executed.fetch_sub(1, Ordering::Relaxed);
-            self.stats_degraded.store(true, Ordering::Relaxed);
+            self.mark_degraded();
             return Err(err);
         }
 
+        // Monotonic (issue #129): a concurrent / out-of-order record can never
+        // move the "latest execution" backwards. Belt-and-braces with the
+        // seqlock, but cheap and independently correct.
         self.last_execution_time
-            .store(current_time, Ordering::Relaxed);
+            .fetch_max(current_time, Ordering::Relaxed);
 
         Ok(())
     }
@@ -402,13 +576,23 @@ impl PriceLevelStatistics {
     ///
     /// This must only be called on a **quiescent** level — with no in-flight
     /// [`record_execution`](Self::record_execution) (and hence no in-flight
-    /// `PriceLevel::match_order`). `reset` `store(0)`s each counter directly; a
-    /// concurrent `record_execution` overflow rollback (`fetch_sub`) racing that
-    /// `store(0)` would wrap a counter toward `u64::MAX`. No engine path calls
-    /// `reset` during matching, so this does not occur today, but it is a
-    /// caller obligation because `reset` is public.
+    /// `PriceLevel::match_order`). `reset` participates in the seqlock as a
+    /// WRITER (issue #129), so it can never interleave the middle of a
+    /// `record_execution` transaction's rollback (which would otherwise wrap a
+    /// counter toward `u64::MAX` via a `store(0)` racing a `fetch_sub`) — but the
+    /// seqlock protects READERS, it does not serialize two writers. The
+    /// single-matcher-per-level model already serializes `record_execution`, and
+    /// this quiescence requirement extends that to `reset`. No engine path calls
+    /// `reset` during matching, so the race does not occur today; it remains a
+    /// caller obligation because `reset` is public. A multi-field reader
+    /// (`Clone` / serialize) racing `reset` retries and observes either the
+    /// pre-reset or fully-reset state, never a mix.
     pub fn reset(&self) {
         let current_time = Self::current_timestamp_milliseconds_or_zero();
+
+        // Seqlock write section: a concurrent multi-field reader retries rather
+        // than capture a half-reset copy.
+        let _write = WriteSeqGuard::new(&self.stats_seq);
 
         self.orders_added.store(0, Ordering::Relaxed);
         self.orders_removed.store(0, Ordering::Relaxed);
@@ -430,44 +614,37 @@ impl Default for PriceLevelStatistics {
 }
 
 impl Clone for PriceLevelStatistics {
-    /// Clones the statistics by snapshotting each atomic counter.
+    /// Clones the statistics by reading a **consistent** snapshot of every field
+    /// under the seqlock (issue #129).
     ///
-    /// Each counter is read with [`Ordering::Relaxed`]: the clone is a
-    /// best-effort point-in-time copy of independent counters (the same
-    /// contract as the serde path and `snapshot()`), not a globally consistent
-    /// transactional read across all eight fields. This is the representation
-    /// persisted in [`PriceLevelSnapshot`](crate::price_level::PriceLevelSnapshot),
-    /// so a restored level carries the recorded statistics rather than a fresh,
-    /// zeroed set.
+    /// This is the representation persisted in
+    /// [`PriceLevelSnapshot`](crate::price_level::PriceLevelSnapshot) and hence
+    /// covered by that snapshot's SHA-256 checksum, so the copy must not mix a
+    /// pre- and post-`record_execution` prefix — the seqlock retries until it
+    /// captures a state the level actually held. A restored level therefore
+    /// carries the recorded statistics rather than a fresh, zeroed set.
     fn clone(&self) -> Self {
-        Self {
-            orders_added: AtomicUsize::new(self.orders_added.load(Ordering::Relaxed)),
-            orders_removed: AtomicUsize::new(self.orders_removed.load(Ordering::Relaxed)),
-            orders_executed: AtomicUsize::new(self.orders_executed.load(Ordering::Relaxed)),
-            quantity_executed: AtomicU64::new(self.quantity_executed.load(Ordering::Relaxed)),
-            value_executed: AtomicU64::new(self.value_executed.load(Ordering::Relaxed)),
-            last_execution_time: AtomicU64::new(self.last_execution_time.load(Ordering::Relaxed)),
-            first_arrival_time: AtomicU64::new(self.first_arrival_time.load(Ordering::Relaxed)),
-            sum_waiting_time: AtomicU64::new(self.sum_waiting_time.load(Ordering::Relaxed)),
-            stats_degraded: AtomicBool::new(self.stats_degraded.load(Ordering::Relaxed)),
-        }
+        Self::from_data(self.read_consistent())
     }
 }
 
 impl fmt::Display for PriceLevelStatistics {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Consistent multi-field read (issue #129): the emitted string is a
+        // coherent snapshot, not a torn mix, and round-trips through `FromStr`.
+        let d = self.read_consistent();
         write!(
             f,
             "PriceLevelStatistics:orders_added={};orders_removed={};orders_executed={};quantity_executed={};value_executed={};last_execution_time={};first_arrival_time={};sum_waiting_time={};stats_degraded={}",
-            self.orders_added.load(Ordering::Relaxed),
-            self.orders_removed.load(Ordering::Relaxed),
-            self.orders_executed.load(Ordering::Relaxed),
-            self.quantity_executed.load(Ordering::Relaxed),
-            self.value_executed.load(Ordering::Relaxed),
-            self.last_execution_time.load(Ordering::Relaxed),
-            self.first_arrival_time.load(Ordering::Relaxed),
-            self.sum_waiting_time.load(Ordering::Relaxed),
-            self.stats_degraded.load(Ordering::Relaxed)
+            d.orders_added,
+            d.orders_removed,
+            d.orders_executed,
+            d.quantity_executed,
+            d.value_executed,
+            d.last_execution_time,
+            d.first_arrival_time,
+            d.sum_waiting_time,
+            d.stats_degraded
         )
     }
 }
@@ -565,6 +742,7 @@ impl FromStr for PriceLevelStatistics {
             first_arrival_time: AtomicU64::new(first_arrival_time),
             sum_waiting_time: AtomicU64::new(sum_waiting_time),
             stats_degraded: AtomicBool::new(stats_degraded),
+            stats_seq: AtomicU64::new(0),
         })
     }
 }
@@ -574,47 +752,34 @@ impl Serialize for PriceLevelStatistics {
     where
         S: Serializer,
     {
+        // Read all fields as ONE consistent seqlock snapshot (issue #129) so a
+        // concurrent `record_execution` can never make the serialized (and hence
+        // checksummed) statistics a torn pre/post-write mix.
+        let d = self.read_consistent();
+
         // Serialize `stats_degraded` ONLY when it is `true` (dynamic 8/9-field
         // count). A non-degraded level then serializes in the exact pre-#117
         // 8-field form — byte-identical to a v2 statistics payload persisted
         // before this flag existed — so a `PriceLevelSnapshotPackage`'s SHA-256
         // checksum, recomputed over the re-serialized bytes on
-        // `validate` / `from_snapshot_json`, still matches. A degraded level
-        // adds the field; `Deserialize` / `FromStr` default a missing flag to
-        // `false`, so both directions round-trip.
-        let degraded = self.stats_degraded.load(Ordering::Relaxed);
+        // `validate` / `from_snapshot_json`, still matches for BOTH a legacy v2
+        // and a new v3 non-degraded package (issue #129 keeps checksum
+        // recomputation version-agnostic — see `SNAPSHOT_FORMAT_VERSION`). A
+        // degraded level adds the 9th field (the v3-only shape); `Deserialize` /
+        // `FromStr` default a missing flag to `false`, so both directions
+        // round-trip.
+        let degraded = d.stats_degraded;
         let field_count = if degraded { 9 } else { 8 };
         let mut state = serializer.serialize_struct("PriceLevelStatistics", field_count)?;
 
-        state.serialize_field("orders_added", &self.orders_added.load(Ordering::Relaxed))?;
-        state.serialize_field(
-            "orders_removed",
-            &self.orders_removed.load(Ordering::Relaxed),
-        )?;
-        state.serialize_field(
-            "orders_executed",
-            &self.orders_executed.load(Ordering::Relaxed),
-        )?;
-        state.serialize_field(
-            "quantity_executed",
-            &self.quantity_executed.load(Ordering::Relaxed),
-        )?;
-        state.serialize_field(
-            "value_executed",
-            &self.value_executed.load(Ordering::Relaxed),
-        )?;
-        state.serialize_field(
-            "last_execution_time",
-            &self.last_execution_time.load(Ordering::Relaxed),
-        )?;
-        state.serialize_field(
-            "first_arrival_time",
-            &self.first_arrival_time.load(Ordering::Relaxed),
-        )?;
-        state.serialize_field(
-            "sum_waiting_time",
-            &self.sum_waiting_time.load(Ordering::Relaxed),
-        )?;
+        state.serialize_field("orders_added", &d.orders_added)?;
+        state.serialize_field("orders_removed", &d.orders_removed)?;
+        state.serialize_field("orders_executed", &d.orders_executed)?;
+        state.serialize_field("quantity_executed", &d.quantity_executed)?;
+        state.serialize_field("value_executed", &d.value_executed)?;
+        state.serialize_field("last_execution_time", &d.last_execution_time)?;
+        state.serialize_field("first_arrival_time", &d.first_arrival_time)?;
+        state.serialize_field("sum_waiting_time", &d.sum_waiting_time)?;
         if degraded {
             state.serialize_field("stats_degraded", &true)?;
         }
@@ -785,6 +950,7 @@ impl<'de> Deserialize<'de> for PriceLevelStatistics {
                     first_arrival_time: AtomicU64::new(first_arrival_time),
                     sum_waiting_time: AtomicU64::new(sum_waiting_time),
                     stats_degraded: AtomicBool::new(stats_degraded),
+                    stats_seq: AtomicU64::new(0),
                 })
             }
         }

--- a/src/price_level/statistics.rs
+++ b/src/price_level/statistics.rs
@@ -4,7 +4,7 @@ use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Tracks performance statistics for a price level.
@@ -60,6 +60,15 @@ pub struct PriceLevelStatistics {
 
     /// Sum of waiting times for orders
     sum_waiting_time: AtomicU64,
+
+    /// Sticky flag: set once and never cleared (except by [`reset`](Self::reset))
+    /// when an execution's statistics contribution was **dropped** — a
+    /// [`record_execution`](Self::record_execution) that failed validation or
+    /// overflowed a counter and so contributed to NONE of the aggregates
+    /// (all-or-nothing, issue #117). The trade itself is unaffected; this flag
+    /// is the observable signal that the recorded aggregates under-count the
+    /// true executions. Serialized so it round-trips through a snapshot.
+    stats_degraded: AtomicBool,
 }
 
 impl PriceLevelStatistics {
@@ -124,6 +133,7 @@ impl PriceLevelStatistics {
             last_execution_time: AtomicU64::new(0),
             first_arrival_time: AtomicU64::new(current_time),
             sum_waiting_time: AtomicU64::new(0),
+            stats_degraded: AtomicBool::new(false),
         }
     }
 
@@ -147,6 +157,26 @@ impl PriceLevelStatistics {
     ///
     /// [`Trade`]: crate::execution::Trade
     ///
+    /// # All-or-nothing (issue #117)
+    ///
+    /// An accepted execution contributes to **every** aggregate, or to **none**.
+    /// If a later counter overflows after earlier ones already advanced, this
+    /// rolls the committed prefix back (a `fetch_sub` of exactly what this call
+    /// added — sound by the same call-backed reservation argument as the #111 /
+    /// #113 rollbacks: the subtracted units are exactly the units this call
+    /// added, so the undo is commutative with concurrent `record_execution`
+    /// deltas). That call-backed argument assumes no concurrent
+    /// [`reset`](Self::reset) `store(0)` races the rollback — see the quiescence
+    /// contract on `reset`. So a caller never observes a partial contribution in
+    /// the final state. On any failure — a validation error or a counter overflow —
+    /// the sticky [`stats_degraded`](Self::stats_degraded) flag is set: the
+    /// dropped execution is then observable, even though the caller
+    /// (`PriceLevel::match_order`) cannot fail the already-committed trade.
+    /// Because these are independent lock-free atomics, a *concurrent* reader may
+    /// still glimpse a prefix transiently before its rollback (the same window
+    /// the #111 reserve-then-rollback admission has); the guarantee is on the
+    /// committed final state, not on the transient.
+    ///
     /// # Errors
     ///
     /// Returns [`PriceLevelError::InvalidOperation`] if any of the counter
@@ -163,44 +193,81 @@ impl PriceLevelStatistics {
         let current_time = execution_timestamp;
 
         // Validate everything that can fail BEFORE mutating any counter, so a
-        // rejected record leaves the statistics untouched. `match_order` ignores
-        // the returned `Result`, so any partial side effect would silently
-        // corrupt the stats.
+        // rejected record leaves the statistics untouched. Any failure marks the
+        // stats degraded: this execution's contribution is being dropped.
         let waiting_time = if order_timestamp > 0 {
-            Some(current_time.checked_sub(order_timestamp).ok_or_else(|| {
-                PriceLevelError::InvalidOperation {
-                    message: format!(
-                        "order timestamp {} is in the future of current time {}",
-                        order_timestamp, current_time
-                    ),
+            match current_time.checked_sub(order_timestamp) {
+                Some(value) => Some(value),
+                None => {
+                    self.stats_degraded.store(true, Ordering::Relaxed);
+                    return Err(PriceLevelError::InvalidOperation {
+                        message: format!(
+                            "order timestamp {order_timestamp} is in the future of current time {current_time}"
+                        ),
+                    });
                 }
-            })?)
+            }
         } else {
             None
         };
 
-        let value_u128 = u128::from(quantity).checked_mul(price).ok_or_else(|| {
-            PriceLevelError::InvalidOperation {
-                message: "value_executed multiplication overflow".to_string(),
+        let value_u64 = match u128::from(quantity)
+            .checked_mul(price)
+            .and_then(|value| u64::try_from(value).ok())
+        {
+            Some(value) => value,
+            None => {
+                self.stats_degraded.store(true, Ordering::Relaxed);
+                return Err(PriceLevelError::InvalidOperation {
+                    message: "value_executed overflow (quantity * price exceeds u64 storage)"
+                        .to_string(),
+                });
             }
-        })?;
+        };
 
-        let value_u64 =
-            u64::try_from(value_u128).map_err(|_| PriceLevelError::InvalidOperation {
-                message: "value_executed exceeds u64 storage".to_string(),
-            })?;
-
-        // All fallible validation passed — now apply the mutations. (The only
-        // residual failure mode is a counter nearing `u64::MAX`, inherent to
-        // independent lock-free atomics.)
+        // Commit the additive aggregates with a rollback of the already-committed
+        // prefix on a later overflow (all-or-nothing). `orders_executed` is a
+        // `usize` counter that cannot overflow in practice, but it is part of the
+        // transaction so it is rolled back too. `last_execution_time` is a
+        // non-additive "latest" store, applied only after every additive commit
+        // succeeds so a rejected record never advances it.
         self.orders_executed.fetch_add(1, Ordering::Relaxed);
-        Self::checked_fetch_add_u64(&self.quantity_executed, quantity, "quantity_executed")?;
-        Self::checked_fetch_add_u64(&self.value_executed, value_u64, "value_executed")?;
+
+        if let Err(err) =
+            Self::checked_fetch_add_u64(&self.quantity_executed, quantity, "quantity_executed")
+        {
+            self.orders_executed.fetch_sub(1, Ordering::Relaxed);
+            self.stats_degraded.store(true, Ordering::Relaxed);
+            return Err(err);
+        }
+
+        if let Err(err) =
+            Self::checked_fetch_add_u64(&self.value_executed, value_u64, "value_executed")
+        {
+            self.quantity_executed
+                .fetch_sub(quantity, Ordering::Relaxed);
+            self.orders_executed.fetch_sub(1, Ordering::Relaxed);
+            self.stats_degraded.store(true, Ordering::Relaxed);
+            return Err(err);
+        }
+
+        if let Some(waiting_time) = waiting_time
+            && let Err(err) = Self::checked_fetch_add_u64(
+                &self.sum_waiting_time,
+                waiting_time,
+                "sum_waiting_time",
+            )
+        {
+            self.value_executed.fetch_sub(value_u64, Ordering::Relaxed);
+            self.quantity_executed
+                .fetch_sub(quantity, Ordering::Relaxed);
+            self.orders_executed.fetch_sub(1, Ordering::Relaxed);
+            self.stats_degraded.store(true, Ordering::Relaxed);
+            return Err(err);
+        }
+
         self.last_execution_time
             .store(current_time, Ordering::Relaxed);
-        if let Some(waiting_time) = waiting_time {
-            Self::checked_fetch_add_u64(&self.sum_waiting_time, waiting_time, "sum_waiting_time")?;
-        }
 
         Ok(())
     }
@@ -268,7 +335,25 @@ impl PriceLevelStatistics {
         self.sum_waiting_time.load(Ordering::Relaxed)
     }
 
-    /// Get average execution price
+    /// Returns `true` if the recorded statistics are **degraded** — at least one
+    /// execution's contribution was dropped all-or-nothing (a validation error
+    /// or a counter overflow in [`record_execution`](Self::record_execution),
+    /// issue #117).
+    ///
+    /// The flag is sticky: once set it stays set until [`reset`](Self::reset).
+    /// When `true`, the aggregate counters under-count the true executions; the
+    /// emitted trade stream is unaffected. Cleared by `reset`.
+    #[must_use]
+    pub fn stats_degraded(&self) -> bool {
+        self.stats_degraded.load(Ordering::Relaxed)
+    }
+
+    /// Get average execution price.
+    ///
+    /// Reads `value_executed` and `quantity_executed` as two independent
+    /// `Relaxed` loads, so under concurrent recording the ratio can be
+    /// transiently inconsistent (a torn read across the two counters); it
+    /// self-corrects once recording quiesces.
     #[must_use]
     pub fn average_execution_price(&self) -> Option<f64> {
         let qty = self.quantity_executed.load(Ordering::Relaxed);
@@ -281,7 +366,12 @@ impl PriceLevelStatistics {
         }
     }
 
-    /// Get average waiting time for executed orders (in milliseconds)
+    /// Get average waiting time for executed orders (in milliseconds).
+    ///
+    /// Reads `sum_waiting_time` and `orders_executed` as two independent
+    /// `Relaxed` loads, so under concurrent recording the ratio can be
+    /// transiently inconsistent (a torn read across the two counters); it
+    /// self-corrects once recording quiesces.
     #[must_use]
     pub fn average_waiting_time(&self) -> Option<f64> {
         let count = self.orders_executed.load(Ordering::Relaxed);
@@ -306,7 +396,17 @@ impl PriceLevelStatistics {
         }
     }
 
-    /// Reset all statistics
+    /// Reset all statistics to zero (and re-stamp `first_arrival_time`).
+    ///
+    /// # Quiescence contract
+    ///
+    /// This must only be called on a **quiescent** level — with no in-flight
+    /// [`record_execution`](Self::record_execution) (and hence no in-flight
+    /// `PriceLevel::match_order`). `reset` `store(0)`s each counter directly; a
+    /// concurrent `record_execution` overflow rollback (`fetch_sub`) racing that
+    /// `store(0)` would wrap a counter toward `u64::MAX`. No engine path calls
+    /// `reset` during matching, so this does not occur today, but it is a
+    /// caller obligation because `reset` is public.
     pub fn reset(&self) {
         let current_time = Self::current_timestamp_milliseconds_or_zero();
 
@@ -319,6 +419,7 @@ impl PriceLevelStatistics {
         self.first_arrival_time
             .store(current_time, Ordering::Relaxed);
         self.sum_waiting_time.store(0, Ordering::Relaxed);
+        self.stats_degraded.store(false, Ordering::Relaxed);
     }
 }
 
@@ -348,6 +449,7 @@ impl Clone for PriceLevelStatistics {
             last_execution_time: AtomicU64::new(self.last_execution_time.load(Ordering::Relaxed)),
             first_arrival_time: AtomicU64::new(self.first_arrival_time.load(Ordering::Relaxed)),
             sum_waiting_time: AtomicU64::new(self.sum_waiting_time.load(Ordering::Relaxed)),
+            stats_degraded: AtomicBool::new(self.stats_degraded.load(Ordering::Relaxed)),
         }
     }
 }
@@ -356,7 +458,7 @@ impl fmt::Display for PriceLevelStatistics {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "PriceLevelStatistics:orders_added={};orders_removed={};orders_executed={};quantity_executed={};value_executed={};last_execution_time={};first_arrival_time={};sum_waiting_time={}",
+            "PriceLevelStatistics:orders_added={};orders_removed={};orders_executed={};quantity_executed={};value_executed={};last_execution_time={};first_arrival_time={};sum_waiting_time={};stats_degraded={}",
             self.orders_added.load(Ordering::Relaxed),
             self.orders_removed.load(Ordering::Relaxed),
             self.orders_executed.load(Ordering::Relaxed),
@@ -364,7 +466,8 @@ impl fmt::Display for PriceLevelStatistics {
             self.value_executed.load(Ordering::Relaxed),
             self.last_execution_time.load(Ordering::Relaxed),
             self.first_arrival_time.load(Ordering::Relaxed),
-            self.sum_waiting_time.load(Ordering::Relaxed)
+            self.sum_waiting_time.load(Ordering::Relaxed),
+            self.stats_degraded.load(Ordering::Relaxed)
         )
     }
 }
@@ -438,6 +541,20 @@ impl FromStr for PriceLevelStatistics {
         let sum_waiting_time_str = get_field("sum_waiting_time")?;
         let sum_waiting_time = parse_u64("sum_waiting_time", sum_waiting_time_str)?;
 
+        // `stats_degraded` is optional for backward compatibility: a string
+        // produced before the field existed decodes with the flag cleared.
+        let stats_degraded = match fields.get("stats_degraded") {
+            Some(value) => {
+                value
+                    .parse::<bool>()
+                    .map_err(|_| PriceLevelError::InvalidFieldValue {
+                        field: "stats_degraded".to_string(),
+                        value: (*value).to_string(),
+                    })?
+            }
+            None => false,
+        };
+
         Ok(PriceLevelStatistics {
             orders_added: AtomicUsize::new(orders_added),
             orders_removed: AtomicUsize::new(orders_removed),
@@ -447,6 +564,7 @@ impl FromStr for PriceLevelStatistics {
             last_execution_time: AtomicU64::new(last_execution_time),
             first_arrival_time: AtomicU64::new(first_arrival_time),
             sum_waiting_time: AtomicU64::new(sum_waiting_time),
+            stats_degraded: AtomicBool::new(stats_degraded),
         })
     }
 }
@@ -456,7 +574,17 @@ impl Serialize for PriceLevelStatistics {
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("PriceLevelStatistics", 8)?;
+        // Serialize `stats_degraded` ONLY when it is `true` (dynamic 8/9-field
+        // count). A non-degraded level then serializes in the exact pre-#117
+        // 8-field form — byte-identical to a v2 statistics payload persisted
+        // before this flag existed — so a `PriceLevelSnapshotPackage`'s SHA-256
+        // checksum, recomputed over the re-serialized bytes on
+        // `validate` / `from_snapshot_json`, still matches. A degraded level
+        // adds the field; `Deserialize` / `FromStr` default a missing flag to
+        // `false`, so both directions round-trip.
+        let degraded = self.stats_degraded.load(Ordering::Relaxed);
+        let field_count = if degraded { 9 } else { 8 };
+        let mut state = serializer.serialize_struct("PriceLevelStatistics", field_count)?;
 
         state.serialize_field("orders_added", &self.orders_added.load(Ordering::Relaxed))?;
         state.serialize_field(
@@ -487,6 +615,9 @@ impl Serialize for PriceLevelStatistics {
             "sum_waiting_time",
             &self.sum_waiting_time.load(Ordering::Relaxed),
         )?;
+        if degraded {
+            state.serialize_field("stats_degraded", &true)?;
+        }
 
         state.end()
     }
@@ -506,6 +637,7 @@ impl<'de> Deserialize<'de> for PriceLevelStatistics {
             LastExecutionTime,
             FirstArrivalTime,
             SumWaitingTime,
+            StatsDegraded,
         }
 
         impl<'de> Deserialize<'de> for Field {
@@ -535,6 +667,7 @@ impl<'de> Deserialize<'de> for PriceLevelStatistics {
                             "last_execution_time" => Ok(Field::LastExecutionTime),
                             "first_arrival_time" => Ok(Field::FirstArrivalTime),
                             "sum_waiting_time" => Ok(Field::SumWaitingTime),
+                            "stats_degraded" => Ok(Field::StatsDegraded),
                             _ => Err(de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -565,6 +698,7 @@ impl<'de> Deserialize<'de> for PriceLevelStatistics {
                 let mut last_execution_time = None;
                 let mut first_arrival_time = None;
                 let mut sum_waiting_time = None;
+                let mut stats_degraded = None;
 
                 while let Some(key) = map.next_key()? {
                     match key {
@@ -616,6 +750,12 @@ impl<'de> Deserialize<'de> for PriceLevelStatistics {
                             }
                             sum_waiting_time = Some(map.next_value()?);
                         }
+                        Field::StatsDegraded => {
+                            if stats_degraded.is_some() {
+                                return Err(de::Error::duplicate_field("stats_degraded"));
+                            }
+                            stats_degraded = Some(map.next_value()?);
+                        }
                     }
                 }
 
@@ -631,6 +771,9 @@ impl<'de> Deserialize<'de> for PriceLevelStatistics {
                 });
 
                 let sum_waiting_time = sum_waiting_time.unwrap_or(0);
+                // Optional for backward compatibility: a payload written before
+                // the field existed decodes with the flag cleared.
+                let stats_degraded = stats_degraded.unwrap_or(false);
 
                 Ok(PriceLevelStatistics {
                     orders_added: AtomicUsize::new(orders_added),
@@ -641,6 +784,7 @@ impl<'de> Deserialize<'de> for PriceLevelStatistics {
                     last_execution_time: AtomicU64::new(last_execution_time),
                     first_arrival_time: AtomicU64::new(first_arrival_time),
                     sum_waiting_time: AtomicU64::new(sum_waiting_time),
+                    stats_degraded: AtomicBool::new(stats_degraded),
                 })
             }
         }
@@ -654,6 +798,7 @@ impl<'de> Deserialize<'de> for PriceLevelStatistics {
             "last_execution_time",
             "first_arrival_time",
             "sum_waiting_time",
+            "stats_degraded",
         ];
 
         deserializer.deserialize_struct("PriceLevelStatistics", FIELDS, StatisticsVisitor)

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -7840,21 +7840,30 @@ mod tests {
     #[test]
     fn test_update_vs_match_iceberg_stays_consistent() {
         // An iceberg maker races a matcher (drawing visible, replenishing from
-        // hidden) against an updater (resizing visible). Invariants: never
-        // panics; hidden never exceeds its pre-race value (an update preserves
-        // live hidden, a match only draws it down — it is never resurrected);
-        // and the level stays consistent (counters == queue == snapshot).
+        // hidden) against an updater (resizing visible). #115 derives the resized
+        // order from the LIVE maker under the entry lock, so hidden is NEVER
+        // resurrected: while the maker rests, its hidden depth is MONOTONICALLY
+        // NON-INCREASING (a match only draws it down; an update preserves it,
+        // never restores a stale higher value). The pre-#115 stale-pre-read code
+        // wrote back a stale hidden after a concurrent match drew it down,
+        // producing an INCREASE this test's strict monotonic assertion catches.
+        //
+        // The matcher runs a FIXED number of matches (so it can never run zero
+        // times) and signals `done` at the end, while the updater resizes for the
+        // whole race; we also assert the matcher committed real fills, so the
+        // race is genuinely exercised rather than trivially satisfied.
         use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
         use std::sync::{Arc as StdArc, Barrier};
         use std::thread;
 
-        const INITIAL_HIDDEN: u64 = 400;
-        const UPDATE_ROUNDS: usize = 200;
+        const INITIAL_HIDDEN: u64 = 4_000;
+        const VISIBLE: u64 = 20;
+        const MATCH_ITERS: usize = 500;
 
         for iter in 0..25 {
             let level = StdArc::new(PriceLevel::new(10_000));
             level
-                .add_order(create_buy_iceberg_order(1, 10_000, 20, INITIAL_HIDDEN))
+                .add_order(create_buy_iceberg_order(1, 10_000, VISIBLE, INITIAL_HIDDEN))
                 .expect("seed iceberg");
             let id = Id::from_u64(1);
             let barrier = StdArc::new(Barrier::new(2));
@@ -7866,14 +7875,17 @@ mod tests {
                 let done = StdArc::clone(&done);
                 thread::spawn(move || {
                     barrier.wait();
-                    for r in 0..UPDATE_ROUNDS {
-                        let new_visible = 5 + (r as u64 % 30);
+                    // Resize continuously until the matcher is done, so an update
+                    // races every stage of the drain (not a fixed short burst).
+                    let mut r = 0u64;
+                    while !done.load(AtomicOrdering::Acquire) {
+                        let new_visible = 5 + (r % 30);
                         let _ = level.update_order(OrderUpdate::UpdateQuantity {
                             order_id: id,
                             new_quantity: Quantity::new(new_visible),
                         });
+                        r += 1;
                     }
-                    done.store(true, AtomicOrdering::Release);
                 })
             };
             let matcher = {
@@ -7883,9 +7895,10 @@ mod tests {
                 thread::spawn(move || {
                     barrier.wait();
                     let generator = UuidGenerator::new(Uuid::from_u128(0xF00D_0000 + iter as u128));
-                    let mut max_hidden = 0u64;
-                    while !done.load(AtomicOrdering::Acquire) {
-                        let _ = level.match_order(
+                    let mut committed = 0usize;
+                    let mut prev_hidden = u64::MAX;
+                    for _ in 0..MATCH_ITERS {
+                        let result = level.match_order(
                             3,
                             Id::from_u64(999),
                             TimeInForce::Gtc,
@@ -7893,25 +7906,36 @@ mod tests {
                             TimestampMs::new(1_700_000_000_000),
                             &generator,
                         );
-                        // Sample the resting maker's hidden depth (if any).
+                        if result.executed_quantity().map(|q| q.as_u64()).unwrap_or(0) > 0 {
+                            committed += 1;
+                        }
+                        // Sample the resting maker's hidden depth; it must never
+                        // rise across the race (strict, tight enough that a
+                        // pre-#115 resurrection would fail here).
                         if let Some(o) = level
                             .snapshot_by_insertion_seq()
                             .into_iter()
                             .find(|o| o.id() == id)
                         {
-                            max_hidden = max_hidden.max(o.hidden_quantity().as_u64());
+                            let h = o.hidden_quantity().as_u64();
+                            assert!(
+                                h <= prev_hidden,
+                                "iter {iter}: hidden rose {prev_hidden} -> {h} (resurrection; #115 regression)"
+                            );
+                            prev_hidden = h;
                         }
                     }
-                    max_hidden
+                    done.store(true, AtomicOrdering::Release);
+                    committed
                 })
             };
 
+            let committed = matcher.join().expect("matcher panicked");
             updater.join().expect("updater panicked");
-            let max_hidden = matcher.join().expect("matcher panicked");
 
             assert!(
-                max_hidden <= INITIAL_HIDDEN,
-                "iter {iter}: hidden {max_hidden} exceeded its pre-race value {INITIAL_HIDDEN} (resurrection)"
+                committed >= 1,
+                "iter {iter}: matcher committed no fills — the race was not exercised"
             );
             assert_counters_match_queue(&level);
         }

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -7940,6 +7940,109 @@ mod tests {
             assert_counters_match_queue(&level);
         }
     }
+
+    // ------------------------------------------------------------------
+    // Issue #117 — statistics overflow degrades but never fails the trade
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_match_order_stats_overflow_degrades_but_trade_intact() {
+        // Restore a level whose stats have quantity_executed near u64::MAX (no
+        // direct counter setter — seed through a snapshot).
+        let stats_text = format!(
+            "PriceLevelStatistics:orders_added=0;orders_removed=0;orders_executed=0;\
+             quantity_executed={};value_executed=0;last_execution_time=0;first_arrival_time=0;\
+             sum_waiting_time=0;stats_degraded=false",
+            u64::MAX - 5
+        );
+        let stats = crate::price_level::PriceLevelStatistics::from_str(&stats_text)
+            .expect("seed stats must parse");
+        let order = std::sync::Arc::new(create_standard_order(1, 10_000, 100));
+        let snapshot = crate::price_level::PriceLevelSnapshot::with_orders_and_stats(
+            Price::new(10_000),
+            vec![order],
+            stats,
+        )
+        .expect("snapshot construction");
+        let level = PriceLevel::from_snapshot(snapshot).expect("restore level");
+        assert!(
+            !level.stats().stats_degraded(),
+            "precondition: not degraded yet"
+        );
+
+        // Match consumes maker 1 (quantity 100); recording quantity += 100 over
+        // u64::MAX - 5 overflows, so the execution's stats are dropped.
+        let generator =
+            UuidGenerator::new(Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap());
+        let result = level.match_order(
+            100,
+            Id::from_u64(999),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(1_700_000_000_000),
+            &generator,
+        );
+
+        // The trade is still emitted and the MatchResult is intact.
+        assert_eq!(result.trades().len(), 1, "trade must still be emitted");
+        assert_eq!(
+            result.executed_quantity().expect("no overflow").as_u64(),
+            100
+        );
+        assert_eq!(
+            result.trades().as_vec()[0].maker_order_id(),
+            Id::from_u64(1)
+        );
+
+        // Stats degraded, and the aggregate did NOT advance (all-or-nothing).
+        assert!(
+            level.stats().stats_degraded(),
+            "stats must be marked degraded"
+        );
+        assert_eq!(
+            level.stats().quantity_executed(),
+            u64::MAX - 5,
+            "quantity_executed unchanged (execution dropped)"
+        );
+        assert_eq!(
+            level.stats().orders_executed(),
+            0,
+            "orders_executed rolled back"
+        );
+
+        // The degraded flag round-trips through a snapshot.
+        let json = level.snapshot_to_json().expect("snapshot json");
+        let restored = PriceLevel::from_snapshot_json(&json).expect("restore json");
+        assert!(
+            restored.stats().stats_degraded(),
+            "the degraded flag must round-trip through a snapshot"
+        );
+    }
+
+    #[test]
+    fn test_snapshot_v2_without_degraded_flag_validates_and_roundtrips() {
+        // A non-degraded level serializes its statistics in the pre-#117
+        // 8-field form (the flag is skipped when false), so its checksummed
+        // package is byte-compatible with a v2 package persisted before the
+        // flag existed: the SHA-256 recomputed over those 8-field bytes on
+        // `from_snapshot_json` still validates. This guards against the
+        // "old snapshot fails ChecksumMismatch after upgrade" regression.
+        let level = PriceLevel::new(10_000);
+        level
+            .add_order(create_standard_order(1, 10_000, 100))
+            .expect("seed maker");
+        let json = level.snapshot_to_json().expect("snapshot json");
+        assert!(
+            !json.contains("stats_degraded"),
+            "a non-degraded snapshot must omit the flag (old-v2 checksum compat)"
+        );
+        // The package validates (checksum over the 8-field statistics bytes) and
+        // restores — i.e. an old-format fixture passes `validate`.
+        let restored =
+            PriceLevel::from_snapshot_json(&json).expect("old-format package must validate");
+        assert!(!restored.stats().stats_degraded());
+        assert_eq!(restored.order_count(), 1);
+    }
 }
 
 #[cfg(test)]

--- a/src/price_level/tests/level.rs
+++ b/src/price_level/tests/level.rs
@@ -5352,6 +5352,27 @@ mod tests {
             orders.len(),
             "order_count must equal the snapshot's own order-list length"
         );
+
+        // In the quiescent state (no concurrent writers — every race test joins
+        // its threads before asserting) the LIVE advisory atomics must have
+        // converged to the queue sums too. The snapshot-only assertions above
+        // are fold==fold by construction; these are the ones that catch a
+        // leaked or dropped counter reservation (issue #115).
+        assert_eq!(
+            level.visible_quantity(),
+            visible_sum,
+            "live visible counter must converge to the queue sum when quiescent"
+        );
+        assert_eq!(
+            level.hidden_quantity(),
+            hidden_sum,
+            "live hidden counter must converge to the queue sum when quiescent"
+        );
+        assert_eq!(
+            level.order_count(),
+            orders.len(),
+            "live order_count must converge to the queue length when quiescent"
+        );
     }
 
     #[test]
@@ -7587,6 +7608,312 @@ mod tests {
                     "iter {iter}: consumed an unexpected maker id {maker}"
                 );
             }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #115 — UpdateQuantity applied to the live maker state
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_update_quantity_level_counter_overflow_rejected() {
+        // Two Buy makers push the level's visible counter to just below u64::MAX;
+        // an upsize whose delta would carry it over must be rejected, with the
+        // maker, its queue position, and the counters all unchanged.
+        let level = PriceLevel::new(10_000);
+        level
+            .add_order(create_standard_order(1, 10_000, u64::MAX - 100))
+            .expect("seed maker 1");
+        level
+            .add_order(create_standard_order(2, 10_000, 50))
+            .expect("seed maker 2");
+        // Level visible counter == u64::MAX - 50.
+
+        let before_json = level.snapshot_to_json().expect("snapshot before");
+        let before_ids: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+
+        // Upsize maker 2: 50 -> 200 (delta +150) would overflow the counter.
+        match level.update_order(OrderUpdate::UpdateQuantity {
+            order_id: Id::from_u64(2),
+            new_quantity: Quantity::new(200),
+        }) {
+            Err(PriceLevelError::InvalidOperation { message }) => {
+                assert!(
+                    message.contains("overflow"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected level-counter-overflow InvalidOperation, got {other:?}"),
+        }
+
+        // Level byte-identical; maker 2 unchanged and in the same position.
+        assert_eq!(
+            level.snapshot_to_json().expect("snapshot after"),
+            before_json,
+            "a rejected update must leave the level unchanged"
+        );
+        let after_ids: Vec<Id> = level
+            .snapshot_by_insertion_seq()
+            .iter()
+            .map(|o| o.id())
+            .collect();
+        assert_eq!(after_ids, before_ids);
+        let m2 = level
+            .snapshot_by_insertion_seq()
+            .into_iter()
+            .find(|o| o.id() == Id::from_u64(2))
+            .expect("maker 2 still rests");
+        assert_eq!(m2.visible_quantity().as_u64(), 50);
+    }
+
+    #[test]
+    fn test_update_quantity_derives_from_live_iceberg_after_partial_fill() {
+        // Sequential sanity that an update resizes the LIVE visible tranche and
+        // preserves the LIVE hidden depth (the contract the concurrent path
+        // upholds): after a partial fill + replenish, the update must not restore
+        // the pre-fill hidden.
+        let level = PriceLevel::new(10_000);
+        level
+            .add_order(create_buy_iceberg_order(1, 10_000, 50, 100))
+            .expect("seed iceberg");
+
+        let namespace = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let generator = UuidGenerator::new(namespace);
+        // Consume the full visible tranche (50): replenishes 50 from hidden, so
+        // the live maker becomes visible 50, hidden 50.
+        let _ = level.match_order(
+            50,
+            Id::from_u64(999),
+            TimeInForce::Gtc,
+            TakerKind::Standard,
+            TimestampMs::new(1_700_000_000_000),
+            &generator,
+        );
+        let live = level
+            .snapshot_by_insertion_seq()
+            .into_iter()
+            .find(|o| o.id() == Id::from_u64(1))
+            .expect("iceberg rests");
+        assert_eq!(
+            live.hidden_quantity().as_u64(),
+            50,
+            "precondition: hidden drawn to 50"
+        );
+
+        // Resize visible to 30. Hidden must stay the LIVE 50, not the pre-fill 100.
+        level
+            .update_order(OrderUpdate::UpdateQuantity {
+                order_id: Id::from_u64(1),
+                new_quantity: Quantity::new(30),
+            })
+            .expect("update ok")
+            .expect("maker present");
+        let updated = level
+            .snapshot_by_insertion_seq()
+            .into_iter()
+            .find(|o| o.id() == Id::from_u64(1))
+            .expect("iceberg rests");
+        assert_eq!(updated.visible_quantity().as_u64(), 30);
+        assert_eq!(
+            updated.hidden_quantity().as_u64(),
+            50,
+            "hidden must reflect the live 50, never resurrect the pre-fill 100"
+        );
+        assert_counters_match_queue(&level);
+    }
+
+    #[test]
+    fn test_competing_updates_same_id_one_winner() {
+        use std::sync::{Arc as StdArc, Barrier};
+        use std::thread;
+
+        const ITERATIONS: usize = 1_000;
+        for iter in 0..ITERATIONS {
+            let level = StdArc::new(PriceLevel::new(10_000));
+            level
+                .add_order(create_standard_order(1, 10_000, 100))
+                .expect("seed maker");
+            let id = Id::from_u64(1);
+            let barrier = StdArc::new(Barrier::new(2));
+
+            let a = {
+                let level = StdArc::clone(&level);
+                let barrier = StdArc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    let _ = level.update_order(OrderUpdate::UpdateQuantity {
+                        order_id: id,
+                        new_quantity: Quantity::new(200),
+                    });
+                })
+            };
+            let b = {
+                let level = StdArc::clone(&level);
+                let barrier = StdArc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    let _ = level.update_order(OrderUpdate::UpdateQuantity {
+                        order_id: id,
+                        new_quantity: Quantity::new(50),
+                    });
+                })
+            };
+            a.join().expect("a panicked");
+            b.join().expect("b panicked");
+
+            // Exactly one order rests, with one of the two requested quantities,
+            // and the counters agree with the queue.
+            let resting = level.snapshot_by_insertion_seq();
+            assert_eq!(resting.len(), 1, "iter {iter}: exactly one maker rests");
+            assert_eq!(resting[0].id(), id);
+            let q = resting[0].visible_quantity().as_u64();
+            assert!(
+                q == 200 || q == 50,
+                "iter {iter}: final quantity {q} not one of the two updates"
+            );
+            assert_counters_match_queue(&level);
+        }
+    }
+
+    #[test]
+    fn test_update_decrease_vs_cancel_no_resurrection() {
+        use std::sync::{Arc as StdArc, Barrier};
+        use std::thread;
+
+        const ITERATIONS: usize = 1_000;
+        for iter in 0..ITERATIONS {
+            let level = StdArc::new(PriceLevel::new(10_000));
+            level
+                .add_order(create_standard_order(1, 10_000, 100))
+                .expect("seed maker");
+            let id = Id::from_u64(1);
+            let barrier = StdArc::new(Barrier::new(2));
+
+            let updater = {
+                let level = StdArc::clone(&level);
+                let barrier = StdArc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    // DECREASE branch (keeps sequence, in-place swap).
+                    level.update_order(OrderUpdate::UpdateQuantity {
+                        order_id: id,
+                        new_quantity: Quantity::new(40),
+                    })
+                })
+            };
+            let canceller = {
+                let level = StdArc::clone(&level);
+                let barrier = StdArc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    level
+                        .update_order(OrderUpdate::Cancel { order_id: id })
+                        .expect("cancel must not error")
+                })
+            };
+
+            let _ = updater.join().expect("updater panicked");
+            let cancelled = canceller.join().expect("canceller panicked");
+
+            let is_resting = level
+                .snapshot_by_insertion_seq()
+                .iter()
+                .any(|o| o.id() == id);
+            // The cancel is the only remover; it always wins and the order is
+            // gone — never cancel-None-yet-resting (resurrection).
+            assert!(
+                cancelled.is_some(),
+                "iter {iter}: cancel returned None (resurrection window)"
+            );
+            assert!(
+                !is_resting,
+                "iter {iter}: order still resting after a winning cancel"
+            );
+            assert_counters_match_queue(&level);
+        }
+    }
+
+    #[test]
+    fn test_update_vs_match_iceberg_stays_consistent() {
+        // An iceberg maker races a matcher (drawing visible, replenishing from
+        // hidden) against an updater (resizing visible). Invariants: never
+        // panics; hidden never exceeds its pre-race value (an update preserves
+        // live hidden, a match only draws it down — it is never resurrected);
+        // and the level stays consistent (counters == queue == snapshot).
+        use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+        use std::sync::{Arc as StdArc, Barrier};
+        use std::thread;
+
+        const INITIAL_HIDDEN: u64 = 400;
+        const UPDATE_ROUNDS: usize = 200;
+
+        for iter in 0..25 {
+            let level = StdArc::new(PriceLevel::new(10_000));
+            level
+                .add_order(create_buy_iceberg_order(1, 10_000, 20, INITIAL_HIDDEN))
+                .expect("seed iceberg");
+            let id = Id::from_u64(1);
+            let barrier = StdArc::new(Barrier::new(2));
+            let done = StdArc::new(AtomicBool::new(false));
+
+            let updater = {
+                let level = StdArc::clone(&level);
+                let barrier = StdArc::clone(&barrier);
+                let done = StdArc::clone(&done);
+                thread::spawn(move || {
+                    barrier.wait();
+                    for r in 0..UPDATE_ROUNDS {
+                        let new_visible = 5 + (r as u64 % 30);
+                        let _ = level.update_order(OrderUpdate::UpdateQuantity {
+                            order_id: id,
+                            new_quantity: Quantity::new(new_visible),
+                        });
+                    }
+                    done.store(true, AtomicOrdering::Release);
+                })
+            };
+            let matcher = {
+                let level = StdArc::clone(&level);
+                let barrier = StdArc::clone(&barrier);
+                let done = StdArc::clone(&done);
+                thread::spawn(move || {
+                    barrier.wait();
+                    let generator = UuidGenerator::new(Uuid::from_u128(0xF00D_0000 + iter as u128));
+                    let mut max_hidden = 0u64;
+                    while !done.load(AtomicOrdering::Acquire) {
+                        let _ = level.match_order(
+                            3,
+                            Id::from_u64(999),
+                            TimeInForce::Gtc,
+                            TakerKind::Standard,
+                            TimestampMs::new(1_700_000_000_000),
+                            &generator,
+                        );
+                        // Sample the resting maker's hidden depth (if any).
+                        if let Some(o) = level
+                            .snapshot_by_insertion_seq()
+                            .into_iter()
+                            .find(|o| o.id() == id)
+                        {
+                            max_hidden = max_hidden.max(o.hidden_quantity().as_u64());
+                        }
+                    }
+                    max_hidden
+                })
+            };
+
+            updater.join().expect("updater panicked");
+            let max_hidden = matcher.join().expect("matcher panicked");
+
+            assert!(
+                max_hidden <= INITIAL_HIDDEN,
+                "iter {iter}: hidden {max_hidden} exceeded its pre-race value {INITIAL_HIDDEN} (resurrection)"
+            );
+            assert_counters_match_queue(&level);
         }
     }
 }

--- a/src/price_level/tests/order_queue.rs
+++ b/src/price_level/tests/order_queue.rs
@@ -619,7 +619,7 @@ mod tests {
         // must therefore NEVER return `Empty` — the liquidity is always resting.
         // Under the old remove-then-insert order the maker vanished from the
         // index between the two ops and a scan could miss it.
-        use crate::price_level::order_queue::{FrontAction, FrontOutcome};
+        use crate::price_level::order_queue::{FrontAction, FrontOutcome, UpdateDecision};
         use std::collections::HashSet;
         use std::sync::Arc as StdArc;
         use std::sync::atomic::{AtomicBool, Ordering};
@@ -637,10 +637,11 @@ mod tests {
                 while !done.load(Ordering::Relaxed) {
                     // Demote the resident maker to a fresh tail sequence, over and
                     // over. It stays resident the whole time.
-                    let _ = queue.resequence_to_tail(
-                        Id::from_u64(1),
-                        StdArc::new(create_test_order(1, 1_000, 100)),
-                    );
+                    let _ = queue.update_entry(Id::from_u64(1), |_live| {
+                        Ok(UpdateDecision::ReplaceAtTail(StdArc::new(
+                            create_test_order(1, 1_000, 100),
+                        )))
+                    });
                 }
             })
         };
@@ -672,14 +673,22 @@ mod tests {
         // Issue #127 🔴: after a maker is demoted, `pop_entry` must return it
         // LAST (at its new tail sequence), never early via a stale old key, and a
         // full drain must leave BOTH the map and the ordered index empty.
+        use crate::price_level::order_queue::UpdateDecision;
+
         let queue = OrderQueue::new();
         queue.push(Arc::new(create_test_order(1, 1_000, 10))); // seq 0
         queue.push(Arc::new(create_test_order(2, 1_000, 20))); // seq 1 (to demote)
         queue.push(Arc::new(create_test_order(3, 1_000, 30))); // seq 2
 
-        let replaced =
-            queue.resequence_to_tail(Id::from_u64(2), Arc::new(create_test_order(2, 1_000, 25)));
-        assert!(replaced.is_some(), "the demoted maker was resident");
+        let replaced = queue.update_entry(Id::from_u64(2), |_live| {
+            Ok(UpdateDecision::ReplaceAtTail(Arc::new(create_test_order(
+                2, 1_000, 25,
+            ))))
+        });
+        assert!(
+            matches!(replaced, Some(Ok(_))),
+            "the demoted maker was resident"
+        );
         // New-before-old re-key leaves no stale old key: map and index are 1:1.
         assert!(queue.debug_map_index_consistent());
 
@@ -703,6 +712,7 @@ mod tests {
 
     #[test]
     fn test_pop_entry_vs_resequence_race_drains_each_once() {
+        use crate::price_level::order_queue::UpdateDecision;
         // Issue #127 🔴: `pop_entry` validates the stored sequence against the
         // popped key, so under continuous demotions racing a drain, every id
         // comes out EXACTLY once (never twice via a stale old key, never lost),
@@ -726,10 +736,11 @@ mod tests {
                     while !done.load(Ordering::Relaxed) {
                         // Continuously demote a mid maker; once it is popped this
                         // returns `None` (id gone) and simply spins.
-                        let _ = queue.resequence_to_tail(
-                            Id::from_u64(N / 2),
-                            StdArc::new(create_test_order(N / 2, 1_000, 10)),
-                        );
+                        let _ = queue.update_entry(Id::from_u64(N / 2), |_live| {
+                            Ok(UpdateDecision::ReplaceAtTail(StdArc::new(
+                                create_test_order(N / 2, 1_000, 10),
+                            )))
+                        });
                     }
                 })
             };

--- a/src/price_level/tests/snapshot.rs
+++ b/src/price_level/tests/snapshot.rs
@@ -201,6 +201,87 @@ mod tests {
     }
 
     #[test]
+    fn test_snapshot_v3_roundtrips_degraded_and_non_degraded() {
+        // Issue #129: new packages are v3 and round-trip BOTH a non-degraded
+        // (8-field statistics) and a degraded (9-field statistics) payload.
+        use crate::price_level::PriceLevelStatistics;
+
+        // Non-degraded.
+        let clean = PriceLevelStatistics::new();
+        clean
+            .record_execution(5, 100, 0, 1_000)
+            .expect("clean record");
+        assert!(!clean.stats_degraded());
+        let snap = PriceLevelSnapshot::with_orders_and_stats(
+            Price::new(10),
+            create_sample_orders(),
+            clean,
+        )
+        .expect("snapshot");
+        let package = PriceLevelSnapshotPackage::new(snap).expect("package");
+        assert_eq!(package.version(), SNAPSHOT_FORMAT_VERSION);
+        assert_eq!(package.version(), 3);
+        let json = package.to_json().expect("to_json");
+        let restored = PriceLevelSnapshotPackage::from_json(&json)
+            .expect("from_json")
+            .into_snapshot()
+            .expect("v3 non-degraded must validate + restore");
+        assert!(!restored.statistics().stats_degraded());
+
+        // Degraded: force a dropped execution (maker in the future of execution).
+        let degraded = PriceLevelStatistics::new();
+        assert!(degraded.record_execution(1, 1, 5_000, 1_000).is_err());
+        assert!(degraded.stats_degraded());
+        let snap = PriceLevelSnapshot::with_orders_and_stats(
+            Price::new(10),
+            create_sample_orders(),
+            degraded,
+        )
+        .expect("snapshot");
+        let package = PriceLevelSnapshotPackage::new(snap).expect("package");
+        assert_eq!(package.version(), 3);
+        let json = package.to_json().expect("to_json");
+        assert!(
+            json.contains("stats_degraded"),
+            "a degraded v3 payload carries the 9th field"
+        );
+        let restored = PriceLevelSnapshotPackage::from_json(&json)
+            .expect("from_json")
+            .into_snapshot()
+            .expect("v3 degraded must validate + restore");
+        assert!(
+            restored.statistics().stats_degraded(),
+            "the degraded flag round-trips through a v3 snapshot"
+        );
+    }
+
+    #[test]
+    fn test_snapshot_v2_legacy_package_restores() {
+        // Issue #129: a legacy v2 package (8-field statistics, checksum over the
+        // v2 bytes) must still validate + restore — checksum recomputation is
+        // version-agnostic, and `validate` accepts both v2 and v3.
+        let snap = PriceLevelSnapshot::with_orders(Price::new(77), create_sample_orders())
+            .expect("snapshot");
+        let package = PriceLevelSnapshotPackage::new(snap).expect("package");
+        // Relabel the (non-degraded, 8-field) payload as the legacy v2 version.
+        // The checksum is computed over the snapshot, not the version, so it
+        // stays valid — exactly the shape an old writer produced.
+        let json = package.to_json().expect("to_json");
+        let mut value: Value = serde_json::from_str(&json).expect("parse");
+        if let Some(obj) = value.as_object_mut() {
+            obj.insert("version".to_string(), Value::Number(2u32.into()));
+        }
+        let v2_json = serde_json::to_string(&value).expect("reserialize");
+
+        let v2_package = PriceLevelSnapshotPackage::from_json(&v2_json).expect("from_json");
+        assert_eq!(v2_package.version(), 2);
+        let restored = v2_package
+            .into_snapshot()
+            .expect("legacy v2 package must validate + restore");
+        assert!(!restored.statistics().stats_degraded());
+    }
+
+    #[test]
     fn test_new() {
         let snapshot = PriceLevelSnapshot::new(Price::new(1000));
         assert_eq!(snapshot.price().as_u128(), 1000);

--- a/src/price_level/tests/statistics.rs
+++ b/src/price_level/tests/statistics.rs
@@ -598,4 +598,158 @@ mod tests {
             serde_json::from_str(&degraded_json).expect("deserialize degraded");
         assert!(degraded_back.stats_degraded(), "the flag must round-trip");
     }
+
+    #[test]
+    fn test_orders_executed_overflow_seeded_via_fromstr_is_all_or_nothing() {
+        // Issue #129: `orders_executed` can be seeded to `usize::MAX` through
+        // FromStr / serde. A later record's checked `+1` must reject the overflow
+        // all-or-nothing — no counter wraps, and no OTHER aggregate advances.
+        let seeded = format!(
+            "PriceLevelStatistics:orders_added=0;orders_removed=0;orders_executed={};quantity_executed=0;value_executed=0;last_execution_time=0;first_arrival_time=0;sum_waiting_time=0;stats_degraded=false",
+            usize::MAX
+        );
+        let stats = PriceLevelStatistics::from_str(&seeded).expect("parse MAX orders_executed");
+        assert_eq!(stats.orders_executed(), usize::MAX);
+
+        assert!(
+            stats.record_execution(5, 100, 0, 1_000).is_err(),
+            "the checked orders_executed overflow must be rejected"
+        );
+        // No wrap, and nothing else moved (all-or-nothing).
+        assert_eq!(stats.orders_executed(), usize::MAX, "no wrap to 0");
+        assert_eq!(stats.quantity_executed(), 0);
+        assert_eq!(stats.value_executed(), 0);
+        assert_eq!(stats.sum_waiting_time(), 0);
+        assert!(
+            stats.stats_degraded(),
+            "the dropped execution is observable"
+        );
+    }
+
+    #[test]
+    fn test_mark_degraded_transitions_once() {
+        // Issue #129: only the FIRST drop transitions the sticky flag
+        // (compare_exchange), so `PriceLevel::match_order` logs one WARN per
+        // degraded episode rather than one per dropped execution.
+        let stats = PriceLevelStatistics::new();
+        assert!(!stats.stats_degraded());
+        assert!(
+            stats.mark_degraded(),
+            "first drop transitions false -> true"
+        );
+        assert!(stats.stats_degraded());
+        assert!(!stats.mark_degraded(), "second drop is silent");
+        assert!(!stats.mark_degraded(), "still silent");
+        // A reset re-arms the transition.
+        stats.reset();
+        assert!(!stats.stats_degraded());
+        assert!(stats.mark_degraded(), "post-reset drop transitions again");
+    }
+
+    #[test]
+    fn test_last_execution_time_is_monotonic() {
+        // Issue #129: `fetch_max` — recording an OLDER execution after a newer
+        // one never moves `last_execution_time` backwards.
+        let stats = PriceLevelStatistics::new();
+        stats.record_execution(1, 100, 0, 5_000).expect("newer");
+        assert_eq!(stats.last_execution_time(), 5_000);
+        stats.record_execution(1, 100, 0, 2_000).expect("older");
+        assert_eq!(
+            stats.last_execution_time(),
+            5_000,
+            "an older record must not move the last-execution time back"
+        );
+        stats.record_execution(1, 100, 0, 9_000).expect("newest");
+        assert_eq!(stats.last_execution_time(), 9_000);
+    }
+
+    #[test]
+    fn test_last_execution_time_max_wins_under_barrier() {
+        // Issue #129: two records with distinct timestamps racing — the max wins
+        // regardless of order (`fetch_max` is atomic, independent of the seqlock).
+        use std::sync::{Arc as StdArc, Barrier};
+
+        const HI: u64 = 9_000;
+        const LO: u64 = 3_000;
+        for _ in 0..500 {
+            let stats = StdArc::new(PriceLevelStatistics::new());
+            let barrier = StdArc::new(Barrier::new(2));
+            let hi = {
+                let stats = StdArc::clone(&stats);
+                let barrier = StdArc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    let _ = stats.record_execution(1, 100, 0, HI);
+                })
+            };
+            let lo = {
+                let stats = StdArc::clone(&stats);
+                let barrier = StdArc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    let _ = stats.record_execution(1, 100, 0, LO);
+                })
+            };
+            hi.join().expect("hi");
+            lo.join().expect("lo");
+            assert_eq!(
+                stats.last_execution_time(),
+                HI,
+                "the max timestamp must win"
+            );
+        }
+    }
+
+    #[test]
+    fn test_clone_is_consistent_under_concurrent_record() {
+        // Issue #129 (F5): a `Clone` (which backs the checksummed snapshot) must
+        // capture a COHERENT set under a concurrent single writer. Each record
+        // adds qty=1 / value=100 / orders+1 inside the seqlock, so a consistent
+        // copy always has `value == 100 * quantity` AND `orders == quantity`. A
+        // pre-#129 torn clone could mix `orders=k` with `quantity=k-1`.
+        use std::sync::{Arc as StdArc, Barrier};
+
+        const N: u64 = 3_000;
+        let stats = StdArc::new(PriceLevelStatistics::new());
+        let barrier = StdArc::new(Barrier::new(2));
+
+        let writer = {
+            let stats = StdArc::clone(&stats);
+            let barrier = StdArc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..N {
+                    stats.record_execution(1, 100, 0, 1_000).expect("record");
+                }
+            })
+        };
+        let reader = {
+            let stats = StdArc::clone(&stats);
+            let barrier = StdArc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..50_000 {
+                    let copy = (*stats).clone();
+                    let q = copy.quantity_executed();
+                    assert_eq!(
+                        copy.value_executed(),
+                        q * 100,
+                        "clone must not tear value vs quantity"
+                    );
+                    assert_eq!(
+                        copy.orders_executed() as u64,
+                        q,
+                        "clone must not tear orders vs quantity"
+                    );
+                }
+            })
+        };
+
+        writer.join().expect("writer");
+        reader.join().expect("reader");
+
+        assert_eq!(stats.orders_executed() as u64, N);
+        assert_eq!(stats.quantity_executed(), N);
+        assert_eq!(stats.value_executed(), N * 100);
+    }
 }

--- a/src/price_level/tests/statistics.rs
+++ b/src/price_level/tests/statistics.rs
@@ -420,5 +420,182 @@ mod tests {
         assert_eq!(deserialized.orders_executed(), 3);
         assert_eq!(deserialized.quantity_executed(), 0);
         assert_eq!(deserialized.value_executed(), 0);
+        // Missing stats_degraded defaults to false.
+        assert!(!deserialized.stats_degraded());
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #117 — all-or-nothing statistics + degraded flag
+    // ------------------------------------------------------------------
+
+    /// Build statistics pre-loaded with specific aggregate values (no public
+    /// counter setter exists, so seed via the `FromStr` surface).
+    fn seed_stats(
+        orders_executed: usize,
+        quantity_executed: u64,
+        value_executed: u64,
+        sum_waiting_time: u64,
+    ) -> PriceLevelStatistics {
+        let text = format!(
+            "PriceLevelStatistics:orders_added=0;orders_removed=0;orders_executed={orders_executed};\
+             quantity_executed={quantity_executed};value_executed={value_executed};\
+             last_execution_time=0;first_arrival_time=0;sum_waiting_time={sum_waiting_time};\
+             stats_degraded=false"
+        );
+        PriceLevelStatistics::from_str(&text).expect("seed stats must parse")
+    }
+
+    #[test]
+    fn test_record_execution_all_or_nothing_on_each_overflow() {
+        // quantity_executed overflow: nothing advances, degraded set.
+        {
+            let stats = seed_stats(0, u64::MAX - 5, 0, 0);
+            assert!(stats.record_execution(10, 1, 0, 1_000).is_err());
+            assert_eq!(stats.orders_executed(), 0, "orders_executed rolled back");
+            assert_eq!(
+                stats.quantity_executed(),
+                u64::MAX - 5,
+                "quantity unchanged"
+            );
+            assert_eq!(stats.value_executed(), 0, "value unchanged");
+            assert!(stats.stats_degraded(), "degraded flag set");
+        }
+        // value_executed overflow: orders + quantity rolled back.
+        {
+            let stats = seed_stats(0, 0, u64::MAX - 5, 0);
+            assert!(stats.record_execution(1, 10, 0, 1_000).is_err());
+            assert_eq!(stats.orders_executed(), 0);
+            assert_eq!(stats.quantity_executed(), 0, "quantity rolled back");
+            assert_eq!(stats.value_executed(), u64::MAX - 5, "value unchanged");
+            assert!(stats.stats_degraded());
+        }
+        // sum_waiting_time overflow: orders + quantity + value rolled back.
+        {
+            let stats = seed_stats(0, 0, 0, u64::MAX - 5);
+            assert!(stats.record_execution(1, 1, 1, 100).is_err());
+            assert_eq!(stats.orders_executed(), 0);
+            assert_eq!(stats.quantity_executed(), 0, "quantity rolled back");
+            assert_eq!(stats.value_executed(), 0, "value rolled back");
+            assert_eq!(stats.sum_waiting_time(), u64::MAX - 5, "sum unchanged");
+            assert!(stats.stats_degraded());
+        }
+        // value multiplication exceeds u64 storage (validation, before mutation).
+        {
+            let stats = seed_stats(0, 0, 0, 0);
+            assert!(stats.record_execution(u64::MAX, 2, 0, 1_000).is_err());
+            assert_eq!(stats.orders_executed(), 0);
+            assert_eq!(stats.quantity_executed(), 0);
+            assert_eq!(stats.value_executed(), 0);
+            assert!(stats.stats_degraded());
+        }
+        // Maker timestamp in the future of execution (validation).
+        {
+            let stats = seed_stats(0, 0, 0, 0);
+            assert!(stats.record_execution(1, 1, 200, 100).is_err());
+            assert_eq!(stats.orders_executed(), 0);
+            assert!(stats.stats_degraded());
+        }
+    }
+
+    #[test]
+    fn test_record_execution_success_leaves_flag_clear() {
+        let stats = PriceLevelStatistics::new();
+        assert!(stats.record_execution(10, 5, 0, 1_000).is_ok());
+        assert_eq!(stats.orders_executed(), 1);
+        assert_eq!(stats.quantity_executed(), 10);
+        assert_eq!(stats.value_executed(), 50);
+        assert!(
+            !stats.stats_degraded(),
+            "a successful record must not degrade"
+        );
+    }
+
+    #[test]
+    fn test_concurrent_record_execution_cross_aggregate_consistency() {
+        use std::sync::Barrier;
+
+        // Seed quantity_executed AND value_executed with exactly K*Q of headroom
+        // below u64::MAX (SYMMETRIC headroom, price = 1, so each record adds Q to
+        // both). With N > K concurrent records, exactly K fit and the rest fail
+        // at the FIRST additive counter (quantity_executed) — so in this
+        // symmetric config a loser never advances any counter and no
+        // cross-counter rollback is exercised; it is a clean reject. (Under
+        // ASYMMETRIC headroom a loser could pass quantity and fail at value, and
+        // the exact-fit count would be `<= K` rather than `== K`; the rollback
+        // path is covered by the deterministic per-aggregate test above.)
+        // Invariant here: orders_executed == K, quantity_executed ==
+        // value_executed (each success advances both in lockstep), the surplus
+        // over the seed equals orders_executed * Q, and the degraded flag is set.
+        const N: usize = 8;
+        const K: u64 = 3;
+        const Q: u64 = 1_000;
+        let seed = u64::MAX - K * Q;
+
+        for _ in 0..50 {
+            let stats = Arc::new(seed_stats(0, seed, seed, 0));
+            // Barrier so all N records race from the same instant.
+            let barrier = Arc::new(Barrier::new(N));
+            let mut handles = Vec::with_capacity(N);
+            for _ in 0..N {
+                let stats = Arc::clone(&stats);
+                let barrier = Arc::clone(&barrier);
+                handles.push(thread::spawn(move || {
+                    barrier.wait();
+                    stats.record_execution(Q, 1, 0, 1_000).is_ok()
+                }));
+            }
+            let successes: u64 = handles
+                .into_iter()
+                .map(|h| u64::from(h.join().expect("thread panicked")))
+                .sum();
+
+            assert_eq!(successes, K, "exactly K records must fit the headroom");
+            assert_eq!(stats.orders_executed() as u64, K);
+            assert_eq!(
+                stats.quantity_executed(),
+                stats.value_executed(),
+                "quantity and value advance in lockstep (each success adds to both)"
+            );
+            assert_eq!(
+                stats.quantity_executed() - seed,
+                K * Q,
+                "the surplus over the seed equals orders_executed * Q"
+            );
+            assert!(
+                stats.stats_degraded(),
+                "some records overflowed -> degraded"
+            );
+        }
+    }
+
+    #[test]
+    fn test_serialize_omits_degraded_flag_when_false() {
+        // A non-degraded statistics serializes in the pre-#117 8-field form
+        // (the flag is skipped when false), so a v2 snapshot payload persisted
+        // before the flag existed re-serializes byte-identically and its SHA-256
+        // checksum still validates.
+        let stats = PriceLevelStatistics::new();
+        assert!(!stats.stats_degraded());
+        let json = serde_json::to_string(&stats).expect("serialize");
+        assert!(
+            !json.contains("stats_degraded"),
+            "a non-degraded statistics must omit the flag (old-v2 checksum compat): {json}"
+        );
+        // It still round-trips: a missing flag decodes to false.
+        let back: PriceLevelStatistics = serde_json::from_str(&json).expect("deserialize");
+        assert!(!back.stats_degraded());
+
+        // A degraded statistics DOES emit the field, and it round-trips.
+        let degraded = seed_stats(0, 0, 0, 0);
+        assert!(degraded.record_execution(u64::MAX, 2, 0, 1_000).is_err()); // value overflow
+        assert!(degraded.stats_degraded());
+        let degraded_json = serde_json::to_string(&degraded).expect("serialize degraded");
+        assert!(
+            degraded_json.contains("\"stats_degraded\":true"),
+            "a degraded statistics must emit the flag: {degraded_json}"
+        );
+        let degraded_back: PriceLevelStatistics =
+            serde_json::from_str(&degraded_json).expect("deserialize degraded");
+        assert!(degraded_back.stats_degraded(), "the flag must round-trip");
     }
 }


### PR DESCRIPTION
## Summary

`record_execution` mutated several independent atomics with fallible checked
additions: a later overflow left the earlier counters advanced (partial
contribution), and `match_order` discarded the returned error — a trade
succeeded with silently inconsistent statistics. Statistics recording is now
all-or-nothing in the committed state, and a dropped execution is observable.

## Stack

- **Stack:** #118 → #114 → #116 → #111 → #113 → #120 → #119 → #115 → #117 → #112 (**this is 9/10**)
- **Base branch:** `stack/8-115-live-update`
- **Stacked on:** #128 — **the diff vs `main` is cumulative**; review against the base branch.

## Changes

- Additive aggregates commit via `fetch_update(checked_add)`; on any later
  failure the already-committed prefix rolls back with `fetch_sub` of exactly
  this call's contribution (the #111/#113 call-backed argument, documented as
  contingent on `reset()`'s new quiescence contract). `last_execution_time`
  stores only after every additive commit succeeds.
- `match_order` no longer discards the error: WARN log (the match is not
  aborted — the committed trade is never unwound) + new sticky
  `stats_degraded` flag on `PriceLevelStatistics`, queryable and carried
  through `Clone` / `Display` / `FromStr` / serde.
- **Snapshot compatibility preserved**: the flag serializes only when `true`,
  so a pre-#117 v2 package re-serializes byte-identically and its SHA-256
  still validates — old snapshots restore unchanged (guarded by an old-format
  compatibility test). No snapshot version bump needed.
- `record_order_added` / `record_order_removed` audited: single-atomic, no
  partiality possible.

## Technical decisions

- Validate-then-commit across 8 independent atomics is not linearizable
  without a lock; CAS-per-counter + prefix rollback keeps the path lock-free
  and matches the crate's rollback precedent. The transient prefix window
  (visible before rollback) is documented honestly — the guarantee is on the
  committed state.
- `architect` caught the HIGH checksum break (unconditional 9th field would
  have failed `validate()` on every pre-#117 package) — fixed with
  skip-when-false serialization. `concurrency-auditor` (0 P1) flagged the
  `reset()`-vs-rollback wrap (P2, unreachable today) — closed by contract:
  `reset()` documented quiescent-only. All LOW items applied (WARN level,
  Barrier in the concurrent test, config-specific exactly-K note, torn-read
  caveats on the average accessors).

## Public API impact

- New additive accessor `PriceLevelStatistics::stats_degraded()`; serde field
  emitted only when `true`. No signature changes, `lib.rs` untouched.

## Testing

- [x] Forced overflow per aggregate: no aggregate advances, flag set, `Err`
- [x] Barrier-controlled concurrent boundary: exactly K symmetric-headroom
  successes, `quantity_executed` / `value_executed` in lockstep
- [x] `match_order` integration: trade + `MatchResult` intact on stats
  overflow, flag observable and round-tripped through snapshot JSON
- [x] Old-format (8-field statistics) package passes `validate()`;
  omit-when-false serde guards
- [x] Pre-push checks clean locally

495 tests passed; 0 failed (476 lib + 9 + 1 + 9 doctests).

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic — no `saturating_*` / `wrapping_*`
- [x] `tracing` only (WARN per the logging taxonomy)
- [x] Snapshot round-trip + previous-format compatibility test
- [x] No new production `unsafe`, no new dependencies

Closes #117


- **Blocks:** #130
